### PR TITLE
add kamilsk/retry package to Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1165,6 +1165,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [rerate](https://github.com/abo/rerate) - Redis-based rate counter and rate limiter for Go.
 * [rerun](https://github.com/ivpusic/rerun) - Recompiling and rerunning go apps when source changes.
 * [resty](https://github.com/go-resty/resty) - Simple HTTP and REST client for Go inspired by Ruby rest-client.
+* [retry](https://github.com/kamilsk/retry) - Functional mechanism based on context to perform actions repetitively until successful.
 * [robustly](https://github.com/VividCortex/robustly) - Runs functions resiliently, catching and restarting panics.
 * [scheduler](https://github.com/carlescere/scheduler) - Cronjobs scheduling made easy.
 * [sling](https://github.com/dghubble/sling) - Go HTTP requests builder for API clients.


### PR DESCRIPTION
Please add `retry` package to Utilities section.

**Please provide package links to:**
- github.com repo: https://github.com/kamilsk/retry
- godoc.org: https://godoc.org/github.com/kamilsk/retry
- goreportcard.com: https://goreportcard.com/report/github.com/kamilsk/retry
- coverage service link (gocover, coveralls etc.): https://coveralls.io/github/kamilsk/retry

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
