### PR TITLE
Remove skydb (no longer in active development)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [groupcache](https://github.com/golang/groupcache) - Groupcache is a caching and cache-filling library, intended as a replacement for memcached in many cases.
 * [influxdb](https://github.com/influxdb/influxdb) - Scalable datastore for metrics, events, and real-time analytics
 * [ledisdb](https://github.com/siddontang/ledisdb) - Ledisdb is a high performance NoSQL like Redis based on LevelDB.
-* [skydb.io](https://github.com/skydb/sky) - Sky is an open source database used for flexible, high performance analysis of behavioral data.
 * [tiedot](https://github.com/HouzuoGuo/tiedot) - Your NoSQL database powered by Golang.
 
 ## Database Drivers


### PR DESCRIPTION
According to the [skydb github page](https://github.com/skydb/sky), the project is no longer in active development.
