### PR TITLE
Named anchor broken when not on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [waveform](https://github.com/mdlayher/waveform) - Go package capable of generating waveform images from audio streams.
 
 
-## Authentication & OAuth
+## <a name="authentication--oauth"></a>Authentication & OAuth
 
 *Libraries for implementing authentications schemes.*
 


### PR DESCRIPTION
I imagine there are others to do. On GitHub the named anchor scheme works, only because GH inserts those anchors for you. On http://awesome-go.com/, this doesn't work for headers that contain multiple words.
