### PR TITLE
Add go-tablib

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,6 +811,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
     * [go-pkg-rss](https://github.com/jteeuwen/go-pkg-rss) - This package reads RSS and Atom feeds and provides a caching mechanism that adheres to the feed specs.
     * [go-pkg-xmlx](https://github.com/jteeuwen/go-pkg-xmlx) - Extension to the standard Go XML package. Maintains a node tree that allows forward/backwards browsing and exposes some simple single/multi-node search functions.
     * [go-runewidth](https://github.com/mattn/go-runewidth) - Functions to get fixed width of the character or string.
+    * [go-tablib](https://github.com/agrison/go-tablib) - Go Module for Tabular Datasets in CSV, JSON, YAML, etc. 
     * [gographviz](https://github.com/awalterschulze/gographviz) - Parses the Graphviz DOT language.
     * [gommon/bytes](https://github.com/labstack/gommon/tree/master/bytes) - Format bytes to string.
     * [gonameparts](https://github.com/polera/gonameparts) - Parses human names into individual name parts


### PR DESCRIPTION
go-tablib is a format-agnostic tabular dataset library, written in Go. It allows you to import, export, and manipulate tabular data sets. Advanced features include, dynamic columns, tags & filtering, and seamless format import & export.
