### PR TITLE
Add crufter/borg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1254,6 +1254,7 @@ Software written in Go.
 * [winrm-cli](https://github.com/masterzen/winrm-cli) - A cli tool to remotely execute commands on Windows machines
 
 ### Other Software
+* [borg](https://github.com/crufter/borg) - A terminal based search engine for bash snippets
 * [boxed](https://github.com/tejo/boxed) - Dropbox based blog engine
 * [Cherry](https://github.com/rafael-santiago/cherry) - A tiny webchat server in Go.
 * [Circuit](https://github.com/gocircuit/circuit) - Circuit is a programmable platform-as-a-service (PaaS) and/or Infrastructure-as-a-Service (IaaS), for management, discovery, synchronization and orchestration of services and hosts comprising cloud applications.


### PR DESCRIPTION
- github.com repo: https://github.com/crufter/borg
- godoc.org: https://godoc.org/github.com/crufter/borg
- goreportcard.com: https://goreportcard.com/report/github.com/crufter/borg
- coverage service link (gocover, coveralls etc.): 

- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [ ] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Gocover is down at the moment so I can't check


