### PR TITLE
Added cachet client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,6 +852,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [anaconda](https://github.com/ChimeraCoder/anaconda) - A Go client library for the Twitter 1.1 API
 * [aws-sdk-go](https://github.com/aws/aws-sdk-go) - The official AWS SDK for the Go programming language.
 * [brewerydb](https://github.com/naegelejd/brewerydb) - Go library for accessing the BreweryDB API.
+* [cachet](https://github.com/andygrunwald/cachet) - Go client library for [Cachet (open source status page system)](https://cachethq.io/)
 * [clarifai](https://github.com/samuelcouch/clarifai) - A Go client library for interfacing with the Clarifai API.
 * [discordgo](https://github.com/bwmarrin/discordgo) -  Go bindings for the Discord Chat API
 * [facebook](https://github.com/huandu/facebook) - Go Library that supports the Facebook Graph API


### PR DESCRIPTION
[Go(lang)](https://golang.org/) client library for [Cachet (open source status page system)](https://cachethq.io/).

Please provide package links to:
- godoc.org: https://godoc.org/github.com/andygrunwald/cachet
- goreportcard.com: https://goreportcard.com/report/github.com/andygrunwald/cachet
- coveralls.io: https://coveralls.io/github/andygrunwald/cachet

