### PR TITLE
Add xkcd API

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,6 +850,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [github](https://github.com/google/go-github) - Go library for accessing the GitHub API.
 * [go-marathon](https://github.com/gambol99/go-marathon) - A Go library for interacting with Mesosphere's Marathon PAAS
 * [go-twitter](https://github.com/dghubble/go-twitter) - Go client library for the Twitter v1.1 APIs.
+* [go-xkcd](https://github.com/nishanths/go-xkcd) - Go client for the xkcd API.
 * [goamz](https://github.com/mitchellh/goamz) - Popular fork of [goamz](https://launchpad.net/goamz) which adds some missing API calls to certain packages.
 * [GoMusicBrainz](https://github.com/michiwend/gomusicbrainz) - a Go MusicBrainz WS2 client library
 * [google](https://github.com/google/google-api-go-client) - Auto-generated Google APIs for Go


### PR DESCRIPTION
go-xkcd: [GitHub](https://github.com/nishanths/go-xkcd), [GoDoc](https://godoc.org/github.com/nishanths/go-xkcd)