### PR TITLE
Add staticcheck, gosimple, unused code analysis tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1264,9 +1264,12 @@ Go software and plugins.
 * [GoLint](https://github.com/golang/lint) - Golint is a linter for Go source code.
 * [Golint online](http://go-lint.appspot.com/) - Lints online Go source files on GitHub, Bitbucket and Google Project Hosting using the golint package.
 * [goreturns](https://sourcegraph.com/github.com/sqs/goreturns) - Adds zero-value return statements to match the func return types.
+* [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple) - gosimple is a linter for Go source code that specialises on simplifying code.
 * [gostatus](https://github.com/shurcooL/gostatus) - A command line tool, shows the status of repositories that contain Go packages.
 * [interfacer](https://github.com/mvdan/interfacer) - A linter that suggests interface types.
 * [lint](https://github.com/surullabs/lint) - Run linters as part of go test
+* [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) - staticcheck is `go vet` on steroids, applying a ton of static analysis checks you might be used to from tools like ReSharper for C#.
+* [unused](https://github.com/dominikh/go-tools/tree/master/cmd/unused) - unused checks Go code for unused constants, variables, functions and types.
 * [validate](https://github.com/mccoyst/validate) - Automatically validates struct fields with tags.
 
 


### PR DESCRIPTION
_staticcheck_ is go vet on steroids, applying a ton of static analysis checks you might be used to from tools like ReSharper for C#.

_gosimple_ is a linter for Go source code that specialises on simplifying code.

_unused_ checks Go code for unused constants, variables, functions and types.

github.com: https://github.com/dominikh/go-tools
godoc.org: https://godoc.org/honnef.co/go/tools/cmd
goreportcard.com: https://goreportcard.com/report/github.com/dominikh/go-tools
coverage service: https://gocover.io/github.com/dominikh/go-tools (fails with "Cannot get 'github.com/dominikh/go-tools'" error for some reason)

- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).