### PR TITLE
add geo-golang

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [aws-go](https://github.com/stripe/aws-go) - An incredibly experimental, automatically generated set of AWS clients in Go.
 * [facebook](https://github.com/huandu/facebook) - Go Library that supports the Facebook Graph API
 * [gami](https://github.com/bit4bit/gami) - Go library for Asterisk Manager Interface.
+* [geo-golang](https://github.com/codingsince1985/geo-golang) - Go Library to access [Google Maps](https://developers.google.com/maps/documentation/geocoding/), [MapQuest](http://open.mapquestapi.com/geocoding/), [Nominatim](http://open.mapquestapi.com/nominatim/), [OpenCage](http://geocoder.opencagedata.com/api.html) and [HERE](https://developer.here.com/rest-apis/documentation/geocoder) geocoding / reverse geocoding APIs.
 * [github](https://github.com/google/go-github) - Go library for accessing the GitHub API.
 * [goamz](https://github.com/mitchellh/goamz) - Popular fork of [goamz](https://launchpad.net/goamz) which adds some missing API calls to certain packages.
 * [GoMusicBrainz](https://github.com/michiwend/gomusicbrainz) - a Go MusicBrainz WS2 client library
@@ -528,7 +529,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [smite](https://github.com/sergiotapia/smitego) - Go package to wraps access to the Smite game API.
 * [snapchat](https://github.com/jamieomatthews/gosnap) - Go wrapper for the snapchat API
 * [spotify](https://github.com/rapito/go-spotify) - Go Library to access Spotify WEB API.
-* [geo-golang](https://github.com/codingsince1985/geo-golang) - Go Library to access [Google Maps](https://developers.google.com/maps/documentation/geocoding/), [MapQuest](http://open.mapquestapi.com/geocoding/), [Nominatim](http://open.mapquestapi.com/nominatim/), [OpenCage](http://geocoder.opencagedata.com/api.html) and [HERE](https://developer.here.com/rest-apis/documentation/geocoder) geocoding / reverse geocoding APIs.
+
 
 ## Utilities
 

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [smite](https://github.com/sergiotapia/smitego) - Go package to wraps access to the Smite game API.
 * [snapchat](https://github.com/jamieomatthews/gosnap) - Go wrapper for the snapchat API
 * [spotify](https://github.com/rapito/go-spotify) - Go Library to access Spotify WEB API.
-
+* [geo-golang](https://github.com/codingsince1985/geo-golang) - Go Library to access [Google Maps](https://developers.google.com/maps/documentation/geocoding/), [MapQuest](http://open.mapquestapi.com/geocoding/), [Nominatim](http://open.mapquestapi.com/nominatim/), [OpenCage](http://geocoder.opencagedata.com/api.html) and [HERE](https://developer.here.com/rest-apis/documentation/geocoder) geocoding / reverse geocoding APIs.
 
 ## Utilities
 


### PR DESCRIPTION
Curated by [Go Newsletter Issue 45](http://golangweekly.com/issues/45), it's a geocoding service developed in an idiomatically Go-style way. Works with Google Maps, MapQuest, OpenCage and HERE out of the box.