### PR TITLE
Added links for gitql and textql

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,12 +839,14 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [VenGO](https://github.com/DamnWidget/VenGO) - create and manage exportable isolated go virtual environments
 
 ## Query Language
-
+* [gitql](https://github.com/cloudson/gitql) - A git query language
 * [graphql](https://github.com/tmc/graphql) - graphql parser + utilities.
 * [graphql](https://github.com/sevki/graphql) - GraphQL implementation in go.
 * [graphql](https://github.com/neelance/graphql-go) - GraphQL server with a focus on ease of use.
 * [graphql-go](https://github.com/graphql-go/graphql) - An implementation of GraphQL for Go.
 * [jsonql](https://github.com/elgs/jsonql) - JSON query expression library in Golang.
+* [textql](https://github.com/dinedal/textql) - Execute SQL against structured text like CSV or TSV
+
 
 ## Resource Embedding
 


### PR DESCRIPTION
## gitql

*REPO* : https://github.com/cloudson/gitql
*GODOC* : http://godoc.org/github.com/cloudson/gitql
*GOREPORTCARD* : https://goreportcard.com/report/github.com/cloudson/gitql
*COVERAGE* : https://cover.run/go/github.com/cloudson/gitql

## textql

*REPO*: https://github.com/dinedal/textql
*GODOC*: http://godoc.org/github.com/dinedal/textql
*GOREPORTCARD*: https://goreportcard.com/report/github.com/dinedal/textql
*COVERAGE* : https://cover.run/go/github.com/dinedal/textql
