### PR TITLE
Update README.md's aws-sdk-go comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,7 +815,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 *Libraries for accessing third party APIs.*
 
 * [anaconda](https://github.com/ChimeraCoder/anaconda) - A Go client library for the Twitter 1.1 API
-* [aws-sdk-go](https://github.com/aws/aws-sdk-go) - The official AWS SDK for the Go programming language. Caution: The SDK is currently in the process of being developed, and not everything may be working fully yet.
+* [aws-sdk-go](https://github.com/aws/aws-sdk-go) - The official AWS SDK for the Go programming language.
 * [brewerydb](https://github.com/naegelejd/brewerydb) - Go library for accessing the BreweryDB API.
 * [clarifai](https://github.com/samuelcouch/clarifai) - A Go client library for interfacing with the Clarifai API.
 * [facebook](https://github.com/huandu/facebook) - Go Library that supports the Facebook Graph API


### PR DESCRIPTION
Updated the AWS SDK for Go's comment line to reflect that it is now officially launched and ready for production use.