### PR TITLE
adding fullcontact-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1054,6 +1054,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [discordgo](https://github.com/bwmarrin/discordgo) -  Go bindings for the Discord Chat API
 * [facebook](https://github.com/huandu/facebook) - Go Library that supports the Facebook Graph API
 * [fcm](https://github.com/maddevsio/fcm) - Go library for Firebase Cloud Messaging
+* [fullcontact-go](https://github.com/Abramovic/fullcontact-go) - Go Library for FullContact's API.
 * [gads](https://github.com/emiddleton/gads) - Google Adwords Unofficial API
 * [gami](https://github.com/bit4bit/gami) - Go library for Asterisk Manager Interface.
 * [gcm](https://github.com/Aorioli/gcm) - Go library for Google Cloud Messaging


### PR DESCRIPTION
Go Library for FullContact's API

github - https://github.com/Abramovic/fullcontact-go
godoc.org - https://godoc.org/github.com/Abramovic/fullcontact-go
goreportcard.com - https://goreportcard.com/report/github.com/Abramovic/fullcontact-go
