### PR TITLE
add a maintained fork of go-bindata

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,6 +932,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 * [esc](https://github.com/mjibson/esc) - Embeds files into Go programs and provides http.FileSystem interfaces to them.
 * [fileb0x](https://github.com/UnnoTed/fileb0x) - Simple tool to embed files in go with focus on "customization" and ease to use.
+* [go-bindata](https://github.com/shuLhan/go-bindata) - Package that converts any file into managable Go source code.
 * [go-embed](https://github.com/pyros2097/go-embed) - Generates go code to embed resource files into your library or executable.
 * [go-resources](https://github.com/omeid/go-resources) - Unfancy resources embedding with Go.
 * [go.rice](https://github.com/GeertJohan/go.rice) - go.rice is a Go package that makes working with resources such as html,js,css,images and templates very easy.


### PR DESCRIPTION
There was a PR that was merged a few days ago https://github.com/avelino/awesome-go/pull/1675 that removed go-bindata and rightly so. 

I would like to propose that we add https://github.com/shuLhan/go-bindata which is a maintained fork of go-bindata.        

My reasons are:      
1. https://github.com/shuLhan/go-bindata is maintained. The last release was only 4 days ago[1]
2. The maintainer is active on the project. As a proxy to that, he has merged no less than 10 pull requests in the last 3months[2]
3. The maintainer has offered to review and merge all open PR's from the parent bindata repo to his fork[3]
4. Because go-bindata  is awesome

ref:             
1. https://github.com/shuLhan/go-bindata/releases/tag/v3.2.0                            
2. https://github.com/shuLhan/go-bindata/pulls?q=is%3Apr+is%3Aclosed
3. https://github.com/jteeuwen/go-bindata/issues/165#issuecomment-328291324

(PR template omitted; doesn't seem to be applicable.)