### PR TITLE
Replaced outdated MySQL driver with current one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ A curated list of awesome Go frameworks, libraries and software. Inspired by [aw
 * Relational Databases
     * [pq](https://github.com/lib/pq) - Pure Go Postgres driver for database/sql.
     * [go-pgsql](https://github.com/lxn/go-pgsql) - A PostgreSQL client package for the Go Programming Language.
-    * [GoMySQL](https://github.com/Philio/GoMySQL) - A quite complete threadsafe MySQL client library written in Go.
+    * [go-sql-driver/mysql](https://github.com/go-sql-driver/mysql) - MySQL driver for Go.
     * [go-sqlite3](https://github.com/mattn/go-sqlite3) - SQLite3 driver for go that using database/sql.
     * [go-db](https://github.com/phf/go-db) - Generic database API for Go.
 * NoSQL Databases


### PR DESCRIPTION
The old MySQL driver targets Go release.r57.1 and was last updated 3 years ago. The https://github.com/go-sql-driver/mysql is actively maintained.
