### PR TITLE
Add Git Town to list of other software

### DIFF
--- a/README.md
+++ b/README.md
@@ -1587,6 +1587,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [Docker](http://www.docker.com/) - Open platform for distributed applications for developers and sysadmins.
 * [Documize](https://github.com/documize/community) - Modern wiki software that integrates data from SaaS tools.
 * [fleet](https://github.com/coreos/fleet) - Distributed init System.
+* [Git Town](https://github.com/originate/git-town) - High-level CLI for Git.
 * [Go Package Store](https://github.com/shurcooL/Go-Package-Store) - App that displays updates for the Go packages in your GOPATH.
 * [gocc](https://github.com/goccmack/gocc) - Gocc is a compiler kit for Go written in Go.
 * [GoDNS](https://github.com/timothyye/godns) - A dynamic DNS client tool, supports DNSPod & HE.net, written in Go.


### PR DESCRIPTION
- github.com repo: https://github.com/originate/git-town
- godoc.org: N/A since this is a CLI tool
- goreportcard.com: https://goreportcard.com/report/github.com/Originate/git-town
- coverage service link: N/A since testing via Cucumber written in Ruby (needed for parallelization of tests). We have 200 end-to-end feature specs in https://github.com/Originate/git-town/tree/master/features that cover the tool completely.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [ ] I have added godoc link to the repo and to my pull request. (N/A since this is a CLI tool)
- [ ] I have added coverage service link to the repo and to my pull request. (N/A due to tests written in Ruby)
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Thanks for your PR, you're awesome! :+1:
