### PR TITLE
Add restic

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,6 +974,7 @@ Software written in Go.
 * [peg](https://github.com/pointlander/peg) - Peg, Parsing Expression Grammar, is an implementation of a Packrat parser generator.
 * [plubi](https://github.com/norwack/plubi) - A Golang Plugin Based IRC Bot.
 * [Postman](https://github.com/zachlatta/postman) - Command-line utility for batch-sending email.
+* [restic](https://github.com/restic/restic) - De-duplicating backup program.
 * [Seaweed File System](https://github.com/chrislusf/seaweedfs) - Fast, Simple and Scalable Distributed File System with O(1) disk seek.
 * [shell2http](https://github.com/msoap/shell2http) - Executing shell commands via http server (for prototyping or remote control)
 * [syncthing](http://www.syncthing.net/) - An open, decentralized file synchronization tool and protocol.


### PR DESCRIPTION
This commit adds a link to restic, a fast and secure backup program
that uses de-deuplication.

Disclaimer: I started the project and I'm the lead developer.

I was a bit unsure whether I should link to the restic GitHub repository or the restic website at https://restic.github.io, feedback here is appreciated.