### PR TITLE
Added Skipper to Web Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1065,6 +1065,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [rex](https://github.com/goanywhere/rex) - Rex is a library for modular development built upon gorilla/mux, fully compatible with `net/http`.
 * [sawsij](http://sawsij.com/) - lightweight, open-source web framework for building high-performance, data-driven web applications.
 * [Siesta](https://github.com/VividCortex/siesta) - Composable framework to write middleware and handlers
+* [Skipper](https://github.com/zalando/skipper) - HTTP router that acts as a reverse proxy with support for custom route definitions.
 * [tango](https://github.com/lunny/tango) - Micro & pluggable web framework for Go.
 * [tigertonic](https://github.com/rcrowley/go-tigertonic) - A Go framework for building JSON web services inspired by Dropwizard
 * [traffic](https://github.com/pilu/traffic) - Sinatra inspired regexp/pattern mux and web framework for Go.


### PR DESCRIPTION
Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard) before sending pull request. Thanks!

Please provide package links to:
- godoc.org: https://godoc.org/github.com/zalando/skipper/proxy
- goreportcard.com: https://goreportcard.com/report/github.com/zalando/skipper
- gocover.io: http://gocover.io/github.com/zalando/skipper

Note, that new categories can be added only when there are 3 packages or more.

Make sure that you've checked the boxes below before you submit PR:
- [ X] I have added my package in alphabetical order
- [ X] I know that this package was not listed before
- [ X] I have added godoc link https://godoc.org/github.com/zalando/skipper/proxy

- [X ] I have added gocover.io link

- [X ] I have added goreportcard link
https://goreportcard.com/report/github.com/zalando/skipper

- [X ] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Thanks for your PR, you're awesome! :+1:

Skipper is an HTTP router, built with Go, that acts as a reverse proxy with support for custom route definitions.