### PR TITLE
Adding Boxfuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1187,6 +1187,7 @@ Software written in Go.
 * [Banshee](https://github.com/eleme/banshee) - Anomalies detection system for periodic metrics.
 * [Boom](https://github.com/rakyll/boom) - Boom is a tiny program that sends some load to a web application.
 * [bosun](https://github.com/bosun-monitor/bosun) - Time Series Alerting Framework.
+* [Boxfuse](https://boxfuse.com) - Boxfuse is a tool based on immutable infrastructure, minimal images and blue/green deployments for deploying Go applications to AWS and provisioning all necessary infrastructure with a single command.
 * [dogo](https://github.com/liudng/dogo) - Monitoring changes in the source file and automatically compile and run (restart).
 * [Dropship](https://github.com/chrismckenzie/dropship) - A tool for deploying code via cdn.
 * [EasySSH](https://github.com/hypersleep/easyssh) - Golang package for easy remote execution through SSH and SCP downloading.


### PR DESCRIPTION
Package links:
- github.com repo: N/A
- godoc.org: N/A
- goreportcard.com: N/A
- coverage service link (gocover, coveralls etc.): N/A

Quality checks:
- [X] I have added my package in alphabetical order
- [X] I know that this package was not listed before
- [ ] I have added godoc link to the repo and to my pull request
- [ ] I have added coverage service link to the repo and to my pull request
- [ ] I have added goreportcard link to the repo and to my pull request
- [X] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Those 3 boxes were left unchecked as Boxfuse is not written in Go and the sources are not publicly available. It does however have deep integration for Go applications.
