### PR TITLE
Add goConfig in the Configuration category

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [envconf](https://github.com/ian-kent/envconf) - Configuration from environment
 * [envconfig](https://github.com/vrischmann/envconfig) - Read your configuration from environment variables.
 * [gcfg](https://github.com/go-gcfg/gcfg) - read INI-style configuration files into Go structs; supports user-defined types and subsections
+* [goConfig](https://github.com/crgimenes/goConfig) - Parse a struct as input and populates the fields of this struct with parameters fom command line, environment variables and configuration file.
 * [gofigure](https://github.com/ian-kent/gofigure) - Go application configuration made easy
 * [hjson](https://github.com/hjson/hjson-go) - Human JSON, a configuration file format for humans. Relaxed syntax, fewer mistakes, more comments.
 * [ingo](https://github.com/schachmat/ingo) - Flags persisted in an ini-like config file


### PR DESCRIPTION
github.com repo: https://github.com/crgimenes/goConfig

godoc.org: https://godoc.org/github.com/crgimenes/goConfig

goreportcard.com: https://goreportcard.com/report/github.com/crgimenes/goConfig

coverage service link (gocover, coveralls etc.): https://codecov.io/gh/crgimenes/goConfig
