### PR TITLE
Adding gosx-notifier library which is desktop notifications for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Join us on IRC at **#awesome-go** on freenode [web access](http://webchat.freeno
 
 * [go-gtk](http://mattn.github.io/go-gtk/) - Go bindings for GTK
 * [go-qml](https://github.com/go-qml/qml) - QML support for the Go language
+* [gosx-notifier](https://github.com/deckarep/gosx-notifier) - OSX Desktop Notifications library for Go.
 * [gotk3](https://github.com/conformal/gotk3) - Go bindings for GTK3.
 * [gxui](https://github.com/google/gxui) - A Go cross platform UI library.
 * [ui](https://github.com/andlabs/ui) - Platform-native GUI library for Go.


### PR DESCRIPTION
Hello,

Many people find this library useful: https://github.com/deckarep/gosx-notifier for building scripts, tools and systems that can generate Desktop Notifications on OSX.

Please consider adding it.

Thanks!