### PR TITLE
[web] Add golax framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,6 +978,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [Goat](https://github.com/bahlo/goat) - A minimalistic REST API server in Go
 * [gocraft/web](https://github.com/gocraft/web) - A mux and middleware package in Go.
 * [Goji](https://github.com/goji/goji) - Goji is a minimalistic and flexible HTTP request multiplexer with support for `net/context`.
+* [golax](https://github.com/fulldump/golax) - Golax is the official go implementation for the Lax framework.
 * [golongpoll](https://github.com/jcuga/golongpoll) - HTTP longpoll server library that makes web pub-sub simple.
 * [Gondola](https://github.com/rainycape/gondola) - The web framework for writing faster sites, faster
 * [goose](https://github.com/ian-kent/goose) - Server Sent Events in Go


### PR DESCRIPTION
[web] Add golax framework. In contrast to all sinatra frameworks, this has a different approach.
