### PR TITLE
Add xurls to the text processing category

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,7 @@ Join us on IRC at **#awesome-go** on freenode [web access](http://webchat.freeno
 * Utility
     * [gotabulate](https://github.com/bndr/gotabulate) - Easily pretty-print your tabular data with Go.
     * [govalidator](https://github.com/asaskevich/govalidator) - package of string validators and sanitizers for Go lang.
+    * [xurls](https://github.com/mvdan/xurls) - Extract urls from text
 
 
 ## Third-party APIs


### PR DESCRIPTION
Uses regex to extract urls from text. Can be used as a library via the regexp package and also has a command line utility.