### PR TITLE
add encdec package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,6 +1184,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
     * [doi](https://github.com/hscells/doi) - Document object identifier (doi) parser in Go.
     * [editorconfig-core-go](https://github.com/editorconfig/editorconfig-core-go) - Editorconfig file parser and manipulator for Go.
     * [enca](https://github.com/endeveit/enca) - Minimal cgo bindings for [libenca](http://cihar.com/software/enca/).
+    * [encdec](https://github.com/mickep76/encdec) - Package provides a generic interface to encoders and decodersa.
     * [genex](https://github.com/alixaxel/genex) - Count and expand Regular Expressions into all matching Strings.
     * [github_flavored_markdown](https://godoc.org/github.com/shurcooL/github_flavored_markdown) - GitHub Flavored Markdown renderer (using blackfriday) with fenced code block highlighting, clickable header anchor links.
     * [go-fixedwidth](https://github.com/ianlopshire/go-fixedwidth) - Fixed-width text formatting (encoder/decoder with reflection).


### PR DESCRIPTION
# encdec

Package provides a generic interface to encoders and decoders

# Links
[![GoDoc](https://godoc.org/github.com/mickep76/encdec?status.svg)](https://godoc.org/github.com/mickep76/encdec)
[![codecov](https://codecov.io/gh/mickep76/encdec/branch/master/graph/badge.svg)](https://codecov.io/gh/mickep76/encdec)
[![Build Status](https://travis-ci.org/mickep76/encdec.svg?branch=master)](https://travis-ci.org/mickep76/encdec)
[![Go Report Card](https://goreportcard.com/badge/github.com/mickep76/encdec)](https://goreportcard.com/report/github.com/mickep76/encdec)
[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/mickep76/mlfmt/blob/master/LICENSE)
