### PR TITLE
Remove bitbucket.org/zombiezen/yaml package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,6 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
     * [go-runewidth](https://github.com/mattn/go-runewidth) - Functions to get fixed width of the character or string.
     * [slug](https://github.com/gosimple/slug) - URL-friendly slugify with multiple languages support.
     * [toml](https://github.com/BurntSushi/toml) - TOML configuration format (encoder/decoder with reflection).
-    * [yaml](https://bitbucket.org/zombiezen/yaml) - Implements a YAML 1.2 parser in Go.
 * Utility
     * [govalidator](https://github.com/asaskevich/govalidator) - package of string validators and sanitizers for Go lang.
 


### PR DESCRIPTION
The package has been last updated in early 2013. The description says it implements a YAML 1.2 parser, but as we've learned at https://github.com/shurcooL/markdownfmt/issues/11#issuecomment-54249637, it has high level parsing functionality completely unimplemented and marked as TODO.

The quality standard says:

> curated list for high-quality, actively maintained Go packages
> - Functional
> - Actively maintained (even if that just means acknowledging open issues when they arise)
> - Stable, or progressing toward stable

This doesn't seem to meet that criteria.

This is simply a suggestion to remove it, please discuss and act as appropriate.
