### PR TITLE
Remove httpware (no longer relevant after go 1.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1193,7 +1193,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [chain](https://github.com/codemodus/chain) - Handler wrapper chaining with scoped data (net/context-based "middleware").
 * [go-wrap](https://github.com/go-on/wrap) - Small middlewares package for net/http.
 * [gores](https://github.com/alioygur/gores) - Go package that handles HTML, JSON, XML and etc. responses. Useful for RESTful APIs.
-* [httpware](https://github.com/nstogner/httpware) - Stackable middleware (using net/context) with easy chaining.
 * [interpose](https://github.com/carbocation/interpose) - Minimalist net/http middleware for golang.
 * [muxchain](https://github.com/stephens2424/muxchain) - Lightweight middleware for net/http.
 * [negroni](https://github.com/codegangsta/negroni) - Idiomatic HTTP middleware for Golang.


### PR DESCRIPTION
Author of httpware here: go 1.7 introduced the net/context pkg into the http pkg... making the "httpware" unnecessary. 