### PR TITLE
Remove GoBuild (http://gobuild.io/), online compile Go projects to Windows, Linux and OS X.

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,7 +883,6 @@ Software written in Go.
 * [Go Metrics](https://github.com/rcrowley/go-metrics) - Go port of Coda Hale's Metrics library: https://github.com/codahale/metrics.
 * [go-selfupdate](https://github.com/sanbornm/go-selfupdate) - Enable your Go applications to self update.
 * [gobrew](https://github.com/cryptojuice/gobrew) - gobrew lets you easily switch between multiple versions of go.
-* [GoBuild](http://gobuild.io/) - Online compile Go projects to Windows, Linux and MacOSX.
 * [godbg](https://github.com/sirnewton01/godbg) - Web-based gdb front-end application.
 * [Gogs](http://gogs.io/) - A Self Hosted Git Service in the Go Programming Language.
 * [gonative](https://github.com/inconshreveable/gonative) - Tool which creates a build of Go that can cross compile to all platforms while still using the Cgo-enabled versions of the stdlib packages.


### PR DESCRIPTION
Don't merge this [within 7 days](https://github.com/avelino/awesome-go/pull/484#issuecomment-127084329) of PR's open date to allow sufficient time for people to review.

The website appears to be down. As far as I can tell it's no longer active, but let me know if that's not the case.

![image](https://cloud.githubusercontent.com/assets/1924134/9028688/1c234232-3936-11e5-8f7d-bdda66ee23b8.png)