### PR TITLE
Add ergo proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,6 +1197,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [Deepcopier](https://github.com/ulule/deepcopier) - Simple struct copying for Go.
 * [delve](https://github.com/derekparker/delve) - Go debugger.
 * [dlog](https://github.com/kirillDanshin/dlog) - Compile-time controlled logger to make your release smaller without removing debug calls.
+* [ergo](https://github.com/cristianoliveira/ergo) - The management of multiple local services running over different ports made easy.
 * [excelize](https://github.com/360EntSecGroup-Skylar/excelize) - Golang library for reading and writing Microsoft Excel™ (XLSX) files.
 * [fastlz](https://github.com/digitalcrab/fastlz) - Wrap over [FastLz](http://fastlz.org/) (free, open-source, portable real-time compression library) for GoLang.
 * [filetype](https://github.com/h2non/filetype) - Small package to infer the file type checking the magic numbers signature.


### PR DESCRIPTION
Add ergo proxy under Utilities. #1611


github.com repo: https://github.com/cristianoliveira/ergo
godoc.org: https://godoc.org/github.com/cristianoliveira/ergo
goreportcard.com:  https://goreportcard.com/report/github.com/cristianoliveira/ergo
coverage service link: https://cover.run/go/github.com/cristianoliveira/ergo


