### PR TITLE
Adding RichardKnop/go-oauth2-server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [authboss](https://github.com/go-authboss/authboss) - A modular authentication system for the web. It tries to remove as much boilerplate and "hard things" as possible so that each time you start a new web project in Go, you can plug it in, configure, and start building your app without having to build an authentication system each time.
 * [Go-AWS-Auth](https://github.com/smartystreets/go-aws-auth) - AWS (Amazon Web Services) request signing library.
 * [go-jose](https://github.com/square/go-jose) - A fairly complete implementation of the JOSE working group's JSON Web Token, JSON Web Signatures, and JSON Web Encryption specs.
+* [go-oauth2-server](https://github.com/RichardKnop/go-oauth2-server) - A standalone, specification-compliant,  OAuth2 server written in Golang.
 * [go.auth](https://github.com/bradrydzewski/go.auth) - Authentication API for Go web applications.
 * [gologin](https://github.com/dghubble/gologin) - chainable handlers for login with OAuth1 and OAuth2 authentication providers.
 * [gorbac](https://github.com/mikespook/gorbac) - provides a lightweight role-based access control (RBAC) implementation in Golang.


### PR DESCRIPTION
Hi,

This pull request adds [go-oauth2-server](https://github.com/RichardKnop/go-oauth2-server) to the Authentication & Oauth section.

It is a full and standalone OAuth2 server based on the [specification](http://tools.ietf.org/html/rfc6749#section-4.3).

As far as I know, it is the fullest server implementation of the spec (including all 4 grant types and introspect endpoint).

It is also used in production and very well tested.

- github.com repo: https://github.com/RichardKnop/go-oauth2-server
- godoc.org: https://godoc.org/github.com/RichardKnop/go-oauth2-server
- goreportcard.com: 
- coverage service link (gocover, coveralls etc.): 
- travis CI link: https://travis-ci.org/RichardKnop/go-oauth2-server

- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [ ] I have added coverage service link to the repo and to my pull request
- [ ] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

