### PR TITLE
Added go-carpet, tool for viewing test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,6 +774,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
     * [bro](https://github.com/marioidival/bro) - Watch files in directory and run tests for them
     * [frisby](https://github.com/verdverm/frisby) - a REST API testing framework
     * [ginkgo](http://onsi.github.io/ginkgo/) - BDD Testing Framework for Go
+    * [go-carpet](https://github.com/msoap/go-carpet) - Tool for viewing test coverage in terminal
     * [go-mutesting](https://github.com/zimmski/go-mutesting) - Mutation testing for Go source code
     * [go-vcr](https://github.com/dnaeon/go-vcr) - Record and replay your HTTP interactions for fast, deterministic and accurate tests
     * [goblin](https://github.com/franela/goblin) - Mocha like testing framework fo Go


### PR DESCRIPTION
Why the go-carpet better builtin tool?

The builtin Go coverage viewer:
- generates in two steps: "go test -coverprofile" and "go tool cover", go-carpet in one (just run)
- generates only html, your don't view coverage in terminal
- not able to show coverage outside of the GOPATH
- not able to show coverage for multiple Go packages (in sub-directories)

Screenshot:
<img width="664" alt="go-carpet-screenshot" src="https://cloud.githubusercontent.com/assets/844117/13379229/967db8e0-de28-11e5-8b3f-cba51af3f3bc.png">