### PR TITLE
Added Apache Thrift to Networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 *Libraries for working with various layers of the network*
 
+* [Apache Thrift](https://github.com/apache/thrift) - Efficient cross-language IPC/RPC, works between Go, C++, Java, Python, PHP, C#, and many more other languages. Originally developed by Facebook.
 * [arp](https://github.com/mdlayher/arp) - Package arp implements the ARP protocol, as described in RFC 826.
 * [buffstreams](https://github.com/stabbycutyou/buffstreams) - Streaming protocolbuffer data over TCP made easy
 * [canopus](https://github.com/zubairhamed/canopus) - CoAP Client/Server implementation (RFC 7252)


### PR DESCRIPTION
**Apache Thrift**
[https://godoc.org/github.com/apache/thrift/lib/go/thrift](https://godoc.org/github.com/apache/thrift/lib/go/thrift)
[https://goreportcard.com/report/github.com/apache/thrift](https://goreportcard.com/report/github.com/apache/thrift)
gocover.io is not working.