### PR TITLE
Update OpenGL section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,9 +451,8 @@ Join us on IRC at **#awesome-go** on freenode [web access](http://webchat.freeno
 
 *Libraries for using OpenGL in Go.*
 
-* [gl](https://github.com/go-gl/gl) - Go bindings for OpenGL. Requires an external dependency GLEW.
+* [gl](https://github.com/go-gl/gl) - Go bindings for OpenGL (generated via glow).
 * [glfw](https://github.com/go-gl/glfw) - Go bindings for GLFW 3.
-* [glow](https://github.com/go-gl/glow) - Go binding generator and bindings for OpenGL.
 * [mathgl](https://github.com/go-gl/mathgl) - Pure Go math package specialized for 3D math, with inspiration from GLM.
 
 


### PR DESCRIPTION
The OpenGL repos have had an overhaul earlier this year. This update is to reflect the changes.

- Update descriptions of go-gl/gl and go-gl/glfw repos.
- Remove `glow`. It is an internal generator tool used to generate the go-gl/gl bindings; most users will not need to know about it unless they are interested in generating custom bindings or fixing issues. But in that case they can find out about glow from the go-gl/gl repository, since it's described in the README.

/cc @errcw Since `glow` is your package, I want to check if removing it is okay with you. See rationale above. It was primarily here before the go-gl overhaul because it contained the glow-generated bindings inside; those are now in go-gl/gl. I think avoiding listing it here will help avoid confusion for new users.