### PR TITLE
Add go convey to testing libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ A curated list of awesome Go frameworks, libraries and software. Inspired by [aw
 *Libraries for testing codebases and generating test data.*
 
 * [gocheck](http://labix.org/gocheck) - A more advanced testing framework alternative to gotest.
+* [GoConvey](http://goconvey.co/) - BDD-ish, rspec inspirated testing framework, automatic testing, coverage report and web UI
 * [GoSpec](https://github.com/orfjackal/gospec) - BDD-style testing framework for the Go programming language.
 * [gospecify](https://github.com/stesla/gospecify) - This provides a BDD syntax for testing your Go code. It should be familiar to anybody who has used libraries such as rspec.
 * [gomock](https://code.google.com/p/gomock/) - Mocking framework for the Go programming language.


### PR DESCRIPTION
GoConvey is probably one of the must complete testing framework for Go,
that's why I put it in 2nd place.
