### PR TITLE
Updating README.md with link to chromedp

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,7 +952,8 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
     * [gofuzz](https://github.com/google/gofuzz) - A library for populating go objects with random values
     * [Tavor](https://github.com/zimmski/tavor) - A generic fuzzing and delta-debugging framework
 
-* Selenium tools
+* Selenium and browser control tools
+    * [chromedp](https://github.com/knq/chromedp) - a way to drive/test Chrome, Safari, Edge, Android Webviews, and other browsers supporting the Chrome Debugging Protocol.
     * [ggr](https://github.com/aandryashin/ggr) - a lightweight server that routes and proxies Selenium Wedriver requests to multiple Selenium hubs.
     * [selenoid](https://github.com/aandryashin/selenoid) - alternative Selenium hub server that launches browsers within containers.
 


### PR DESCRIPTION
Request to add https://github.com/knq/chromedp

While chromedp still doesn't have > 80% coverage, we are on track to finish the unit tests for those within the next couple weeks. The coverage that has yet to remaining are trivial lines such as testing all the various `if err != nil { ... }` blocks, as well as specific library / package functional options that only configure/set various system settings that are extremely difficult to generate error conditions for, as well as to do testing on.

**Please provide package links to:**
- github.com repo:  https://github.com/knq/chromedp/
- godoc.org: https://godoc.org/github.com/knq/chromedp
- goreportcard.com: https://goreportcard.com/report/github.com/knq/chromedp
- coverage service link (gocover, coveralls etc.): https://coveralls.io/github/knq/chromedp


**Note**: that new categories can be added only when there are 3 packages or more.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
