### PR TITLE
Update import path of github_flavored_markdown package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ Join us on IRC at **#awesome-go** on freenode [web access](http://webchat.freeno
 
 * Specific Formats
     * [blackfriday](https://github.com/russross/blackfriday) - Markdown processor in Go
-        * [github_flavored_markdown](http://godoc.org/github.com/shurcooL/go/github_flavored_markdown) - GitHub Flavored Markdown renderer in Go.
+        * [github_flavored_markdown](https://godoc.org/github.com/shurcooL/github_flavored_markdown) - GitHub Flavored Markdown renderer with fenced code block highlighting, clickable header anchor links.
     * [bluemonday](https://github.com/microcosm-cc/bluemonday) - HTML Sanitizer
     * [enca](https://github.com/endeveit/enca) - Minimal cgo bindings for [libenca](http://cihar.com/software/enca/).
     * [genex](https://github.com/alixaxel/genex) - Count and expand Regular Expressions into all matching Strings


### PR DESCRIPTION
It has moved out into a standalone repo. See shurcooL/go#19 for rationale.