### PR TITLE
Add link to Jsonf: Console tool for highlighted formatting and struct query fetching JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [gorequest](https://github.com/parnurzeal/gorequest) - Simplified HTTP client with rich features for Go.
 * [gotenv](https://github.com/subosito/gotenv) - Load environment variables from `.env` or any `io.Reader` in Go
 * [hystrix-go](https://github.com/afex/hystrix-go) - Imprements Hystrix patterns of programmer-defined fallbacks aka circuit breaker.
+* [jsonf](https://github.com/miolini/jsonf) - Console tool for highlighted formatting and struct query fetching JSON.
 * [lrserver](https://github.com/jaschaephraim/lrserver) - LiveReload server for Go
 * [mp](https://github.com/sanbornm/mp) - A simple cli email parser. It currently takes stdin and outputs JSON.
 * [netbug](https://github.com/e-dard/netbug) - Easy remote profiling of your services.


### PR DESCRIPTION
Add link to Jsonf: Console tool for highlighted formatting and struct query fetching JSON.