### PR TITLE
Update repository for avatica database driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 *Libraries for connecting and operating databases.*
 
 * Relational Databases
-    * [avatica](https://github.com/Boostport/avatica) - Apache Phoenix/Avatica SQL driver for database/sql.
+    * [avatica](https://github.com/apache/calcite-avatica-go) - Apache Avatica/Phoenix SQL driver for database/sql.
     * [bgc](https://github.com/viant/bgc) - Datastore Connectivity for BigQuery for go.
     * [firebirdsql](https://github.com/nakagami/firebirdsql) - Firebird RDBMS SQL driver for Go.
     * [go-adodb](https://github.com/mattn/go-adodb) - Microsoft ActiveX Object DataBase driver for go that uses database/sql.


### PR DESCRIPTION
The original Boostport/avatica database/sql driver was donated to the Apache Calcite project (part of the Apache Foundation).

The code has been imported to github.com/apache/calcite-avatica-go and all new development will continue in that repository.

This PR changes the url from github.com/Boosport/avatica to github.com/apache/calcite-avatica