### PR TITLE
Adding Tile38

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [rqlite](https://github.com/otoolep/rqlite) - Replicated SQLite, using Raft consensus.
 * [tidb](https://github.com/pingcap/tidb) - TiDB is a distributed SQL database. Inspired by the design of Google F1.
 * [tiedot](https://github.com/HouzuoGuo/tiedot) - Your NoSQL database powered by Golang.
+* [Tile38](https://github.com/tidwall/tile38) - A geolocation DB with spatial index and realtime geofencing.
 
 *Database tools.*
 


### PR DESCRIPTION
[Tile38](https://github.com/tidwall/tile38) is a geolocation data store, spatial index, and realtime geofence. It supports a variety of object types including lat/lon points, bounding boxes, XYZ tiles, Geohashes, and GeoJSON.

It's like Redis but for GIS.

- website: http://tile38.com
- godoc.org: https://godoc.org/github.com/tidwall/tile38
- goreportcard.com: https://goreportcard.com/report/github.com/tidwall/tile38