### PR TITLE
Include vendor to be easy to reproduce tests and examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ If you removed our PR template you can find it [here](https://github.com/avelino
 To be on the list, project repositories should adhere to these quality standards (http://goreportcard.com/report/**github_user**/**github_repo**):
 
 - Code functions as documented and expected
+- Tests and examples should be easy to reproduce
+  - include third-party packages(vendor)
 - Generally useful to the wider community of Go programmers
 - Actively maintained
   - Regular, recent commits


### PR DESCRIPTION
Proposal to include vendor in packages to be easy to reproduce tests and examples. It's a practice large adopted by go community.
