### PR TITLE
update package location for go-validate-yourself to bluesuncorp/validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ Join us on IRC at **#awesome-go** on freenode [web access](http://webchat.freeno
 
 *Libraries for validation.*
 
-* [go-validate-yourself](https://github.com/joeybloggs/go-validate-yourself) - Go Struct and Field validation
+* [validator](https://github.com/bluesuncorp/validator) - Go Struct and Field validation supporting Cross Field and Cross Struct validation
 
 
 ## Version Control


### PR DESCRIPTION
I just moved my package from my user account to an organization account and renamed the repository so here's a pull request to update.