### PR TITLE
Update mattes/migrate URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [gondolier](https://github.com/emvicom/gondolier) - Gondolier is a library to auto migrate database schemas using structs.
 * [goose](https://github.com/steinbacher/goose) - Database migration tool. You can manage your database's evolution by creating incremental SQL or Go scripts.
 * [gormigrate](https://github.com/go-gormigrate/gormigrate) - Database schema migration helper for Gorm ORM.
-* [migrate](https://github.com/mattes/migrate) - Database migrations. CLI and Golang library.
+* [migrate](https://github.com/golang-migrate/migrate) - Database migrations. CLI and Golang library.
 * [pravasan](https://github.com/pravasan/pravasan) - Simple Migration tool - currently for MySQL but planning to soon support Postgres, SQLite, MongoDB, etc.
 * [soda](https://github.com/markbates/pop/tree/master/soda) - Database migration, creation, ORM, etc... for MySQL, PostgreSQL, and SQLite.
 * [sql-migrate](https://github.com/rubenv/sql-migrate) - Database migration tool. Allows embedding migrations into the application using go-bindata.


### PR DESCRIPTION
https://github.com/mattes/migrate has been deprecated in favor of https://github.com/golang-migrate/migrate.