### PR TITLE
Add go-jira: Go client library for Atlassian JIRA

### DIFF
--- a/README.md
+++ b/README.md
@@ -861,6 +861,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [geo-golang](https://github.com/codingsince1985/geo-golang) - Go Library to access [Google Maps](https://developers.google.com/maps/documentation/geocoding/intro), [MapQuest](http://open.mapquestapi.com/geocoding/), [Nominatim](http://open.mapquestapi.com/nominatim/), [OpenCage](http://geocoder.opencagedata.com/api.html), [HERE](https://developer.here.com/rest-apis/documentation/geocoder), [Bing](https://msdn.microsoft.com/en-us/library/ff701715.aspx), and [Mapbox](https://www.mapbox.com/developers/api/geocoding/) geocoding / reverse geocoding APIs.
 * [ghost](https://github.com/neuegram/ghost) - Go Library for accessing the Snapchat API.
 * [github](https://github.com/google/go-github) - Go library for accessing the GitHub API.
+* [go-jira](https://github.com/andygrunwald/go-jira) - Go client library for [Atlassian JIRA](https://www.atlassian.com/software/jira)
 * [go-marathon](https://github.com/gambol99/go-marathon) - A Go library for interacting with Mesosphere's Marathon PAAS.
 * [go-trending](https://github.com/andygrunwald/go-trending) - Go library for accessing [trending repositories](https://github.com/trending) and [developers](https://github.com/trending/developers) at Github.
 * [go-twitter](https://github.com/dghubble/go-twitter) - Go client library for the Twitter v1.1 APIs.


### PR DESCRIPTION
[go-jira](https://github.com/andygrunwald/go-jira): A [Go](https://golang.org/) client library for [Atlassian JIRA](https://www.atlassian.com/software/jira).

Please provide package links to:
- godoc.org: https://godoc.org/github.com/andygrunwald/go-jira
- goreportcard.com: https://goreportcard.com/report/github.com/andygrunwald/go-jira
- coveralls.io: https://coveralls.io/github/andygrunwald/go-jira?branch=master 

