### PR TITLE
add ingo config utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [envconfig](https://github.com/vrischmann/envconfig) - Read your configuration from environment variables.
 * [gcfg](https://github.com/go-gcfg/gcfg) - read INI-style configuration files into Go structs; supports user-defined types and subsections
 * [gofigure](https://github.com/ian-kent/gofigure) - Go application configuration made easy
+* [ingo](https://github.com/schachmat/ingo) - Flags persisted in an ini-like config file
 * [ini](https://github.com/go-ini/ini) - Go package for read and write INI files
 * [mini](https://github.com/FogCreek/mini) - A golang package for parsing ini-style configuration files
 * [store](https://github.com/tucnak/store) - A lightweight configuration manager for Go


### PR DESCRIPTION
required links:
- [godoc.org](https://godoc.org/github.com/schachmat/ingo)
- [goreportcard.com](https://goreportcard.com/report/github.com/schachmat/ingo)
- [gocover.io](https://gocover.io/github.com/schachmat/ingo)

It distinguishes itself from the other choices by its simplicity. It just has around 100 lines of code only using standard library imports and only one exported function `ingo.Parse(appName string)` which is supposed to be used as a drop-in replacement for flags.Parse().