### PR TITLE
Adding streadway/AMQP

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 *Libraries that implement messaging systems*
 
+* [amqp] (https://github.com/streadway/amqp) - A generic AMQP client for Go.
 * [dbus](https://github.com/godbus/dbus) - Native Go bindings for D-Bus.
 * [EventBus](https://github.com/asaskevich/EventBus) - The lightweight event bus with async compatibility.
 * [go-notify](https://github.com/TheCreeper/go-notify) - Native implementation of the freedesktop notification spec.


### PR DESCRIPTION
I quite like the Streadway AMQP client for working with RabbitMQ and other AMQP queue brokers. I've found it to be fast, feature complete, and deserving of a place on this list.