### PR TITLE
Add anaconda

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 *Libraries for accessing third party APIs.*
 
+* [anaconda](https://github.com/ChimeraCoder/anaconda) - A Go client library for the Twitter 1.1 API
 * [aws-sdk-go](https://github.com/aws/aws-sdk-go) - The official AWS SDK for the Go programming language. Caution: The SDK is currently in the process of being developed, and not everything may be working fully yet.
 * [brewerydb](https://github.com/naegelejd/brewerydb) - Go library for accessing the BreweryDB API.
 * [facebook](https://github.com/huandu/facebook) - Go Library that supports the Facebook Graph API


### PR DESCRIPTION
Add [anaconda](https://github.com/ChimeraCoder/anaconda) library for working with Twitter 1.1 API to `Third-party APIs` section