### PR TITLE
Added Embeddable Scripting Languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
     - [Logging](#logging)
     - [Code Analysis and Linter](#code-analysis-and-linter)
     - [Code generation & ‘generics’](#code-generation--generics)
+    - [Embeddable Scripting Languages](#embeddable-scripting-languages)
 - [Resources](#resources)
     - [Websites](#websites)
     - [(e)Books](#ebooks)
@@ -389,7 +390,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [otto](https://github.com/robertkrimen/otto) - A JavaScript interpreter written in Go
 * [v8-go](https://github.com/idada/v8.go/) - V8 JavaScript engine bindings for Go
 
-
+
 # Resources
 
 Where to discover new Go libraries.


### PR DESCRIPTION
I created a section for libraries that allow you to embed other languages into your code and added golua, go-python, otto and v8-go as active/stable examples of such projects.

There also is mattn/go-v8 but chose the one from idada because of the higher amount of activity and contributors.

I also looked through the corresponding section in the go-wiki but most of the other projects are stale since a couple of years.
