### PR TITLE
Add amazon-product-advertising-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,6 +955,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 *Libraries for accessing third party APIs.*
 
+* [amazon-product-advertising-api](https://github.com/ngs/go-amazon-product-advertising-api) - Go Client Library for [Amazon Product Advertising API](https://affiliate-program.amazon.com/gp/advertising/api/detail/main.html)
 * [anaconda](https://github.com/ChimeraCoder/anaconda) - A Go client library for the Twitter 1.1 API
 * [aws-sdk-go](https://github.com/aws/aws-sdk-go) - The official AWS SDK for the Go programming language.
 * [brewerydb](https://github.com/naegelejd/brewerydb) - Go library for accessing the BreweryDB API.


### PR DESCRIPTION
- github.com repo: https://github.com/ngs/go-amazon-product-advertising-api
- godoc.org: https://godoc.org/github.com/ngs/go-amazon-product-advertising-api/amazon
- goreportcard.com: https://goreportcard.com/report/github.com/ngs/go-amazon-product-advertising-api
- coverage service link (gocover, coveralls etc.): https://coveralls.io/github/ngs/go-amazon-product-advertising-api?branch=master

- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).