### PR TITLE
Added goracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
     * [go-bqstreamer](https://github.com/rounds/go-bqstreamer) - BigQuery fast and concurrent stream insert.
     * [go-mssqldb](https://github.com/denisenkom/go-mssqldb) - Microsoft MSSQL driver for Go.
     * [go-oci8](https://github.com/mattn/go-oci8) - Oracle driver for go that uses database/sql.
+    * [goracle](https://github.com/go-goracle/goracle) - Oracle driver for Go, using the ODPI-C driver
     * [go-sql-driver/mysql](https://github.com/go-sql-driver/mysql) - MySQL driver for Go.
     * [go-sqlite3](https://github.com/mattn/go-sqlite3) - SQLite3 driver for go that uses database/sql.
     * [gofreetds](https://github.com/minus5/gofreetds) - Microsoft MSSQL driver. Go wrapper over [FreeTDS](http://www.freetds.org).

--- a/README.md
+++ b/README.md
@@ -365,10 +365,10 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
     * [go-bqstreamer](https://github.com/rounds/go-bqstreamer) - BigQuery fast and concurrent stream insert.
     * [go-mssqldb](https://github.com/denisenkom/go-mssqldb) - Microsoft MSSQL driver for Go.
     * [go-oci8](https://github.com/mattn/go-oci8) - Oracle driver for go that uses database/sql.
-    * [goracle](https://github.com/go-goracle/goracle) - Oracle driver for Go, using the ODPI-C driver
     * [go-sql-driver/mysql](https://github.com/go-sql-driver/mysql) - MySQL driver for Go.
     * [go-sqlite3](https://github.com/mattn/go-sqlite3) - SQLite3 driver for go that uses database/sql.
     * [gofreetds](https://github.com/minus5/gofreetds) - Microsoft MSSQL driver. Go wrapper over [FreeTDS](http://www.freetds.org).
+    * [goracle](https://github.com/go-goracle/goracle) - Oracle driver for Go, using the ODPI-C driver
     * [pgx](https://github.com/jackc/pgx) - PostgreSQL driver supporting features beyond those exposed by database/sql.
     * [pq](https://github.com/lib/pq) - Pure Go Postgres driver for database/sql.
 


### PR DESCRIPTION
Oracle driver for Go, using the ODPI-C driver

https://github.com/go-goracle/goracle

https://godoc.org/gopkg.in/goracle.v2

https://goreportcard.com/report/github.com/go-goracle/goracle