### PR TITLE
Add go-collada, a Go package for working with the Collada file format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [glop](https://github.com/runningwild/glop) - Glop (Game Library Of Power) is a fairly simple cross-platform game library.
 * [go3d](https://github.com/ungerik/go3d) - A performance oriented 2D/3D math package for Go
 * [go-astar](https://github.com/beefsack/go-astar) - Go implementation of the A* path finding algorithm
+* [go-collada](https://github.com/GlenKelley/go-collada) - Go package for working with the Collada file format.
 * [gonet](https://github.com/xtaci/gonet) - A game server skeleton implemented with golang
 
 


### PR DESCRIPTION
This isn't my package, it's by @GlenKelley, and it's either a fork or simply related to `github.com/go3d/go-collada` by @metaleap. However, it actually works (in my [testing](https://github.com/shurcooL/play/commit/bb12dd54f9d6b69523b695420b4cac9423bddd03#commitcomment-9134222)) and is useful for loading/parsing the Collada file format, unlike the go3d package which [isn't working/finished](https://github.com/go3d/go-collada/issues/1#issuecomment-68077857).

I'm willing to help maintain it if @GlenKelley doesn't want to, but I think adding it to this list is helpful because as far as I know, it's the only (working) Go package for dealing with the Collada file format.