### PR TITLE
Add Cardiff meetup to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1813,6 +1813,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [Golang Belo Horizonte - Brazil](https://www.meetup.com/go-belo-horizonte/)
 * [Golang Boston](https://www.meetup.com/bostongo/)
 * [Golang Bulgaria](https://www.meetup.com/Golang-Bulgaria/)
+* [Golang Cardiff, UK](https://www.meetup.com/Cardiff-Go-Meetup/)
 * [Golang DC, Arlington, VA](https://www.meetup.com/Golang-DC/)
 * [Golang Dorset, UK](https://www.meetup.com/golang-dorset/)
 * [Golang Israel](https://www.meetup.com/Go-Israel/)


### PR DESCRIPTION
Cardiff (Wales) meetup added in accordance with formatting of other meetups on README.md

No package being added - only link to Meetup page

Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard) before sending pull request. Thanks!