### PR TITLE
add cmp - Provides comparison for different Go types and a Comparer i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [bloom](https://github.com/zhenjl/bloom) - Bloom filters implemented in Go.
 * [bloom](https://github.com/yourbasic/bloom) - Golang Bloom filter implementation.
 * [boomfilters](https://github.com/tylertreat/BoomFilters) - Probabilistic data structures for processing continuous, unbounded streams.
+* [cmp](https://github.com/mickep76/cmp) - Provides comparison for different Go types and a Comparer interface when using structs.
 * [concurrent-writer](https://github.com/free/concurrent-writer) - Highly concurrent drop-in replacement for `bufio.Writer`.
 * [conjungo](https://github.com/InVisionApp/conjungo) - A small, powerful and flexible merge library.
 * [count-min-log](https://github.com/seiflotfy/count-min-log) - Go implementation Count-Min-Log sketch: Approximately counting with approximate counters (Like Count-Min sketch but using less memory).


### PR DESCRIPTION
add cmp - Provides comparison for different Go types and a Comparer interface.

[![GoDoc](https://godoc.org/github.com/mickep76/cmp?status.svg)](https://godoc.org/github.com/mickep76/cmp)
[![codecov](https://codecov.io/gh/mickep76/cmp/branch/master/graph/badge.svg)](https://codecov.io/gh/mickep76/cmp)
[![Build Status](https://travis-ci.org/mickep76/cmp.svg?branch=master)](https://travis-ci.org/mickep76/cmp)
[![Go Report Card](https://goreportcard.com/badge/github.com/mickep76/cmp)](https://goreportcard.com/report/github.com/mickep76/cmp)
[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/mickep76/mlfmt/blob/master/LICENSE)