### PR TITLE
Updated `graphql-go` package new repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 * [graphql](https://github.com/tmc/graphql) - graphql parser + utilities.
 * [graphql](https://github.com/sevki/graphql) - GraphQL implementation in go.
-* [graphql-go](https://github.com/chris-ramon/graphql-go) - An implementation of GraphQL for Go.
+* [graphql-go](https://github.com/graphql-go/graphql) - An implementation of GraphQL for Go.
 * [jsonql](https://github.com/elgs/jsonql) - JSON query expression library in Golang.
 
 


### PR DESCRIPTION
Previously https://github.com/chris-ramon/graphql-go, now https://github.com/graphql-go/graphql