### PR TITLE
Adds go-vcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,6 +985,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
     * [go-pkg-xmlx](https://github.com/jteeuwen/go-pkg-xmlx) - Extension to the standard Go XML package. Maintains a node tree that allows forward/backwards browsing and exposes some simple single/multi-node search functions.
     * [go-runewidth](https://github.com/mattn/go-runewidth) - Functions to get fixed width of the character or string.
     * [go-slugify](https://github.com/mozillazg/go-slugify) - Make pretty slug with multiple languages support.
+    * [go-vcard](https://github.com/emersion/go-vcard) - Parse and format vCard
     * [gofeed](https://github.com/mmcdole/gofeed) - Parse RSS and Atom feeds in Go
     * [gographviz](https://github.com/awalterschulze/gographviz) - Parses the Graphviz DOT language.
     * [gommon/bytes](https://github.com/labstack/gommon/tree/master/bytes) - Format bytes to string.


### PR DESCRIPTION
- github.com repo: https://github.com/emersion/go-vcard
- godoc.org: https://godoc.org/github.com/emersion/go-vcard
- goreportcard.com: https://goreportcard.com/report/github.com/emersion/go-vcard
- coverage service link (gocover, coveralls etc.): https://codecov.io/gh/emersion/go-vcard