### PR TITLE
Add mow.cli, a library for building CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [kingpin](https://github.com/alecthomas/kingpin) - A command line and flag parser supporting sub commands.
 * [liner](https://github.com/peterh/liner) - A Go readline-like library for command-line interfaces.
 * [mitchellh/cli](https://github.com/mitchellh/cli) - A Go library for implementing command-line interfaces.
+* [mow.cli](https://github.com/jawher/mow.cli) - A Go library for building CLI applications with sophisticated flag and argument parsing and validation.
 * [readline](https://github.com/chzyer/readline) - A pure golang implementation that provide most of features in GNU-Readline under MIT license.
 * [ukautz/clif](https://github.com/ukautz/clif) - A small command line interface framework.
 


### PR DESCRIPTION
A [library](https://github.com/jawher/mow.cli) for building CLI applications.

## Why yet another CLI library ?

mow.cli comes with support for what you would expect from any decent CLI library: posix syntax, option groups, commands and sub commands, contextual help, ...

What sets it apart is a sophisticated call validation, by providing a spec string to specify how exactly a command should be called.
For example, here's the spec string you can use with mow.cli to define the call syntax of a `cp` like command:

```
[-R [-H | -L | -P]] [-fi | -n] [-apvX] SRC... DST
```

I've written 2 articles to explain in more details the why and how: [1](https://jawher.me/2015/01/13/parsing-command-line-arguments-shameless-plug-mowcli/), [2](https://jawher.me/2015/01/18/parsing-command-line-arguments-finite-state-machine-backtracking/)

mow.cli is fairly well tested (84% coverage), well documented (see [godoc](https://godoc.org/github.com/jawher/mow.cli)) and the code quality is not too bad either ([A+ grade](http://goreportcard.com/report/jawher/mow.cli)).