### PR TITLE
Add awless, a mighty CLI for AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,6 +1391,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 * [aptly](https://github.com/smira/aptly) - aptly is a Debian repository management tool.
 * [aurora](https://github.com/Luxurioust/aurora) - Cross-platform web-based Beanstalkd queue server console.
+* [awless](https://github.com/wallix/awless) - A Mighty command-line interface for Amazon Web Services (AWS).
 * [awsenv](https://github.com/soniah/awsenv) - a small binary that loads Amazon (AWS) environment variables for a profile.
 * [Banshee](https://github.com/eleme/banshee) - Anomalies detection system for periodic metrics.
 * [bombardier](https://github.com/codesenberg/bombardier) - Fast cross-platform HTTP benchmarking tool.


### PR DESCRIPTION
This pull request propose to add `awless` to `awesome-go`. It has a very good test coverage except for code that is generated (a main part of `awless` code) or code that is directly related to the connection with AWS. Godoc and coverage are not on our repo, as we do not build a library but rather a CLI tool.

- github.com repo: https://github.com/wallix/awless
- godoc.org: https://godoc.org/github.com/wallix/awless/template
- goreportcard.com: https://goreportcard.com/report/github.com/wallix/awless
- coverage service link: ![cover.run go](https://cover.run/go/github.com/wallix/awless/template.svg)

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [ ] I have added godoc link to the repo and to my pull request
- [ ] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Thanks for this repo, you're awesome! :+1:
