### PR TITLE
Add github.com/RichardKnop/jsonhal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1178,6 +1178,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [jsonapi-errors](https://github.com/AmuzaTkts/jsonapi-errors) - Go bindings based on the JSON API errors reference.
 * [jsonf](https://github.com/miolini/jsonf) - Console tool for highlighted formatting and struct query fetching JSON.
 * [jsongo](https://github.com/ricardolonga/jsongo) - Fluent API to make it easier to create Json objects.
+* [jsonhal](https://github.com/RichardKnop/jsonhal) - A simple Go package to make custom structs marshal into HAL compatible JSON responses.
 * [kazaam](https://github.com/Qntfy/kazaam) - API for arbitrary transformation of JSON documents.
 * [lrserver](https://github.com/jaschaephraim/lrserver) - LiveReload server for Go
 * [mc](https://github.com/minio/mc) - Minio Client provides minimal tools to work with Amazon S3 compatible cloud storage and filesystems.


### PR DESCRIPTION
Hi,

This pull request adds [jsonhal](https://github.com/RichardKnop/jsonhal) to the utilities section.

It is a useful package to implement structs which JSON encode into HAL format which is one of emerging standards for hyperlinked API responses.

- github.com repo: https://github.com/RichardKnop/jsonhal
- godoc.org: https://godoc.org/github.com/RichardKnop/jsonhal
- goreportcard.com: https://goreportcard.com/report/github.com/RichardKnop/jsonhal
- coverage service link: https://codecov.io/gh/RichardKnop/jsonhal
- travis CI link: https://travis-ci.org/RichardKnop/jsonhal
- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
