### PR TITLE
Add TARGA image format decoder/encoder package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [rez](https://github.com/bamiaux/rez) - Image resizing in pure Go and SIMD.
 * [smartcrop](https://github.com/muesli/smartcrop) - Finds good crops for arbitrary images and crop sizes
 * [svgo](https://github.com/ajstarks/svgo) - Go Language Library for SVG generation.
+* [tga](https://github.com/ftrvxmtrx/tga) - Package tga is a TARGA image format decoder/encoder.
 
 ## Logging
 


### PR DESCRIPTION
There is no other tga encoder/decoder package in the awesome-go list, so I think it would be beneficial to add it. This is the only and best tga package I know of.

> Supports RLE and raw TARGA images with 8/15/16/24/32 bits per pixel, monochrome, truecolor and colormapped images. Correctly handles origins and attribute type in extensions area. Passes TGA 2.0 conformance suite (http://googlesites.inequation.org/tgautilities).

I've opened https://github.com/ftrvxmtrx/tga/issues/4 to see if it's still well maintained, since it was last updated 3 years ago. But it's complete and functional, so I wouldn't hold it too much against it.

/cc @ftrvxmtrx