### PR TITLE
Added megos: A client library for accessing an Apache Mesos Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,6 +874,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [hipchat](https://github.com/andybons/hipchat) - This project implements a golang client library for the Hipchat API.
 * [hipchat (xmpp)](https://github.com/daneharrigan/hipchat) - A golang package to communicate with HipChat over XMPP.
 * [Medium](https://github.com/Medium/medium-sdk-go) - A Golang SDK for Medium's OAuth2 API.
+* [megos](https://github.com/andygrunwald/megos) - A client library for accessing an [Apache Mesos](http://mesos.apache.org/) cluster
 * [minio-go](https://github.com/minio/minio-go) - Minio Go Library for Amazon S3 compatible cloud storage.
 * [mixpanel](https://github.com/dukex/mixpanel) - Mixpanel is a library for tracking events and sending Mixpanel profile updates to Mixpanel from your go applications.
 * [paypal](https://github.com/logpacker/paypalsdk) - Wrapper for PayPal payment API


### PR DESCRIPTION
[Megos](https://github.com/andygrunwald/megos): [Go(lang)](https://golang.org/) client library for accessing an [Apache Mesos](http://mesos.apache.org/) cluster.

Please provide package links to:
- godoc.org: https://godoc.org/github.com/andygrunwald/megos
- goreportcard.com: https://goreportcard.com/report/github.com/andygrunwald/megos
- coveralls.io: https://coveralls.io/github/andygrunwald/megos

