### PR TITLE
Add trayhost package to GUI section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [gotk3](https://github.com/gotk3/gotk3) - Go bindings for GTK3.
 * [gxui](https://github.com/google/gxui) - A Go cross platform UI library.
 * [sciter](https://github.com/oskca/sciter) - Go bindings for Sciter: the Embeddable HTML/CSS/script engine for modern desktop UI development.
+* [trayhost](https://github.com/shurcooL/trayhost) - Cross-platform Go library to place an icon in the host operating system's taskbar.
 * [ui](https://github.com/andlabs/ui) - Platform-native GUI library for Go.
 * [walk](https://github.com/lxn/walk) - Windows application library kit for Go.
 


### PR DESCRIPTION
Package trayhost is a cross-platform Go library to place an icon in the host operating system's taskbar.

[`github.com/shurcooL/trayhost`](https://github.com/shurcooL/trayhost)

Here are some screenshots from [an app](https://github.com/pavben/InstantShare#readme) (/cc @pavben) that uses trayhost for its GUI.

![Screenshot 1](https://cloud.githubusercontent.com/assets/1924134/8891878/8dd7a024-32ee-11e5-8eca-1994f8503094.png)

![Screenshot 2](https://cloud.githubusercontent.com/assets/1924134/8891877/8dc67272-32ee-11e5-9656-7f9749394ad3.png)

The implementation status is fully implemented for OS X, but there's not a working implementation for Linux nor Windows yet. Contributors for those platforms are welcome.