### PR TITLE
Remove go.auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [Go-AWS-Auth](https://github.com/smartystreets/go-aws-auth) - AWS (Amazon Web Services) request signing library.
 * [go-jose](https://github.com/square/go-jose) - Fairly complete implementation of the JOSE working group's JSON Web Token, JSON Web Signatures, and JSON Web Encryption specs.
 * [go-oauth2-server](https://github.com/RichardKnop/go-oauth2-server) - Standalone, specification-compliant,  OAuth2 server written in Golang.
-* [go.auth](https://github.com/bradrydzewski/go.auth) - Authentication API for Go web applications.
 * [gologin](https://github.com/dghubble/gologin) - chainable handlers for login with OAuth1 and OAuth2 authentication providers.
 * [gorbac](https://github.com/mikespook/gorbac) - provides a lightweight role-based access control (RBAC) implementation in Golang.
 * [goth](https://github.com/markbates/goth) - provides a simple, clean, and idiomatic way to use OAuth and OAuth2. Handles multiple provides out of the box.


### PR DESCRIPTION
https://github.com/bradrydzewski/go.auth says in the description that it is deprecated and it has not been updated since 2013.