### PR TITLE
re-add github.com/go-music-theory/music-theory

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [go_mediainfo](https://github.com/zhulik/go_mediainfo) - libmediainfo bindings for go.
 * [mix](https://github.com/go-mix/mix) - Sequence-based Go-native audio mixer for music apps.
 * [mp3](https://github.com/tcolgate/mp3) - A native Go MP# decoder.
+* [music-theory](https://github.com/go-music-theory/music-theory) - Music theory models in Go.
 * [PortAudio](https://github.com/gordonklaus/portaudio) - Go bindings for the PortAudio audio I/O library.
 * [portmidi](https://github.com/rakyll/portmidi) - Go bindings for PortMidi.
 * [taglib](https://github.com/wtolson/go-taglib) - Go bindings for taglib.


### PR DESCRIPTION
This diff is identical to the already-merged-and-closed [#869](https://github.com/avelino/awesome-go/pull/869/files) which my own subsequent  79cc8dc126c3f4fa3f764e351dfb32fe662f64d3 has accidentally reversed.

*To re-cap:*

I've been working on the `gopkg.in/music-theory.v0` library for a while and it is now at a point of having some decent utility. I am actively continuing work on it. Thanks!

###### github.com

https://github.com/go-music-theory/music-theory

###### godoc.org

https://godoc.org/github.com/go-music-theory/music-theory

###### goreportcard.com

https://goreportcard.com/report/github.com/go-music-theory/music-theory

###### gocover.io

 * https://gocover.io/github.com/go-music-theory/music-theory/chord
 * https://gocover.io/github.com/go-music-theory/music-theory/key
 * https://gocover.io/github.com/go-music-theory/music-theory/note