### PR TITLE
Add distillog to 'Logging' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 *Libraries for generating and working with log files.*
 
+* [distillog](https://github.com/amoghe/distillog) - distilled levelled logging (think of it as stdlib + log levels).
 * [glg](https://github.com/kpango/glg) - glg is simple and fast leveled logging library for Go.
 * [glog](https://github.com/golang/glog) - Leveled execution logs for Go.
 * [go-cronowriter](https://github.com/utahta/go-cronowriter) - Simple writer that rotate log files automatically based on current date and time, like cronolog.


### PR DESCRIPTION
Adds [distillog](https://github.com/amoghe/distillog) to the `Logging` section.
