### PR TITLE
Remove 'doc', which is deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,7 +875,6 @@ Go software and plugins.
 
 ## Code Analysis
 
-* [doc](http://godoc.org/robpike.io/cmd/doc) - Go documentation tool that produces an alternative doc format.
 * [dupl](https://github.com/mibk/dupl) - A tool for code clone detection.
 * [errcheck](https://github.com/kisielk/errcheck) - Errcheck is a program for checking for unchecked errors in Go programs.
 * [gcvis](https://github.com/davecheney/gcvis) - Visualise Go program GC trace data in real time.


### PR DESCRIPTION
"Doc is an old program that was used to design a nice command-level API for presenting Go documentation. It is deprecated; use the new go doc in 1.5 instead."

- https://godoc.org/robpike.io/cmd/doc