### PR TITLE
update Bone for preferable URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,7 +648,7 @@ Join us on IRC at **#awesome-go** on freenode [web access](http://webchat.freeno
 *Full stack web frameworks.*
 
 * [Beego](https://github.com/astaxie/beego) - beego is an open-source, high-performance web framework for the Go programming language.
-* [Bone](https://github.com/squiidz/bone) - Lightning Fast HTTP Multiplexer.
+* [Bone](https://github.com/go-zoo/bone) - Lightning Fast HTTP Multiplexer.
 * [Echo](https://github.com/labstack/echo) - A fast HTTP router (zero memory allocation) + micro web framework in Go.
 * [Gin](https://github.com/gin-gonic/gin) - Gin is a web framework written in Go! It features a martini-like API with much better performance, up to 40 times faster. If you need performance and good productivity.
 * [Goat](https://github.com/bahlo/goat) - A minimalistic REST API server in Go


### PR DESCRIPTION
at Web Frameworks section.
current squiidz/bone seems just one of fork.