### PR TITLE
Add httpexpect

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,6 +832,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
     * [GoSpec](https://github.com/orfjackal/gospec) - BDD-style testing framework for the Go programming language.
     * [gospecify](https://github.com/stesla/gospecify) - This provides a BDD syntax for testing your Go code. It should be familiar to anybody who has used libraries such as rspec.
     * [Hamcrest](https://github.com/rdrdr/hamcrest) - fluent framework for declarative Matcher objects that, when applied to input values, produce self-describing results.
+    * [httpexpect](https://github.com/gavv/httpexpect) - Concise, declarative, and easy to use end-to-end HTTP and REST API testing
     * [restit](https://github.com/yookoala/restit) - A Go micro framework to help writing RESTful API integration test.
     * [testfixtures](https://github.com/go-testfixtures/testfixtures) - A helper for Rails' like test fixtures to test database applications.
     * [Testify](https://github.com/stretchr/testify) - A sacred extension to the standard go testing package.


### PR DESCRIPTION
Hi, this PR adds [httpexpect](https://github.com/gavv/httpexpect) package.

- godoc.org: https://godoc.org/github.com/gavv/httpexpect
- goreportcard.com: https://goreportcard.com/report/github.com/gavv/httpexpect
- gocover.io or coveralls: https://coveralls.io/github/gavv/httpexpect?branch=master

Boxes:
- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added gocover.io or coveralls link to the repo and to my pull request
- [ ] I have added goreportcard link to the repo
- [x] I have added goreportcard link to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

