### PR TITLE
Added link to minimock generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
     * [gock](https://github.com/h2non/gock) - Versatile HTTP mocking made easy.
     * [gomock](https://github.com/golang/mock) - Mocking framework for the Go programming language.
     * [govcr](https://github.com/seborama/govcr) -  HTTP mock for Golang: record and replay HTTP interactions for offline testing
+    * [minimock](https://github.com/gojuno/minimock) - Mock generator for Go interfaces
     * [mockhttp](https://github.com/tv42/mockhttp) - Mock object for Go http.ResponseWriter
 
 * Fuzzing and delta-debugging/reducing/shrinking


### PR DESCRIPTION
Hi Guys!

Please take a look at this mock generator. The main feature is that it generates mocks that do not rely on reflection.

- github.com repo: https://github.com/gojuno/minimock
- godoc.org: http://godoc.org/github.com/gojuno/minimock
- goreportcard.com: https://goreportcard.com/report/github.com/gojuno/minimock
- coverage service link: https://cover.run/go/github.com/gojuno/minimock/tests.svg

Please find tests in the test subpackage, I've tested minimock via the generated code it produces.