### PR TITLE
Update test to 1.7 and display correct sorting order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.4
+  - 1.7
   
 sudo: false
 

--- a/repo_test.go
+++ b/repo_test.go
@@ -25,16 +25,18 @@ func TestDuplicatedLinks(t *testing.T) {
 	links := make(map[string]bool, 0)
 
 	query.Find("body  a").Each(func(_ int, s *goquery.Selection) {
-		href, ok := s.Attr("href")
-		if !ok {
-			t.Errorf("expected '%s' to have href", s.Text())
-		}
+		t.Run(fmt.Sprintf("%s", s.Text()), func(t *testing.T) {
+			href, ok := s.Attr("href")
+			if !ok {
+				t.Error("expected to have href")
+			}
 
-		if links[href] {
-			t.Fatalf("duplicated link '%s'", href)
-		}
+			if links[href] {
+				t.Fatalf("duplicated link '%s'", href)
+			}
 
-		links[href] = true
+			links[href] = true
+		})
 	})
 }
 

--- a/repo_test.go
+++ b/repo_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"sort"
 	"strings"
@@ -25,7 +24,7 @@ func TestDuplicatedLinks(t *testing.T) {
 	links := make(map[string]bool, 0)
 
 	query.Find("body  a").Each(func(_ int, s *goquery.Selection) {
-		t.Run(fmt.Sprintf("%s", s.Text()), func(t *testing.T) {
+		t.Run(s.Text(), func(t *testing.T) {
 			href, ok := s.Attr("href")
 			if !ok {
 				t.Error("expected to have href")

--- a/repo_test.go
+++ b/repo_test.go
@@ -46,9 +46,9 @@ func testList(t *testing.T, list *goquery.Selection) {
 		items.RemoveFiltered("ul")
 	})
 
-	cat := list.Prev().Text()
+	category := list.Prev().Text()
 
-	t.Run(fmt.Sprintf("order of [%s]", cat), func(t *testing.T) {
+	t.Run(category, func(t *testing.T) {
 		checkAlphabeticOrder(t, list)
 	})
 }


### PR DESCRIPTION
Per discussion in #1217 updating the test to latest stable and adding a log for correct sorting order if a fail occurs.