### PR TITLE
Added d3d9 library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1301,4 +1301,5 @@ Where to discover new Go libraries.
 
 ## Windows
 
+* [d3d9](https://github.com/gonutz/d3d9) - Go bindings for Direct3D9
 * [go-ole](https://github.com/go-ole/go-ole) - Win32 OLE implementation for golang.


### PR DESCRIPTION
I created a Direct3D9 wrapper for Go because none existed. The API is complete, I created some samples, added a readme with build instructions and documentation, ran go vet and golint on the code and fixed the issues that needed to be fixed, tested the library on two different Windows systems with different compilers and now it is ready to be used by other people so I would like it to be added to this list so people can find it.
Here are the links:
[d3d9 library](https://github.com/gonutz/d3d9)
[godoc](https://godoc.org/github.com/gonutz/d3d9)
[goreportcard](https://goreportcard.com/report/github.com/gonutz/d3d9)
gocover is not able to build the project, I assume because it uses cgo on Windows.