### PR TITLE
Add 1backend, remove borg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1577,7 +1577,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [winrm-cli](https://github.com/masterzen/winrm-cli) - Cli tool to remotely execute commands on Windows machines.
 
 ### Other Software
-* [borg](https://github.com/crufter/borg) - Terminal based search engine for bash snippets.
+* [1backend](https://github.com/1backend/1backend) - A PaaS in Go.
 * [boxed](https://github.com/tejo/boxed) - Dropbox based blog engine.
 * [Cherry](https://github.com/rafael-santiago/cherry) - Tiny webchat server in Go.
 * [Circuit](https://github.com/gocircuit/circuit) - Circuit is a programmable platform-as-a-service (PaaS) and/or Infrastructure-as-a-Service (IaaS), for management, discovery, synchronization and orchestration of services and hosts comprising cloud applications.


### PR DESCRIPTION
I have removed Borg, which I have submitted a year ago but I don't maintain anymore.
I have added 1Backend, a PaaS service which has a go backend.

**Please provide package links to:**

- github.com repo: https://github.com/1backend/1backend
- godoc: https://godoc.org/github.com/1backend/1backend