### PR TITLE
Add github.com/mvdan/sh to text processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,6 +867,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
     * [goregen](https://github.com/zach-klippenstein/goregen) - A library for generating random strings from regular expressions.
     * [guesslanguage](https://github.com/endeveit/guesslanguage) - Functions to determine the natural language of a unicode text.
     * [mxj](https://github.com/clbanning/mxj) - Encode / decode XML as JSON or map[string]interface{}; extract values with dot-notation paths and wildcards. Replaces x2j and j2x packages.
+    * [sh](https://github.com/mvdan/sh) - A shell parser and formatter
     * [slug](https://github.com/gosimple/slug) - URL-friendly slugify with multiple languages support.
     * [Slugify](https://github.com/avelino/slugify) - A Go slugify application that handles string.
     * [toml](https://github.com/BurntSushi/toml) - TOML configuration format (encoder/decoder with reflection).


### PR DESCRIPTION
Note that the gocover.io link is broken as I am using `testing.T.Run()` from tip. If you want to know the coverage:

```
ok      github.com/mvdan/sh     0.093s  coverage: 99.8% of statements
?       github.com/mvdan/sh/cmd/shfmt   [no test files]
```

- godoc.org: https://godoc.org/github.com/mvdan/sh
- goreportcard.com: https://goreportcard.com/report/github.com/mvdan/sh
- gocover.io: https://gocover.io/github.com/mvdan/sh