### PR TITLE
Add kelseyhightower/envconfig to Configurations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [ingo](https://github.com/schachmat/ingo) - Flags persisted in an ini-like config file.
 * [ini](https://github.com/go-ini/ini) - Go package to read and write INI files.
 * [joshbetz/config](https://github.com/joshbetz/config) - Small configuration library for Go that parses environment variables, JSON files, and reloads automatically on SIGHUP.
+* [kelseyhightower/envconfig](https://github.com/kelseyhightower/envconfig) - Go library for managing configuration data from environment variables.
 * [mini](https://github.com/sasbury/mini) - Golang package for parsing ini-style configuration files.
 * [store](https://github.com/tucnak/store) - Lightweight configuration manager for Go.
 * [viper](https://github.com/spf13/viper) - Go configuration with fangs.
@@ -1675,7 +1676,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [kala](https://github.com/ajvb/kala) - Simplistic, modern, and performant job scheduler.
 * [kcli](https://github.com/cswank/kcli) - Command line tool for inspecting kafka topics/partitions/messages.
 * [kubernetes](https://github.com/kubernetes/kubernetes) - Container Cluster Manager from Google.
-* [lstags](https://github.com/ivanilves/lstags) - Tool and API to sync Docker images across different registries. 
+* [lstags](https://github.com/ivanilves/lstags) - Tool and API to sync Docker images across different registries.
 * [lwc](https://github.com/timdp/lwc) - A live-updating version of the UNIX wc command.
 * [manssh](https://github.com/xwjdsh/manssh) - manssh is a command line tool for managing your ssh alias config easily.
 * [Moby](https://github.com/moby/moby) - Collaborative project for the container ecosystem to assemble container-based systems.


### PR DESCRIPTION
This is a pull request to add [kelseyhightower/envconfig](https://github.com/kelseyhightower/envconfig). I believe these meet the [quality standards](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

**Package links:**

- github.com repo: https://github.com/kelseyhightower/envconfig
- godoc.org: https://godoc.org/github.com/kelseyhightower/envconfig
- goreportcard.com: [![Go Report Card](https://goreportcard.com/badge/github.com/kelseyhightower/envconfig)](https://goreportcard.com/report/github.com/kelseyhightower/envconfig)
- coverage service link: [cover.run](http://cover.run/go/github.com/kelseyhightower/envconfig?tag=golang-1.10)

Checklist:

- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
