### PR TITLE
Add autoflags package

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 
 *These libraries were placed here because none of the other categories seemed to fit*
 
+* [autoflags](https://github.com/artyom/autoflags) - Go package to automatically define command line flags from struct fields
 * [browscap_go](https://github.com/fromYukki/browscap_go) - GoLang Library for [Browser Capabilities Project](http://browscap.org/).
 * [envconf](https://github.com/ian-kent/envconf) - Configuration from environment
 * [gofigure](https://github.com/ian-kent/gofigure) - Go application configuration made easy


### PR DESCRIPTION
Package autoflags provides a convenient way of exposing struct fields as command line flags. Exposed fields should have flag tag attached: `flag:"flagName,usage string"`.