### PR TITLE
Add unconvert tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1270,6 +1270,7 @@ Go software and plugins.
 * [interfacer](https://github.com/mvdan/interfacer) - A linter that suggests interface types.
 * [lint](https://github.com/surullabs/lint) - Run linters as part of go test
 * [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) - staticcheck is `go vet` on steroids, applying a ton of static analysis checks you might be used to from tools like ReSharper for C#.
+* [unconvert](https://github.com/mdempsky/unconvert) - Remove unnecessary type conversions from Go source.
 * [unused](https://github.com/dominikh/go-tools/tree/master/cmd/unused) - unused checks Go code for unused constants, variables, functions and types.
 * [validate](https://github.com/mccoyst/validate) - Automatically validates struct fields with tags.
 


### PR DESCRIPTION
The unconvert program analyzes Go packages to identify unnecessary type conversions; i.e., expressions `T(x)` where `x` already has type `T`.

/cc @mdempsky

github.com repo: https://github.com/mdempsky/unconvert
godoc.org: https://godoc.org/github.com/mdempsky/unconvert
goreportcard.com: https://goreportcard.com/report/github.com/mdempsky/unconvert
coverage service link (gocover, coveralls etc.): https://gocover.io/github.com/mdempsky/unconvert

- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).