### PR TITLE
add link to VarHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,6 +1036,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [tango](https://github.com/lunny/tango) - Micro & pluggable web framework for Go.
 * [tigertonic](https://github.com/rcrowley/go-tigertonic) - A Go framework for building JSON web services inspired by Dropwizard
 * [traffic](https://github.com/pilu/traffic) - Sinatra inspired regexp/pattern mux and web framework for Go.
+* [VarHandler](https://github.com/azr/generators/tree/master/varhandler) - Generate boilerplate http input and ouput handling.
 * [vestigo](https://github.com/husobee/vestigo) -  A performant, stand-alone, HTTP compliant URL Router for go web applications.
 * [Volatile](https://github.com/volatile/core) - Minimalist middleware stack promoting flexibility, good practices and clean code.
 * [web.go](https://github.com/hoisie/web) - A simple framework to write webapps in Go.


### PR DESCRIPTION
- godoc.org: https://godoc.org/github.com/azr/generators/varhandler
- goreportcard.com:  https://goreportcard.com/report/github.com/azr/generators
- gocover.io: Can't really, its a generator.

I'll be the maintainer.

I'd rather put it into web framework stuff, but it can put be in generation too, so I put it in both.

Is it fine ?

Cheers !