### PR TITLE
Update webhooks library description

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,7 +847,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [TheMovieDb](https://github.com/jbrodriguez/go-tmdb) - A simple golang package to communicate with [themoviedb.org](https://themoviedb.org)
 * [translate](https://github.com/poorny/translate) - Go online translation package
 * [tumblr](https://github.com/mattcunningham/gumblr) - Go wrapper for the Tumblr v2 API.
-* [webhooks](https://github.com/go-playground/webhooks) - Webhook receiver for GitHub.. more services to come
+* [webhooks](https://github.com/go-playground/webhooks) - Webhook reciever for GitHub and Bitbucket
 
 ## Utilities
 


### PR DESCRIPTION
add Bitbucket support to [webhooks](https://github.com/go-playground/webhooks) library description.
