### PR TITLE
Add httpware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,6 +1032,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [catena](https://github.com/codemodus/catena) - http.Handler wrapper catenation (same API as "chain").
 * [chain](https://github.com/codemodus/chain) - Handler wrapper chaining with scoped data (net/context-based "middleware").
 * [go-wrap](https://github.com/go-on/wrap) - Small middlewares package for net/http.
+* [httpware](https://github.com/nstogner/httpware) - Stackable middleware (using net/context) with easy chaining.
 * [interpose](https://github.com/carbocation/interpose) - Minimalist net/http middleware for golang
 * [muxchain](https://github.com/stephens2424/muxchain) - Lightweight middleware for net/http.
 * [negroni](https://github.com/codegangsta/negroni) - Idiomatic HTTP middleware for Golang.


### PR DESCRIPTION
httpware is a library for composing/creating http middleware. It also contains a collection of middleware packages. I was not sure whether to put it under "Actual Middlewares" or "Libraries for creating HTTP middlewares", so I went with the latter.