### PR TITLE
Update description for go-mssqldb database driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
     * [firebirdsql](https://github.com/nakagami/firebirdsql) - Firebird RDBMS SQL driver for Go
     * [go-adodb](https://github.com/mattn/go-adodb) - Microsoft ActiveX Object DataBase driver for go that using database/sql.
     * [go-bqstreamer](https://github.com/rounds/go-bqstreamer) - BigQuery fast and concurrent stream insert.
-    * [go-mssqldb](https://github.com/denisenkom/go-mssqldb) - Microsoft MSSQL driver prototype in go language.
+    * [go-mssqldb](https://github.com/denisenkom/go-mssqldb) - Microsoft MSSQL driver for Go.
     * [go-oci8](https://github.com/mattn/go-oci8) - Oracle driver for go that using database/sql.
     * [go-sql-driver/mysql](https://github.com/go-sql-driver/mysql) - MySQL driver for Go.
     * [go-sqlite3](https://github.com/mattn/go-sqlite3) - SQLite3 driver for go that using database/sql.


### PR DESCRIPTION
Not the owner of the project.

Looking at the [project's `README`](https://github.com/denisenkom/go-mssqldb), I believe the driver is no longer considered a prototype.