### PR TITLE
Add govaluate

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [go-python](https://github.com/sbinet/go-python) - naive go bindings to the CPython C-API.
 * [golua](https://github.com/aarzilli/golua) - Go bindings for Lua C API.
 * [gopher-lua](https://github.com/yuin/gopher-lua) - Lua 5.1 VM and compiler written in Go.
+* [govaluate](https://github.com/Knetic/govaluate) - Arbitrary expression evaluation for golang.
 * [ngaro](https://github.com/db47h/ngaro) - Embeddable Ngaro VM implementation enabling scripting in Retro.
 * [otto](https://github.com/robertkrimen/otto) - JavaScript interpreter written in Go.
 * [purl](https://github.com/ian-kent/purl) - Perl 5.18.2 embedded in Go.


### PR DESCRIPTION
I was looking for something to parse mathematical equation in a string.
Couldn't find one here, I tried to write one myself.
Knowing it would take a while before I could make one that work, I googled a bit and found [govaluate](github.com/Knetic/govaluate).
So I decided to make a PR so others who are looking for the same thing can find it here.

Not sure though if I put it in the right category :p

-- Updated: --
Here's the link: [![github](https://img.shields.io/badge/github-govaluate-5272B4.svg?style=flat-square)](https://github.com/Knetic/govaluate) [![godoc](https://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square)](https://godoc.org/github.com/Knetic/govaluate) [![Go Report Card](https://goreportcard.com/badge/github.com/Knetic/govaluate)](https://goreportcard.com/report/github.com/Knetic/govaluate) [![gocover](https://gocover.io/_badge/github.com/Knetic/govaluate)](https://gocover.io/github.com/Knetic/govaluate)

- [x] I have added the package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to my pull request and it's exists in the repo.
- [x] I have added coverage service link ~to the repo and~ to my pull request.
- [x] I have added goreportcard link ~to the repo and~ to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

* The strike through is because I don't own the repo, though I'll make a PR there.