### PR TITLE
add axiomhq/hyperloglog

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [goskiplist](https://github.com/ryszard/goskiplist) - A skip list implementation in Go.
 * [gota](https://github.com/kniren/gota) - An implementation of dataframes, series, and data wrangling methods for Go.
 * [hilbert](https://github.com/google/hilbert) - Go package for mapping values to and from space-filling curves, such as Hilbert and Peano curves.
+* [hyperloglog](https://github.com/axiomhq/hyperloglog) - HyperLogLog implementation with Sparse, LogLog-Beta bias correction and TailCut space reduction.
 * [levenshtein](https://github.com/agext/levenshtein) - Levenshtein distance and similarity metrics with customizable edit costs and Winkler-like bonus for common prefix.
 * [levenshtein](https://github.com/agnivade/levenshtein) - Implementation to calculate levenshtein distance in Go.
 * [mafsa](https://github.com/smartystreets/mafsa) - MA-FSA implementation with Minimal Perfect Hashing


### PR DESCRIPTION
Voila!

* github.com repo: [http://github.com/axiomhq/hyperloglog](http://github.com/axiomhq/hyperloglog)
* godoc.org: [![GoDoc](https://godoc.org/github.com/axiomhq/hyperloglog?status.svg)](https://godoc.org/github.com/axiomhq/hyperloglog)
* goreportcard.com: [![Go Report Card](https://goreportcard.com/badge/github.com/axiomhq/hyperloglog)](https://goreportcard.com/report/github.com/axiomhq/hyperloglog)
* coverage service link: ![cover.run go](https://cover.run/go/github.com/axiomhq/hyperloglog.svg)

- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
