### PR TITLE
Add githubql package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1086,7 +1086,8 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [gcm](https://github.com/Aorioli/gcm) - Go library for Google Cloud Messaging
 * [geo-golang](https://github.com/codingsince1985/geo-golang) - Go Library to access [Google Maps](https://developers.google.com/maps/documentation/geocoding/intro), [MapQuest](http://open.mapquestapi.com/geocoding/), [Nominatim](http://open.mapquestapi.com/nominatim/), [OpenCage](http://geocoder.opencagedata.com/api.html), [HERE](https://developer.here.com/rest-apis/documentation/geocoder), [Bing](https://msdn.microsoft.com/en-us/library/ff701715.aspx), [Mapbox](https://www.mapbox.com/developers/api/geocoding/), and [OpenStreetMap](https://wiki.openstreetmap.org/wiki/Nominatim) geocoding / reverse geocoding APIs.
 * [ghost](https://github.com/neuegram/ghost) - Go Library for accessing the Snapchat API.
-* [github](https://github.com/google/go-github) - Go library for accessing the GitHub API.
+* [github](https://github.com/google/go-github) - Go library for accessing the GitHub REST API v3.
+* [githubql](https://github.com/shurcooL/githubql) - Go library for accessing the GitHub GraphQL API v4.
 * [go-imgur](https://github.com/koffeinsource/go-imgur) - Go client library for [imgur](https://imgur.com)
 * [go-jira](https://github.com/andygrunwald/go-jira) - Go client library for [Atlassian JIRA](https://www.atlassian.com/software/jira)
 * [go-marathon](https://github.com/gambol99/go-marathon) - A Go library for interacting with Mesosphere's Marathon PAAS.


### PR DESCRIPTION
Package githubql is a client library for accessing GitHub GraphQL API v4 (https://developer.github.com/v4/).

Status: In active early research and development. The API will change when opportunities for improvement are discovered; it is not yet frozen.

[![Build Status](https://travis-ci.org/shurcooL/githubql.svg?branch=master)](https://travis-ci.org/shurcooL/githubql) [![GoDoc](https://godoc.org/github.com/shurcooL/githubql?status.svg)](https://godoc.org/github.com/shurcooL/githubql) [![](https://goreportcard.com/badge/github.com/shurcooL/githubql)](https://goreportcard.com/report/github.com/shurcooL/githubql)

- github.com repo: https://github.com/shurcooL/githubql
- godoc.org: https://godoc.org/github.com/shurcooL/githubql
- goreportcard.com: https://goreportcard.com/report/github.com/shurcooL/githubql
- coverage service: https://gocover.io/github.com/shurcooL/githubql

The coverage score is low, at around 40-50%. This is because so far I only have unit tests. The rest of the code is tested manually via a test program, because it needs to hit a live GitHub API. I can't put that in a test at this time.

The package is very new and in active development. Improving test coverage is on the roadmap, but there is additional higher priority work which will be done first. I think that's a reasonable justification for the current coverage score for this type of package.

---

- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).