### PR TITLE
Add github_flavored_markdown package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ A curated list of awesome Go frameworks, libraries and software. Inspired by [aw
     * [go-pkg-xmlx](https://github.com/jteeuwen/go-pkg-xmlx) - Extension to the standard Go XML package. Maintains a node tree that allows forward/backwards browsing and exposes some simple single/multi-node search functions.
     * [go-pkg-rss](https://github.com/jteeuwen/go-pkg-rss) - This package reads RSS and Atom feeds and provides a caching mechanism that adheres to the feed specs.
     * [blackfriday](https://github.com/russross/blackfriday) - Markdown processor in Go
+        * [github_flavored_markdown](http://godoc.org/github.com/shurcooL/go/github_flavored_markdown) - GitHub Flavored Markdown renderer in Go.
     * [bluemonday](https://github.com/microcosm-cc/bluemonday) - HTML Sanitizer
 
 


### PR DESCRIPTION
It's a pure Go package that lets one easily render GitHub Flavored Markdown. Written on top of `blackfriday`, `bluemonday`.
### Screenshot

![image](https://cloud.githubusercontent.com/assets/1924134/3490089/3930b57e-0559-11e4-8ced-fbedb6de50cd.png)
