### PR TITLE
Add Go WinRM client library and cli tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,7 +648,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [sslb](https://github.com/eduardonunesp/sslb) - It's a Super Simples Load Balancer, just a little project to achieve some kind of performance.
 * [tcp_server](https://github.com/firstrow/tcp_server) - A Go library for building tcp servers faster.
 * [utp](https://github.com/anacrolix/utp) - Go uTP micro transport protocol implementation.
-
+* [winrm](https://github.com/masterzen/winrm) - A Go WinRM client to remotely execute commands on Windows machines
 
 ## OpenGL
 
@@ -1180,7 +1180,7 @@ Software written in Go.
 * [Vegeta] (https://github.com/tsenart/vegeta) - HTTP load testing tool and library. It's over 9000!
 * [webhook](https://github.com/adnanh/webhook) - Tool which allows user to create HTTP endpoints (hooks) that execute commands on the server.
 * [Wide](https://wide.b3log.org/login) - A Web-based IDE for Teams using Golang.
-
+* [winrm-cli](https://github.com/masterzen/winrm-cli) - A cli tool to remotely execute commands on Windows machines
 
 ### Other Software
 * [boxed](https://github.com/tejo/boxed) - Dropbox based blog engine


### PR DESCRIPTION
Hi,

As the masterzen/winrm and masterzen/winrm-cli maintainer, I'd like this library and tool to be added
to the awesome-go list.

This (now mature) library is in used in Packer and some other Go projects.
As of this writing it is maintained, and relatively well tested.

Godoc:
https://godoc.org/github.com/masterzen/winrm

Go Report Card: A+
https://goreportcard.com/report/github.com/masterzen/winrm

Gocover: 86%
https://gocover.io/github.com/masterzen/winrm

- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link
- [x] I have added gocover.io link
- [x] I have added goreportcard link
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
