### PR TITLE
Add secdl, Golang implementation of Lighttpd ModSecDownload algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [jobs](https://github.com/albrow/jobs) - A persistent and flexible background jobs library.
 * [margelet](https://github.com/zhulik/margelet) - A framework for building Telegram bots.
 * [notify](https://github.com/rjeczalik/notify) - File system event notification library with simple API, similar to os/signal.
+* [secdl](https://github.com/xor-gate/secdl) - Lighttpd ModSecDownload algorithm ported to go to secure download urls.
 * [stats](https://github.com/go-playground/stats) - Monitors Go MemStats + System stats such as Memory, Swap and CPU and sends via UDP anywhere you want for logging etc...
 * [werr](https://github.com/txgruppi/werr) - Error Wrapper creates an wrapper for the error type in Go which captures the File, Line and Stack of where it was called.
 * [xkg](https://github.com/go-xkg/xkg) - X Keyboard Grabber


### PR DESCRIPTION
- godoc.org: https://godoc.org/github.com/xor-gate/secdl
- goreportcard.com: https://goreportcard.com/report/github.com/xor-gate/secdl
- gocover.io: https://gocover.io/github.com/xor-gate/secdl

- [X] I have added my package in alphabetical order
- [X] I know that this package was not listed before
- [X] I have added godoc link
- [X] I have added gocover.io link
- [X] I have added goreportcard link
- [X] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).