### PR TITLE
Add httpware - composable (net/context based) middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1075,6 +1075,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [chain](https://github.com/codemodus/chain) - Handler wrapper chaining with scoped data (net/context-based "middleware").
 * [go-wrap](https://github.com/go-on/wrap) - Small middlewares package for net/http.
 * [gores](https://github.com/alioygur/gores) - Go package that handles HTML, JSON, XML and etc. responses. Useful for RESTful APIs.
+* [httpware](https://github.com/nstogner/httpware) - Stackable middleware (using net/context) with easy chaining.
 * [interpose](https://github.com/carbocation/interpose) - Minimalist net/http middleware for golang.
 * [muxchain](https://github.com/stephens2424/muxchain) - Lightweight middleware for net/http.
 * [negroni](https://github.com/codegangsta/negroni) - Idiomatic HTTP middleware for Golang.


### PR DESCRIPTION
httpware is a library for composing/creating http middleware. It also contains a collection of middleware packages. I was not sure whether to put it under "Actual Middlewares" or "Libraries for creating HTTP middlewares", so I went with the latter.

The old pull request is here: https://github.com/avelino/awesome-go/pull/830

Godoc:
https://godoc.org/github.com/nstogner/httpware

Go Report Card:
https://goreportcard.com/report/github.com/nstogner/httpware

Go Cover:
https://gocover.io/github.com/nstogner/httpware
https://gocover.io/github.com/nstogner/httpware/contentware
https://gocover.io/github.com/nstogner/httpware/corsware
https://gocover.io/github.com/nstogner/httpware/errorware
https://gocover.io/github.com/nstogner/httpware/httpctx (no testable code in this pkg)
https://gocover.io/github.com/nstogner/httpware/limitware
https://gocover.io/github.com/nstogner/httpware/logware
https://gocover.io/github.com/nstogner/httpware/routeradapt
https://gocover.io/github.com/nstogner/httpware/tokenware
