### PR TITLE
Add github.com/kpango/glg

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 *Libraries for generating and working with log files.*
 
+* [glg](https://github.com/kpango/glg) - glg is simple and fast leveled logging library for Go.
 * [glog](https://github.com/golang/glog) - Leveled execution logs for Go.
 * [go-log](https://github.com/siddontang/go-log) - Log lib supports level and multi handlers.
 * [go-log](https://github.com/ian-kent/go-log) - A log4j implementation in Go.


### PR DESCRIPTION
Hi,

This pull request adds [glg](https://github.com/kpango/glg) to the logging section.

It is a useful package can quickly output that are colored and leveled logs  with simple syntax

- github.com repo: https://github.com/kpango/glg
- godoc.org: http://godoc.org/github.com/kpango/glg
- goreportcard.com: https://goreportcard.com/report/github.com/kpango/glg
- coverage service link:  [gocover](http://gocover.io/github.com/kpango/glg), [codecov](https://codecov.io/gh/kpango/glg)

- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).