### PR TITLE
Add Scalingo command line client

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,6 +970,7 @@ Software written in Go.
 * [Packer](https://github.com/mitchellh/packer) - Packer is a tool for creating identical machine images for multiple platforms from a single source configuration.
 * [Rodent](https://github.com/alouche/rodent) - Rodent helps you manage Go versions, projects and track dependencies.
 * [s3gof3r](https://github.com/rlmcpherson/s3gof3r) - A small utility/library optimized for high speed transfer of large objects into and out of Amazon S3.
+* [scalingo](https://github.com/Scalingo/cli) - Scalingo command-line interface in Go.
 * [Vegeta] (https://github.com/tsenart/vegeta) - HTTP load testing tool and library. It's over 9000!
 * [webhook](https://github.com/adnanh/webhook) - Tool which allows user to create HTTP endpoints (hooks) that execute commands on the server
 * [Wide](https://wide.b3log.org) - A Web-based IDE for Teams using Golang.


### PR DESCRIPTION
This PR adds [Scalingo's command line client](https://github.com/Scalingo/cli) to the list of DevOps.
[Scalingo](https://scalingo.com/) is a PaaS like Heroku.
