### PR TITLE
Added github.com/udhos/jazigo

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [gotcp](https://github.com/gansidui/gotcp) - A Go package for quickly writing tcp applications
 * [grab](https://github.com/cavaliercoder/grab) - Go package for managing file downloads
 * [graval](https://github.com/koofr/graval) - An experimental FTP server framework.
+* [jazigo](https://github.com/udhos/jazigo) - Jazigo is a tool written in Go for retrieving configuration for multiple network devices.
 * [kcp-go](https://github.com/xtaci/kcp-go) - KCP - A Fast and Reliable ARQ Protocol.
 * [kcptun](https://github.com/xtaci/kcptun) - An extremely simple & fast udp tunnel based on KCP protocol
 * [lhttp](https://github.com/fanux/lhttp) - A powerful websocket framework, build your IM server more easily.


### PR DESCRIPTION
- github.com repo: https://github.com/udhos/jazigo
- godoc.org: https://godoc.org/github.com/udhos/jazigo/jazigo
- goreportcard.com: https://goreportcard.com/report/github.com/udhos/jazigo
- coverage service link (gocover, coveralls etc.): http://gocover.io/github.com/udhos/jazigo/dev
