### PR TITLE
add Go supplementary cryptography libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,6 +983,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [sqlx](https://github.com/jmoiron/sqlx) - provides a set of extensions on top of the excellent built-in database/sql package.
 * [ugo](https://github.com/alxrm/ugo) - ugo is slice toolbox with concise syntax for Go.
 * [xlsx](https://github.com/tealeg/xlsx) - Library to simplify reading the XML format used by recent version of Microsoft Excel in Go programs.
+* [crypto](https://github.com/xigang/crypto) - Go supplementary cryptography libraries.
 
 
 ## Validation
@@ -1190,7 +1191,7 @@ Software written in Go.
 * [Juju](https://jujucharms.com/) - Cloud-agnostic service deployment and orchestration - supports EC2, Azure, Openstack, MAAS and more.
 * [limetext](http://limetext.org/) Lime Text is a powerful and elegant text editor primarily developed in Go that aims to be a Free and open-source software successor to Sublime Text.
 * [LiteIDE](https://github.com/visualfc/liteide) LiteIDE is a simple, open source, cross-platform Go IDE.
-* [mockingjay](https://github.com/quii/mockingjay-server) Fake HTTP servers and consumer driven contracts from one configuration file. You can also make the server randomly misbehave to help do more realistic performance tests. 
+* [mockingjay](https://github.com/quii/mockingjay-server) Fake HTTP servers and consumer driven contracts from one configuration file. You can also make the server randomly misbehave to help do more realistic performance tests.
 * [naclpipe](https://github.com/unix4fun/naclpipe) - A simple NaCL EC25519 based crypto pipe tool written in Go.
 * [nes](https://github.com/fogleman/nes) - A Nintendo Entertainment System (NES) emulator written in Go.
 * [orange-cat](https://github.com/noraesae/orange-cat) - A Markdown previewer written in Go.


### PR DESCRIPTION
- [crypto](https://github.com/xigang/crypto) -Go supplementary cryptography libraries
- [godoc.org](https://godoc.org/github.com/xigang/crypto) 
- [goreportcard.com](https://goreportcard.com/report/github.com/xigang/crypto) 
- [gocover.io](https://gocover.io/github.com/xigang/crypto) 

Make sure that you've checked the boxes below before you submit PR:
- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link
- [x] I have added gocover.io link
- [x] I have added goreportcard link
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard)