### PR TITLE
add dchenk/msgp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [goprotobuf](https://github.com/golang/protobuf) - Go support, in the form of a library and protocol compiler plugin, for Google's protocol buffers.
 * [jsoniter](https://github.com/json-iterator/go) - High-performance 100% compatible drop-in replacement of "encoding/json".
 * [mapstructure](https://github.com/mitchellh/mapstructure) - Go library for decoding generic map values into native Go structures.
+* [msgp](https://github.com/dchenk/msgp) - MessagePack serialization library, powered in part by a tool that generates highly efficient code.
 * [php_session_decoder](https://github.com/yvasiyarov/php_session_decoder) - GoLang library for working with PHP session format and PHP Serialize/Unserialize functions.
 * [structomap](https://github.com/tuvistavie/structomap) - Library to easily and dynamically generate maps from static structures.
 * [structs](https://github.com/fatih/structs) - Library with support for converting structs to maps, struct keys/values to slices, and more.


### PR DESCRIPTION
This repository includes a code generator that uses the "go generate" tool to generate highly efficient code to encode and decode data into and from the MessagePack format.

- github.com repo: https://github.com/dchenk/msgp
- godoc.org: https://godoc.org/github.com/dchenk/msgp (main library is https://godoc.org/github.com/dchenk/msgp/msgp)
- goreportcard.com: https://goreportcard.com/report/github.com/dchenk/msgp
- coverage service link: https://coveralls.io/github/dchenk/msgp

- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

**EDIT:** 
I have now removed the Coveralls coverage testing feature from the repository because it is not representative of the actual testing we do. Note the "tests" folder and all of the tests in there—there's no way to indicate to Coveralls that that's where all the testing logic is. I suggest that you download the repo and run "make test". You'll see the great thoroughness of the tests.