### PR TITLE
Add tollbooth to list of middlewares.

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 * [CORS](https://github.com/rs/cors) - Easily add CORS capabilities to your API
 * [formjson](https://github.com/rs/formjson) - Transparently handle JSON input as a standard form POST
+* [Tollbooth](https://github.com/didip/tollbooth) - Rate limit HTTP request handler
 * [XFF](https://github.com/sebest/xff) - Handle `X-Forwarded-For` header and friends
 
 #### Libraries for creating HTTP middlewares


### PR DESCRIPTION
[Tollbooth](https://github.com/didip/tollbooth) is an HTTP rate limiter middleware.
We are using it internally at work for various internal services and I use it for some personal projects at home as well.