### PR TITLE
Remove iris from listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1127,7 +1127,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [Gorilla](https://github.com/gorilla/) - Gorilla is a web toolkit for the Go programming language.
 * [httprouter](https://github.com/julienschmidt/httprouter) - A high performance router. Use this and the standard http handlers to form a very high performance web framework.
 * [httptreemux](https://github.com/dimfeld/httptreemux) - High-speed, flexible tree-based HTTP router for Go. Inspiration from httprouter.
-* [Iris](https://github.com/kataras/iris) - A very minimal but flexible and high-performance golang web application framework, providing a robust set of features for building web applications.
 * [lars](https://github.com/go-playground/lars) - Is a lightweight, fast and extensible zero allocation HTTP router for Go used to create customizable frameworks.
 * [Macaron](https://github.com/go-macaron/macaron) - Macaron is a high productive and modular design web framework in Go.
 * [mango](https://github.com/paulbellamy/mango) - Mango is a modular web-application framework for Go, inspired by Rack, and PEP333.


### PR DESCRIPTION
Based on previous issues such as [1] and [2] as well as still not accepting
open-source contributions, flattening contributions, closing PRs from users,
editing issues, breaking changes very often and overall poor leadership of
the project this PR removes the iris as a project from this listing.

Thank you.

[1] https://github.com/julienschmidt/httprouter/issues/148
[2] https://github.com/julienschmidt/httprouter/issues/160