### PR TITLE
Add utron web framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1154,6 +1154,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [tango](https://github.com/lunny/tango) - Micro & pluggable web framework for Go.
 * [tigertonic](https://github.com/rcrowley/go-tigertonic) - A Go framework for building JSON web services inspired by Dropwizard
 * [traffic](https://github.com/pilu/traffic) - Sinatra inspired regexp/pattern mux and web framework for Go.
+* [utron](https://github.com/gernest/utron) - A lightweight MVC framework for Go(Golang).
 * [VarHandler](https://github.com/azr/generators/tree/master/varhandler) - Generate boilerplate http input and ouput handling.
 * [vestigo](https://github.com/husobee/vestigo) -  A performant, stand-alone, HTTP compliant URL Router for go web applications.
 * [Volatile](https://github.com/volatile/core) - Minimalist middleware stack promoting flexibility, good practices and clean code.


### PR DESCRIPTION
Hi,

IThis adds [utron](https://github.com/gernest/utron)  a web framework. 

**Please provide package links to:**
- github.com repo: https://github.com/gernest/utron
- godoc.org: https://godoc.org/github.com/gernest/utron
- goreportcard.com: https://goreportcard.com/report/github.com/gernest/utron
- coverage service link (gocover, coveralls etc.): https://coveralls.io/github/gernest/utron?branch=master


**Note**: that new categories can be added only when there are 3 packages or more.

**Make sure that you've checked the boxes below before you submit PR:**
- [x ] I have added my package in alphabetical order
- [x ] I know that this package was not listed before
- [x ] I have added godoc link to the repo and to my pull request
- [x ] I have added coverage service link to the repo and to my pull request
- [x ] I have added goreportcard link to the repo and to my pull request
- [ ] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Thanks for your PR, you're awesome! :+1:

This adds utron MVC framework on the web frameworks section