### PR TITLE
Add OctoLinker browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1299,6 +1299,7 @@ Go software and plugins.
 * [go-callvis](https://github.com/TrueFurby/go-callvis) - Visualize call graph of your Go program using dot format.
 * [go-pkg-complete](https://github.com/skelterjohn/go-pkg-complete) - Bash completion for go and wgo.
 * [go-swagger](https://github.com/go-swagger/go-swagger) - Swagger 2.0 implementation for go. Swagger is a simple yet powerful representation of your RESTful API.
+* [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through go files efficiently with the OctoLinker browser extension for GitHub.
 * [rts](https://github.com/galeone/rts) - RTS: response to struct. Generates Go structs from server responses.
 
 ## Software Packages


### PR DESCRIPTION
[github.com/OctoLinker/browser-extension](https://github.com/OctoLinker/browser-extension)

Navigate through projects on GitHub.com efficiently with the OctoLinker browser extension.

Most projects consist of many files and third party dependencies. Files are referencing other files and / or dependencies by language specific statements like `import` or `require`. OctoLinker makes these references clickable. No more copy and search.

## Demo

![](https://cloud.githubusercontent.com/assets/1393946/22442194/c4342b9a-e73a-11e6-8474-ef234978ca99.gif)

### Core library imports

A standard library import like `import "math/big"` will reference to `https://golang.org/pkg/math/big`.

### Relative imports

An import path beginning with `./` or `../` is treated as a relative path. OctoLinker tries to resolve the path and redirects you to the linked resource.

### Remote imports

Last but not least, OctoLinker also supports hosting sites. For example `import "github.com/foo/bar"` will reference to `https://github.com/foo/bar`. The following hosting sites are supported:

- github.com
- bitbucket.org
- launchpad.net
- hub.jazz.net
- gopkg.in

**Note, other remote import path like `company.com/foo/bar` aren't supported yet.** If you want to get this implemented vote on the related issue https://github.com/OctoLinker/browser-extension/issues/264.