### PR TITLE
Add gomol to logging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [go-log](https://github.com/ian-kent/go-log) - A log4j implementation in Go.
 * [go-logger](https://github.com/apsdehal/go-logger) - Simple logger of Go Programs, with level handlers.
 * [gologger](https://github.com/sadlil/gologger) - Simple easy to use log lib for go, logs in Colored Cosole, Simple Console, File or Elasticsearch.
+* [gomol](https://github.com/aphistic/gomol) - Multiple-output, structured logging for Go with extensible logging outputs.
 * [gone/log](https://github.com/One-com/gone/tree/master/log#readme) - Fast, extendable, full-featured, std-lib source compatible log library.
 * [log](https://github.com/apex/log) - Structured logging package for Go.
 * [log](https://github.com/go-playground/log) - Simple, configurable and scalable Structured Logging for Go.


### PR DESCRIPTION
**Please provide package links to:**
- github.com repo: https://github.com/aphistic/gomol
- godoc.org: https://godoc.org/github.com/aphistic/gomol
- goreportcard.com: https://goreportcard.com/report/github.com/aphistic/gomol
- coverage service link (gocover, coveralls etc.): https://codecov.io/github/aphistic/gomol?branch=master

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

**Question**: I've only included gomol in this PR but I noticed there's a logrus plugin for Loggly added, does that mean for logging libraries that are extensible that the implementations for those libraries can be added to the list as well? gomol has a number of loggers it supports that are in separate repositories, so that's why I was wondering.  I do make a note of them in the readme, though, so they're still discoverable either way.
