### PR TITLE
Remove go-bindata

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,7 +931,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 * [esc](https://github.com/mjibson/esc) - Embeds files into Go programs and provides http.FileSystem interfaces to them.
 * [fileb0x](https://github.com/UnnoTed/fileb0x) - Simple tool to embed files in go with focus on "customization" and ease to use.
-* [go-bindata](https://github.com/jteeuwen/go-bindata) - Package that converts any file into managable Go source code.
 * [go-embed](https://github.com/pyros2097/go-embed) - Generates go code to embed resource files into your library or executable.
 * [go-resources](https://github.com/omeid/go-resources) - Unfancy resources embedding with Go.
 * [go.rice](https://github.com/GeertJohan/go.rice) - go.rice is a Go package that makes working with resources such as html,js,css,images and templates very easy.


### PR DESCRIPTION
This (fork of) go-bindata unfortunately is not awesome anymore.

The project is not maintained anymore and has a great bunch of issues.
Currently there are 50 unresolved issue tickets and 18 unmerge pull
requests. Many of the issues make this tool very annoying to use, but
would be easy to fix if it was maintained.

An example issue that is very easy to fix is jteeuwen/go-bindata/issues/148
which brought to make this PR.

See also jteeuwen/go-bindata/issues/165 
Apparently the maintainer has disappeared from earth's surface two years
ago. Let's hope that's not actually true!

(PR template omitted; doesn't seem to be applicable.)