### PR TITLE
Add github.com/olahol/melody.

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [gorush](https://github.com/appleboy/gorush) - A push notification server using [APNs2](https://github.com/sideshow/apns2) and google [GCM](https://github.com/google/go-gcm).
 * [machinery](https://github.com/RichardKnop/machinery) - An asynchronous task queue/job queue based on distributed message passing.
 * [mangos](https://github.com/go-mangos/mangos) - Pure go implementation of the Nanomsg ("Scalable Protocols") with transport interoperability.
+* [melody](https://github.com/olahol/melody) - Minimalist framework for dealing with websocket sessions, includes broadcasting and automatic ping/pong handling.
 * [NATS Go Client](https://github.com/nats-io/nats) - A lightweight and high performance publish-subscribe and distributed queueing messaging system - this is the Go library.
 * [oplog](https://github.com/dailymotion/oplog) - A generic oplog/replication system for REST APIs
 * [pubsub](https://github.com/tuxychandru/pubsub) - A simple pubsub package for go.


### PR DESCRIPTION
Here is my application for inclusion of my websocket framework [melody](https://github.com/olahol/melody) in `awsome-go`:
- godoc.org: https://godoc.org/github.com/olahol/melody
- goreportcard.com: https://goreportcard.com/report/github.com/olahol/melody
- gocover.io: https://gocover.io/github.com/olahol/melody
- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link
- [x] I have added gocover.io link
- [x] I have added goreportcard link
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
