### PR TITLE
Add kirilldanshin/nulltime

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [go-persian-calendar](https://github.com/yaa110/go-persian-calendar) - The implementation of the Persian (Solar Hijri) Calendar in Go (golang).
 * [goweek](https://github.com/grsmv/goweek) - Library for working with week entity in golang.
 * [now](https://github.com/jinzhu/now) - Now is a time toolkit for golang.
+* [NullTime](https://github.com/kirillDanshin/nulltime) - Nullable time.Time
 * [timeutil](https://github.com/leekchan/timeutil) - Useful extensions (Timedelta, Strftime, ...) to the golang's time package.
 
 


### PR DESCRIPTION
Link to https://goreportcard.com/: https://goreportcard.com/report/github.com/kirillDanshin/nulltime

Link to https://gocover.io/: https://gocover.io/github.com/kirillDanshin/nulltime

Link to https://godoc.org/: https://godoc.org/github.com/kirillDanshin/nulltime

This library provides a modified version of nulltime from lib/pq as small library. So we don't need to `import github.com/lib/pq` when we don't need the whole library, just `import github.com/kirilldanshin/nulltime`.