### PR TITLE
Add application of Line notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 * [Centrifugo](https://github.com/centrifugal/centrifugo) - Real-time messaging (Websockets or SockJS) server in Go.
 * [dbus](https://github.com/godbus/dbus) - Native Go bindings for D-Bus.
+* [drone-line](https://github.com/appleboy/drone-line) - Sending [Line](https://business.line.me/en/services/bot) notifications using a binary, docker or Drone CI.
 * [emitter](https://github.com/olebedev/emitter) - Emits events using Go way, with wildcard, predicates, cancellation possibilities and many other good wins.
 * [EventBus](https://github.com/asaskevich/EventBus) - The lightweight event bus with async compatibility.
 * [go-longpoll](https://github.com/ventu-io/go-longpoll) - PubSub with long polling.


### PR DESCRIPTION
- github.com repo: https://github.com/appleboy/drone-line
- godoc.org: https://godoc.org/github.com/appleboy/drone-line
- goreportcard.com: https://goreportcard.com/report/github.com/appleboy/drone-line
- coverage service link (gocover, coveralls etc.): https://codecov.io/gh/appleboy/drone-line

- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Please refer to [LINE Business Center](https://business.line.me/en/services/bot).

