### PR TITLE
Remove aac/h264 package because of 404.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1035,7 +1035,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 *Libraries for manipulating video.*
 
-* [aac/h264](https://github.com/nareix/codec) - Golang aac/h264 encoder and decoder.
 * [gmf](https://github.com/3d0c/gmf) - Go bindings for FFmpeg av\* libraries.
 * [goav](https://github.com/giorgisio/goav) - Comphrensive Go bindings for FFmpeg.
 * [gst](https://github.com/ziutek/gst) - Go bindings for GStreamer.


### PR DESCRIPTION
Resolves #1016.

As I mentioned there, @nareix, please let us know if the package has moved and is still deserving to be listed here, then we can update the link and close this PR.

According to https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#reporting-issues, we should wait 1 week.

I'm not sure if that applies if the entire repo is missing and the link is 404. Any thoughts?