### PR TITLE
Added quicktemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [kasia.go](https://github.com/ziutek/kasia.go) - Templating system for HTML and other text documents - go implementation.
 * [mustache](https://github.com/hoisie/mustache) - A Go implementation of the Mustache template language.
 * [pongo2](https://github.com/flosch/pongo2) - A Django-like template-engine for Go.
+* [quicktemplate](https://github.com/valyala/quicktemplate) - Fast, powerful, yet easy to use template engine. Converts templates into Go code and then compiles it.
 * [raymond](https://github.com/aymerick/raymond) - A complete handlebars implementation in Go.
 * [Razor](https://github.com/sipin/gorazor) - Razor view engine for Golang.
 * [Soy](https://github.com/robfig/soy) - Closure templates (aka Soy templates) for Go, following the [official spec](https://developers.google.com/closure/templates/)


### PR DESCRIPTION
Please provide package links to:
- godoc.org: https://godoc.org/github.com/valyala/quicktemplate
- goreportcard.com: http://goreportcard.com/report/valyala/quicktemplate
- gocover.io: https://gocover.io/github.com/valyala/quicktemplate

