### PR TITLE
Adding Emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [celeriac](https://github.com/svcavallar/celeriac.v1) - Library for adding support for interacting and monitoring Celery workers, tasks and events in Go.
 * [digota](https://github.com/digota/digota) - grpc ecommerce microservice.
 * [drmaa](https://github.com/dgruber/drmaa) - Job submission library for cluster schedulers based on the DRMAA standard.
+* [emitter-io](https://github.com/emitter-io/emitter) - High performance, distributed, secure and low latency publish-subscribe platform built with MQTT, Websockets and love.
 * [flowgraph](https://github.com/vectaport/flowgraph) - MPI-style ready-send coordination layer.
 * [gleam](https://github.com/chrislusf/gleam) - Fast and scalable distributed map/reduce system written in pure Go and Luajit, combining Go's high concurrency with Luajit's high performance, runs standalone or distributed.
 * [glow](https://github.com/chrislusf/glow) - Easy-to-Use scalable distributed big data processing, Map-Reduce, DAG execution, all in pure Go.


### PR DESCRIPTION
**Links to:**

- github.com repo: https://github.com/emitter-io/emitter
- godoc.org: https://godoc.org/github.com/emitter-io/emitter
- goreportcard.com: https://goreportcard.com/report/github.com/emitter-io/emitter
- coverage service link: https://coveralls.io/github/emitter-io/emitter?branch=master

[![Coverage Status](https://coveralls.io/repos/github/emitter-io/emitter/badge.svg?branch=master)](https://coveralls.io/github/emitter-io/emitter?branch=master)

**Note**: that new categories can be added only when there are 3 packages or more.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Latest test coverage report:
```
?       github.com/emitter-io/emitter   [no test files]
ok      github.com/emitter-io/emitter/broker    1.142s  coverage: 57.3% of statements
ok      github.com/emitter-io/emitter/broker/cluster    0.501s  coverage: 21.1% of statements
ok      github.com/emitter-io/emitter/broker/message    0.022s  coverage: 91.7% of statements
ok      github.com/emitter-io/emitter/broker/storage    0.035s  coverage: 98.5% of statements
ok      github.com/emitter-io/emitter/broker/subscription       0.036s  coverage: 82.5% of statements
ok      github.com/emitter-io/emitter/collection        0.031s  coverage: 100.0% of statements
ok      github.com/emitter-io/emitter/config    0.021s  coverage: 100.0% of statements
ok      github.com/emitter-io/emitter/logging   0.024s  coverage: 33.3% of statements
ok      github.com/emitter-io/emitter/network/address   0.478s  coverage: 57.8% of statements
ok      github.com/emitter-io/emitter/network/http      0.026s  coverage: 64.3% of statements
ok      github.com/emitter-io/emitter/network/listener  0.501s  coverage: 81.1% of statements
?       github.com/emitter-io/emitter/network/mock      [no test files]
ok      github.com/emitter-io/emitter/network/mqtt      0.111s  coverage: 96.6% of statements
ok      github.com/emitter-io/emitter/network/websocket 0.024s  coverage: 12.2% of statements
ok      github.com/emitter-io/emitter/security  0.033s  coverage: 93.5% of statements
ok      github.com/emitter-io/emitter/security/mock     0.022s  coverage: 100.0% of statements
ok      github.com/emitter-io/emitter/security/usage    0.020s  coverage: 48.7% of statements
ok      github.com/emitter-io/emitter/utils     0.027s  coverage: 100.0% of statements
```
