### PR TITLE
Adding golang-kardianos-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [go-chat-bot](https://github.com/go-chat-bot/bot) - IRC, Slack & Telegram bot written in Go.
 * [go-multierror](https://github.com/hashicorp/go-multierror) - A Go (golang) package for representing a list of errors as a single error.
 * [go-shortid](https://github.com/ventu-io/go-shortid) - Distributed generation of super short, unique, non-sequential, URL friendly IDs.
-* [golang-kardianos-service](https://github.com/ayufan/golang-kardianos-service) - Run go programs as a service on major platforms (this is used in the gitlab-ci-multi-runner app - https://gitlab.com/gitlab-org/gitlab-ci-multi-runner)
 * [gopsutil](https://github.com/shirou/gopsutil) - A cross-platform library for retrieving process and system utilization(CPU, Memory, Disks, etc).
 * [gosms](https://github.com/haxpax/gosms) - Your own local SMS gateway in Go that can be used to send SMS
 * [jobs](https://github.com/albrow/jobs) - A persistent and flexible background jobs library.
@@ -1084,6 +1083,7 @@ Software written in Go.
 * [gobrew](https://github.com/cryptojuice/gobrew) - gobrew lets you easily switch between multiple versions of go.
 * [godbg](https://github.com/sirnewton01/godbg) - Web-based gdb front-end application.
 * [Gogs](https://gogs.io/) - A Self Hosted Git Service in the Go Programming Language.
+* [golang-kardianos-service](https://github.com/ayufan/golang-kardianos-service) - Run go programs as a service on major platforms (this is used in the gitlab-ci-multi-runner app - https://gitlab.com/gitlab-org/gitlab-ci-multi-runner)
 * [gonative](https://github.com/inconshreveable/gonative) - Tool which creates a build of Go that can cross compile to all platforms while still using the Cgo-enabled versions of the stdlib packages.
 * [gox](https://github.com/mitchellh/gox) - A dead simple, no frills Go cross compile tool.
 * [goxc](https://github.com/laher/goxc) - build tool for Go, with a focus on cross-compiling and packaging.

--- a/README.md
+++ b/README.md
@@ -543,6 +543,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [go-chat-bot](https://github.com/go-chat-bot/bot) - IRC, Slack & Telegram bot written in Go.
 * [go-multierror](https://github.com/hashicorp/go-multierror) - A Go (golang) package for representing a list of errors as a single error.
 * [go-shortid](https://github.com/ventu-io/go-shortid) - Distributed generation of super short, unique, non-sequential, URL friendly IDs.
+* [golang-kardianos-service](https://github.com/ayufan/golang-kardianos-service) - Run go programs as a service on major platforms (this is used in the gitlab-ci-multi-runner app - https://gitlab.com/gitlab-org/gitlab-ci-multi-runner)
 * [gopsutil](https://github.com/shirou/gopsutil) - A cross-platform library for retrieving process and system utilization(CPU, Memory, Disks, etc).
 * [gosms](https://github.com/haxpax/gosms) - Your own local SMS gateway in Go that can be used to send SMS
 * [jobs](https://github.com/albrow/jobs) - A persistent and flexible background jobs library.


### PR DESCRIPTION
Adding https://github.com/ayufan/golang-kardianos-service

An amazing repo for installing any golang app as a Service on Windows, Linux, etc. This repo is used by the [gitlab-ci-multi-runner](https://gitlab.com/gitlab-org/gitlab-ci-multi-runner)
