### PR TITLE
Add "go-callvis" program to Go Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1272,6 +1272,7 @@ Go software and plugins.
 
 * [colorgo](https://github.com/songgao/colorgo) - A wrapper around `go` command for colorized `go build` output.
 * [gb](https://getgb.io/) - An easy to use project based build tool for the Go programming language.
+* [go-callvis](https://github.com/TrueFurby/go-callvis) - Visualize call graph of your Go program using dot format.
 * [go-pkg-complete](https://github.com/skelterjohn/go-pkg-complete) - Bash completion for go and wgo.
 * [go-swagger](https://github.com/go-swagger/go-swagger) - Swagger 2.0 implementation for go. Swagger is a simple yet powerful representation of your RESTful API.
 * [rts](https://github.com/galeone/rts) - RTS: response to struct. Generates Go structs from server responses.


### PR DESCRIPTION
Site | Link
---- | ----
github.com | https://github.com/TrueFurby/go-callvis
godoc.org | https://godoc.org/github.com/TrueFurby/go-callvis
goreportcard.com | https://goreportcard.com/report/github.com/TrueFurby/go-callvis
gocover.io | https://gocover.io/github.com/TrueFurby/go-callvis

✅ I have added my package in alphabetical order
✅ I know that this package was not listed before
✅ I have added godoc link to the repo and to my pull request
✅ I have added coverage service link to the repo and to my pull request
✅ I have added goreportcard link to the repo and to my pull request
✅ I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).