### PR TITLE
added persian repo to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [indigo](https://github.com/osamingo/indigo) - Distributed unique ID generator of using Sonyflake and encoded by Base58.
 * [jobs](https://github.com/albrow/jobs) - Persistent and flexible background jobs library.
 * [margelet](https://github.com/zhulik/margelet) - Framework for building Telegram bots.
+* [persian](https://github.com/mavihq/persian) - Some utilities for Persian language in go.
 * [secdl](https://github.com/xor-gate/secdl) - Lighttpd ModSecDownload algorithm ported to go to secure download urls.
 * [shellwords](https://github.com/Wing924/shellwords) - A Golang library to manipulate strings according to the word parsing rules of the UNIX Bourne shell.
 * [slacker](https://github.com/shomali11/slacker) - Easy to use framework to create Slack bots.


### PR DESCRIPTION
Some utilities for Persian language in go.

- github.com repo: https://github.com/mavihq/persian
- godoc.org: https://godoc.org/github.com/mavihq/persian
- goreportcard.com: https://goreportcard.com/report/github.com/mavihq/persian 
- coverage service link: https://cover.run/go/github.com/mavihq/persian

- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
