### PR TITLE
Add go-on-rails as a Web Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1325,6 +1325,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [Gin](https://github.com/gin-gonic/gin) - Gin is a web framework written in Go! It features a martini-like API with much better performance, up to 40 times faster. If you need performance and good productivity.
 * [Gizmo](https://github.com/NYTimes/gizmo) - Microservice toolkit used by the New York Times.
 * [go-json-rest](https://github.com/ant0ine/go-json-rest) - Quick and easy way to setup a RESTful JSON API.
+* [go-on-rails](https://github.com/goonr/go-on-rails) - Use Ruby on Rails to manage, develope and generate Go APIs.
 * [go-relax](https://github.com/codehack/go-relax) - Framework of pluggable components to build RESTful API's.
 * [go-rest](https://github.com/ungerik/go-rest) - Small and evil REST framework for Go.
 * [goa](https://github.com/raphael/goa) - Framework for developing microservices based on the design of Ruby's Praxis.


### PR DESCRIPTION
Add [go-on-rails](https://github.com/goonr/go-on-rails) to the list under the `Web Frameworks` node.
