### PR TITLE
Add Betwixt implements the OMA Lightweight M2M (LWM2M)

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 *Libraries for working with various layers of the network*
 
 * [arp](https://github.com/mdlayher/arp) - Package arp implements the ARP protocol, as described in RFC 826.
+* [betwixt](https://github.com/zubairhamed/betwixt) - Betwixt implements the OMA Lightweight M2M (LWM2M) protocol for Device Management and Monitoring
 * [buffstreams](https://github.com/stabbycutyou/buffstreams) - Streaming protocolbuffer data over TCP made easy
 * [dhcp6](https://github.com/mdlayher/dhcp6) - Package dhcp6 implements a DHCPv6 server, as described in RFC 3315.
 * [dns](https://github.com/miekg/dns) - Go library for working with DNS


### PR DESCRIPTION
Betwixt implements the OMA Lightweight M2M (LWM2M) protocol for Device Management and Monitoring
