### PR TITLE
Adding YANFF library

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,6 +831,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [water](https://github.com/songgao/water) - Simple TUN/TAP library.
 * [winrm](https://github.com/masterzen/winrm) - Go WinRM client to remotely execute commands on Windows machines.
 * [xtcp](https://github.com/xfxdev/xtcp) - TCP Server Framework with simultaneous full duplex communication,graceful shutdown,custom protocol.
+* [YANNFF](https://github.com/intel-go/yanff) - Framework for rapid development of performant network functions for cloud and bare-metal.
 
 ## OpenGL
 


### PR DESCRIPTION
Hi again,
Adding a link to the YANFF - Yet Another Network Function Framework to the awesome-go. Framework for creating cloud native network scalable network functions.

- github.com repo: https://github.com/intel-go/yanff
- godoc.org: https://godoc.org/github.com/intel-go/yanff
- goreportcard.com: [![Go Report Card](https://goreportcard.com/badge/github.com/intel-go/yanff)](https://goreportcard.com/report/github.com/intel-go/yanff)
- coverage service link - This is a framework, it has external dependencies for the successful build, which cannot be done online. 

- [X] I have added my package in alphabetical order.
- [X] I have an appropriate description with correct grammar.
- [X] I know that this package was not listed before.
- [X] I have added godoc link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request. - cannot be done by coverage tool online
- [X] I have added goreportcard link to the repo and to my pull request.
- [X] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Thanks for your PR, you're awesome! :+1:
