### PR TITLE
Updated goes link to maintained repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
     * [elastic](https://github.com/olivere/elastic) - Elasticsearch client for Go.
     * [elasticsql](https://github.com/cch123/elasticsql) - Convert sql to elasticsearch dsl in Go.
     * [elastigo](https://github.com/mattbaird/elastigo) - Elasticsearch client library.
-    * [goes](https://github.com/belogik/goes) - Library to interact with Elasticsearch.
+    * [goes](https://github.com/OwnLocal/goes) - Library to interact with Elasticsearch.
     * [riot](https://github.com/go-ego/riot) - Go Open Source, Distributed, Simple and efficient Search Engine
     * [skizze](https://github.com/seiflotfy/skizze) - probabilistic data-structures service and storage.
 


### PR DESCRIPTION
Very basic update moving link for goes repo from the [unmaintained page](https://github.com/belogik/goes) to the [maintained one](https://github.com/OwnLocal/goes).