### PR TITLE
Add github.com/RichardKnop/logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [logdump](https://github.com/ewwwwwqm/logdump) - Package for multi-level logging
 * [logex](https://github.com/chzyer/logex) - An golang log lib, supports tracking and level, wrap by standard log lib
 * [logger](https://github.com/azer/logger) - Minimalistic logging library for Go.
+* [logger](https://github.com/RichardKnop/logging) - A simple leveled logging library with coloured output.
 * [logrus](https://github.com/Sirupsen/logrus) - a structured logger for Go.
 * [logrusly](https://github.com/sebest/logrusly) - [logrus](https://github.com/sirupsen/logrus) plug-in to send errors to a [Loggly](https://www.loggly.com/).
 * [logutils](https://github.com/hashicorp/logutils) - Utilities for slightly better logging in Go (Golang) extending the standard logger.


### PR DESCRIPTION
Hi,

This pull request adds [logging](https://github.com/RichardKnop/logging) to the logging section.

It's a simple leveled logging library with coloured output, pluggable architecture and conforming to the core log interface.

- github.com repo: https://github.com/RichardKnop/logging
- godoc.org: https://godoc.org/github.com/RichardKnop/logging
- goreportcard.com: https://goreportcard.com/report/github.com/RichardKnop/logging
- coverage service link: https://codecov.io/gh/RichardKnop/logging
- travis CI link: https://travis-ci.org/RichardKnop/logging
- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
