### PR TITLE
Add google/subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [readline](https://github.com/chzyer/readline) - Pure golang implementation that provides most features in GNU-Readline under MIT license.
 * [sflags](https://github.com/octago/sflags) - Struct based flags generator for flag, urfave/cli, pflag, cobra, kingpin and other libraries.
 * [strumt](https://github.com/antham/strumt) - Library to create prompt chain.
+* [subcommands](https://github.com/google/subcommands) - Library to break up CLI applications into various subcommands.
 * [ukautz/clif](https://github.com/ukautz/clif) - Small command line interface framework.
 * [urfave/cli](https://github.com/urfave/cli) - Simple, fast, and fun package for building command line apps in Go (formerly codegangsta/cli).
 * [wlog](https://github.com/dixonwille/wlog) - Simple logging interface that supports cross-platform color and concurrency.


### PR DESCRIPTION
**Please provide package links to:**

- github.com repo: https://github.com/google/subcommands
- godoc.org: https://godoc.org/github.com/google/subcommands
- goreportcard.com: https://goreportcard.com/report/google/subcommands
- coverage service link: [![cover.run](https://cover.run/go/https:/github.com/google/subcommands.svg?style=flat&tag=golang-1.10)](https://cover.run/go?tag=golang-1.10&repo=https%3A%2Fgithub.com%2Fgoogle%2Fsubcommands) 

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
