### PR TITLE
add beego config

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 
 *Libraries for configuration parsing*
 
+* [beego-config](https://github.com/astaxie/beego/tree/master/config) - Configuration parsing inspired by database/sql, supports ini, json, xml and yaml.
 * [config](https://github.com/olebedev/config) - JSON or YAML configuration wrapper with environment variables and flags parsing.
 * [env](https://github.com/caarlos0/env) - Parse environment variables to Go structs (with defaults).
 * [envcfg](https://github.com/tomazk/envcfg) - Un-marshaling environment variables to Go structs.


### PR DESCRIPTION
to me it's even better than viper for config reading. 
If you use viper.GetInt("foo") when ``foo: bar``, you will get int 0.
Beego config returns error.