### PR TITLE
Add go-atomix to the Audio & Music section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 *Libraries for manipulating audio.*
 
 * [flac](https://github.com/eaburns/flac) - A native Go FLAC decoder.
+* [go-atomix](https://github.com/outrightmental/go-atomix) - Sequence-based Go-native audio mixer for Music apps.
 * [go-sox](https://github.com/krig/go-sox) - libsox bindings for go.
 * [go_mediainfo](https://github.com/zhulik/go_mediainfo) - libmediainfo bindings for go.
 * [mp3](https://github.com/tcolgate/mp3) - A native Go MP# decoder.


### PR DESCRIPTION
[go-atomix](https://github.com/outrightmental/go-atomix) is a sequence-based Go-native audio mixer for Music apps.

Here is its A+ [go report card](http://goreportcard.com/report/outrightmental/go-atomix)

This is a library I've been working on for two months now, since first discovering `go-sdl2` through your awesome list. It now meets the criteria of being awesome. Please add!