### PR TITLE
Add GoshawkDB under databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [geocache](https://github.com/melihmucuk/geocache) - An in-memory cache that is suitable for geolocation based applications.
 * [go-cache](https://github.com/pmylund/go-cache) - An in-memory key:value store/cache (similar to Memcached) library for Go, suitable for single-machine applications.
 * [goleveldb](https://github.com/syndtr/goleveldb) - An implementation of the [LevelDB](https://github.com/google/leveldb) key/value database in the Go.
+* [GoshawkDB](https://github.com/goshawkdb/server) - A distributed, transactional, fault-tolerant object store
 * [groupcache](https://github.com/golang/groupcache) - Groupcache is a caching and cache-filling library, intended as a replacement for memcached in many cases.
 * [influxdb](https://github.com/influxdb/influxdb) - Scalable datastore for metrics, events, and real-time analytics
 * [ledisdb](https://github.com/siddontang/ledisdb) - Ledisdb is a high performance NoSQL like Redis based on LevelDB.


### PR DESCRIPTION
- github.com repo:
Server is at: https://github.com/goshawkdb/server
Go Client is at: https://github.com/goshawkdb/client
- godoc.org:
It's only the client which is properly documented: https://godoc.org/github.com/goshawkdb/client
- goreportcard.com: 
Server: https://goreportcard.com/report/github.com/goshawkdb/server
Client https://goreportcard.com/report/github.com/goshawkdb/client
- coverage service link (gocover, coveralls etc.): 
Don't use these; I do have mechanisms to measure coverage of e2e tests / soak tests. It's a bit involved because of the client/server nature.

In general, I use github as a mirror/backup only; all the docs are on the website at goshawkdb.io. For example https://goshawkdb.io/documentation/client-go.html for the Go client.
