### PR TITLE
Add cdp to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
     * [Tavor](https://github.com/zimmski/tavor) - A generic fuzzing and delta-debugging framework
 
 * Selenium and browser control tools
+    * [cdp](https://github.com/mafredri/cdp) - Type-safe bindings for the Chrome Debugging Protocol that can be used with browsers or other debug targets that implement it.
     * [chromedp](https://github.com/knq/chromedp) - a way to drive/test Chrome, Safari, Edge, Android Webviews, and other browsers supporting the Chrome Debugging Protocol.
     * [ggr](https://github.com/aandryashin/ggr) - a lightweight server that routes and proxies Selenium Wedriver requests to multiple Selenium hubs.
     * [selenoid](https://github.com/aandryashin/selenoid) - alternative Selenium hub server that launches browsers within containers.


### PR DESCRIPTION
I would love it if you would consider `cdp` for `awesome-go`! The project contains a lot of generated code, but I've managed to get the coverage up to ~90% by generating tests as well.

**Please provide package links to:**
- github.com repo: https://github.com/mafredri/cdp
- godoc.org: https://godoc.org/github.com/mafredri/cdp
- goreportcard.com: https://goreportcard.com/report/github.com/mafredri/cdp
- coverage service link (gocover, coveralls etc.): https://coveralls.io/github/mafredri/cdp?branch=master

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).