### PR TITLE
add alxrm/ugo

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,6 +952,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [sling](https://github.com/dghubble/sling) - Go HTTP requests builder for API clients.
 * [spinner](https://github.com/briandowns/spinner) - Go package to easily provide a terminal spinner with options.
 * [sqlx](https://github.com/jmoiron/sqlx) - provides a set of extensions on top of the excellent built-in database/sql package
+* [ugo](https://github.com/alxrm/ugo) - ugo is slice toolbox with concise syntax for Go
 * [xlsx](https://github.com/tealeg/xlsx) - Library to simplify reading the XML format used by recent version of Microsoft Excel in Go programs.
 
 


### PR DESCRIPTION
Link to [goreportcard](https://goreportcard.com/): https://goreportcard.com/report/github.com/alxrm/ugo

Link to [gocover](https://gocover.io/): https://gocover.io/github.com/alxrm/ugo

Link to [godoc](https://godoc.org/): https://godoc.org/github.com/alxrm/ugo

ugo is a set of slice helper methods, written in Go. It provides many different functions, mostly for slices though. Inspired by [underscore.js](underscorejs.org) and copies it's syntax and behaviour.