### PR TITLE
Add orange-cat, a Markdown previewer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ Software written in Go.
 * [heka] (https://github.com/mozilla-services/heka) - universal tool for data processing from Mozilla. Large collection of built-in plugins. Extendable via Go and Lua plugin API.
 * [Juju](https://juju.ubuntu.com/) - Cloud-agnostic service deployment and orchestration - supports EC2, Azure, Openstack, MAAS and more.
 * [nsq](http://nsq.io/) - A realtime distributed messaging platform
+* [orange-cat](https://github.com/noraesae/orange-cat) - A Markdown previewer written in Go.
 * [peg](https://github.com/pointlander/peg) - Peg, Parsing Expression Grammar, is an implementation of a Packrat parser generator.
 * [Postman](https://github.com/zachlatta/postman) - Command-line utility for batch-sending email.
 * [syncthing](http://www.syncthing.net/) - An open, decentralized file synchronization tool and protocol.


### PR DESCRIPTION
Hi,

I've just released a Markdown previewer written in Go, named [`orange-cat`](https://github.com/noraesae/orange-cat). It's a quite simple tool, which can hopefully be used in several editor plugins.

I added it under the `blackfriday` item, cause it uses the module for Markdown processing.

It's still `v0.1.0`, but I've added test cases covering every module and set continuous integration with Travis CI.

I hope many people like and enjoy it :)

Cheers,
