### PR TITLE
Fix a word in Ebiten explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 *Awesome game development libraries.*
 
 * [Azul3D](https://github.com/azul3d/engine) - A 3D game engine written in Go
-* [Ebiten](https://github.com/hajimehoshi/ebiten) - A simple SNES-style 2D game library in Go
+* [Ebiten](https://github.com/hajimehoshi/ebiten) - A simple 2D game library in Go
 * [engo](https://github.com/EngoEngine/engo) - Engo is an open-source 2D game engine written in Go. It follows the Entity-Component-System paradigm.
 * [GarageEngine](https://github.com/vova616/GarageEngine) - 2d game engine written in Go working on OpenGL.
 * [glop](https://github.com/runningwild/glop) - Glop (Game Library Of Power) is a fairly simple cross-platform game library.


### PR DESCRIPTION
This omits the word 'SNES-style' from Ebiten explanation.