### PR TITLE
add gron package -- Cron Jobs in Go.

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,6 +972,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [gorequest](https://github.com/parnurzeal/gorequest) - Simplified HTTP client with rich features for Go.
 * [gotenv](https://github.com/subosito/gotenv) - Load environment variables from `.env` or any `io.Reader` in Go
 * [grequests](https://github.com/levigross/grequests) - An elegant and simple `net/http` wrapper that follows Python's requests library
+* [gron](https://github.com/roylee0704/gron) - Define time-based tasks using a simple Go API and Gron’s scheduler will run them accordingly.
 * [htcat](https://github.com/htcat/htcat) - Parallel and Pipelined HTTP GET Utility
 * [httpcontrol](https://github.com/facebookgo/httpcontrol) - Package httpcontrol allows for HTTP transport level control around timeouts and retries.
 * [hystrix-go](https://github.com/afex/hystrix-go) - Implements Hystrix patterns of programmer-defined fallbacks aka circuit breaker.


### PR DESCRIPTION
Package links:

github.com:

https://github.com/roylee0704/gron

godoc.org:

https://godoc.org/github.com/roylee0704/gron

goreportcard.com:

https://goreportcard.com/report/github.com/roylee0704/gron

gocover.io:

https://gocover.io/github.com/roylee0704/gron
