### PR TITLE
Rename Engi to Engo

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 
 *Awesome game development libraries.*
 
-* [engi](https://github.com/paked/engi) - A cross-platform game engine following the Entity Component System design pattern
+* [engo](https://github.com/EngoEngine/engo) - Engo is an open-source 2D game engine written in Go. It follows the Entity-Component-System paradigm.
 * [GarageEngine](https://github.com/vova616/GarageEngine) - 2d game engine written in Go working on OpenGL.
 * [glop](https://github.com/runningwild/glop) - Glop (Game Library Of Power) is a fairly simple cross-platform game library.
 * [go-astar](https://github.com/beefsack/go-astar) - Go implementation of the A\* path finding algorithm


### PR DESCRIPTION
We've recently renamed the project and moved to an organisation.

I'm really sorry I haven't included the godoc, gocover, etc. links at the moment. I'll put this on my todo list.