### PR TITLE
Add bitbucket-golang-api in third party

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,6 +1240,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [tumblr](https://github.com/mattcunningham/gumblr) - Go wrapper for the Tumblr v2 API.
 * [webhooks](https://github.com/go-playground/webhooks) - Webhook receiver for GitHub and Bitbucket.
 * [zooz](https://github.com/gojuno/go-zooz) - Go client for the Zooz API.
+* [bitbucket-golang-api](https://github.com/crossid/bitbucket-golang-api) - Bitbucket client (v1/v2) written in GO
 
 ## Utilities
 


### PR DESCRIPTION
Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard) before sending pull request. Thanks!

**Please provide package links to:**

- github.com repo:
- godoc.org:
- goreportcard.com:
- coverage service link ([cover.run](https://cover.run/), [gocover](http://gocover.io/), [coveralls](https://coveralls.io/) etc.), example: `![cover.run go](https://cover.run/go/github.com/user/repository.svg)`

Very good coverage

**Note**: that new categories can be added only when there are 3 packages or more.

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] I have added my package in alphabetical order.
- [ ] I have an appropriate description with correct grammar.
- [ ] I know that this package was not listed before.
- [ ] I have added godoc link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request.
- [ ] I have added goreportcard link to the repo and to my pull request.
- [ ] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Thanks for your PR, you're awesome! :+1:
