### PR TITLE
add github.com/go-music-theory/music-theory

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [go-sox](https://github.com/krig/go-sox) - libsox bindings for go.
 * [go_mediainfo](https://github.com/zhulik/go_mediainfo) - libmediainfo bindings for go.
 * [mp3](https://github.com/tcolgate/mp3) - A native Go MP# decoder.
+* [music-theory](https://github.com/go-music-theory/music-theory) - Music theory models in Go.
 * [ontomix](https://github.com/go-ontomix/ontomix) - Sequence-based Go-native audio mixer for Music apps.
 * [PortAudio](https://github.com/gordonklaus/portaudio) - Go bindings for the PortAudio audio I/O library.
 * [portmidi](https://github.com/rakyll/portmidi) - Go bindings for PortMidi.


### PR DESCRIPTION
I've been working on this and it is now at a point of having some decent utility. I am actively continuing work on it. Thanks!

###### github.com

https://github.com/go-music-theory/music-theory

###### godoc.org

https://godoc.org/github.com/go-music-theory/music-theory

###### goreportcard.com

https://goreportcard.com/report/github.com/go-music-theory/music-theory

###### gocover.io

 * https://gocover.io/github.com/go-music-theory/music-theory/chord
 * https://gocover.io/github.com/go-music-theory/music-theory/key
 * https://gocover.io/github.com/go-music-theory/music-theory/note
