### PR TITLE
Add go-develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -944,6 +944,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [generate](https://github.com/go-playground/generate) - runs go generate recursively on a specified path or environment variable and can filter by regex.
 * [gentleman](https://github.com/h2non/gentleman) - Full-featured plugin-driven HTTP client library.
 * [go-cron](https://github.com/rk/go-cron) - A simple Cron library for go that can execute closures or functions at varying intervals, from once a second to once a year on a specific date and time. Primarily for web applications and long running daemons.
+* [go-develop](https://github.com/mehcode/go-develop) - Replacement for `go get` for use in development (allows private repositories)
 * [go-debug](https://github.com/tj/go-debug) - Conditional debug logging for Golang libraries & applications.
 * [go-dry](https://github.com/ungerik/go-dry) - DRY (don't repeat yourself) package for Go.
 * [go-rate](https://github.com/beefsack/go-rate) -  A timed rate limiter for Go.


### PR DESCRIPTION
https://github.com/mehcode/go-develop

---
# go-develop

> Wrapper for `go get` to setup a project for development.
## Features
- Uses `git clone` (therefore supports ssh, private repositories, etc.)
- Operates like `git clone` by creating a symlink to the project directory from GOPATH to the current directory
## Usage

Each of the following commands result in an identical project layout in GOPATH.

```
$ go-develop https://github.com/mehcode/go-develop.git
$ go-develop https://github.com/mehcode/go-develop
$ go-develop git@github.com:mehcode/go-develop
$ go-develop git@github.com:mehcode/go-develop.git
$ go-develop ssh://git@github.com/mehcode/go-develop.git
```
