### PR TITLE
Add Joinville Go Meetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1695,6 +1695,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [Golang Boston](https://www.meetup.com/bostongo/)
 * [Golang DC, Arlington, VA](https://www.meetup.com/Golang-DC/)
 * [Golang Israel](https://www.meetup.com/Go-Israel/)
+* [Golang Joinville - Brazil](https://www.meetup.com/Joinville-Go-Meetup/)
 * [Golang Lima - Peru](https://www.meetup.com/Golang-Peru/)
 * [Golang Lyon](https://www.meetup.com/Golang-Lyon/)
 * [Golang Melbourne](https://www.meetup.com/golang-mel/)


### PR DESCRIPTION
Add the Joinville -Brazil Go meetup to the list.

@avelino i didn't follow the PR template because it's focused on go repo/packages and not make sense to a new meetup link. is it ok?