### PR TITLE
Add form url.Values to struct decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [bind](https://github.com/robfig/bind)  - Bind form data to any Go values
 * [binding](https://github.com/mholt/binding) - Binds form and JSON data from net/http Request to struct.
 * [conform](https://github.com/leebenson/conform) - Keeps user input in check. Trims, sanitizes & scrubs data based on struct tags.
+* [form](https://github.com/go-playground/form) - decodes url.Values into struct, creating objects as necessary. Dual Array and Full map support.
 * [formam](https://github.com/monoculum/formam) - decode form's values into a struct.
 * [forms](https://github.com/albrow/forms) - A framework-agnostic library for parsing and validating form/JSON data which supports multipart forms and files.
 * [gorilla/csrf](https://github.com/gorilla/csrf) - CSRF protection for Go web applications & services.


### PR DESCRIPTION
🚂  [form](https://github.com/go-playground/form) - decodes url.Values into struct, creating objects as necessary. Dual Array and Full map support.

- [![GoDoc](https://godoc.org/github.com/go-playground/form?status.svg)](https://godoc.org/github.com/go-playground/form)
- [![Go Report Card](https://goreportcard.com/badge/github.com/go-playground/form)](https://goreportcard.com/report/github.com/go-playground/form)
- [![Coverage Status](https://coveralls.io/repos/github/go-playground/form/badge.svg?branch=master)](https://coveralls.io/github/go-playground/form?branch=master)
- [gocover.io](https://gocover.io/github.com/go-playground/form)


- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link
- [x] I have added gocover.io link
- [x] I have added goreportcard link
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).