### PR TITLE
Add drone-scp tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1289,6 +1289,7 @@ Software written in Go.
 * [Banshee](https://github.com/eleme/banshee) - Anomalies detection system for periodic metrics.
 * [bosun](https://github.com/bosun-monitor/bosun) - Time Series Alerting Framework.
 * [dogo](https://github.com/liudng/dogo) - Monitoring changes in the source file and automatically compile and run (restart).
+* [drone-scp](https://github.com/appleboy/drone-scp) - Copy files and artifacts via SSH using a binary, docker or Drone CI.
 * [Dropship](https://github.com/chrismckenzie/dropship) - A tool for deploying code via cdn.
 * [EasySSH](https://github.com/hypersleep/easyssh) - Golang package for easy remote execution through SSH and SCP downloading.
 * [Gitea](https://github.com/go-gitea/gitea) - A fork of Gogs, entirely community driven.


### PR DESCRIPTION
Copy files and artifacts via SSH using a binary, docker or Drone CI.

- github.com repo: https://github.com/appleboy/drone-scp
- godoc.org: https://godoc.org/github.com/appleboy/drone-scp 
- goreportcard.com: https://goreportcard.com/report/github.com/appleboy/drone-scp
- coverage service link: [![codecov](https://codecov.io/gh/appleboy/drone-scp/branch/master/graph/badge.svg)](https://codecov.io/gh/appleboy/drone-scp)

