### PR TITLE
Add go-guerrilla to Email list

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [douceur](https://github.com/aymerick/douceur) - CSS inliner for your HTML emails.
 * [email](https://github.com/jordan-wright/email) - A robust and flexible email library for Go.
 * [go-dkim](https://github.com/toorop/go-dkim) - DKIM library, to sign & verify email.
+* [go-guerrilla](https://github.com/flashmob/go-guerrilla) - A lightweight SMTP server made for receiving large volumes of email.
 * [go-imap](https://github.com/emersion/go-imap) - IMAP library for clients and servers.
 * [go-message](https://github.com/emersion/go-message) - Streaming library for the Internet Message Format and mail messages.
 * [Gomail](https://github.com/go-gomail/gomail/) - Gomail is a very simple and powerful package to send emails.


### PR DESCRIPTION
Hi, this is a pull request to add go-guerrilla to the Email list. I believe it meets the [quality standards](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

**Useful links:**

- github.com repo: https://github.com/flashmob/go-guerrilla
- godoc.org: https://godoc.org/github.com/flashmob/go-guerrilla
- goreportcard.com: [![A-Great!](https://goreportcard.com/badge/github.com/flashmob/go-guerrilla)](https://goreportcard.com/report/github.com/flashmob/go-guerrilla)
- gocover.io: [75.7%](https://gocover.io/github.com/flashmob/go-guerrilla)

**Checked boxes:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Thanks for awesome-go! :+1: