### PR TITLE
Add awless, command line interface for AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1672,6 +1672,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 * [aptly](https://github.com/smira/aptly) - aptly is a Debian repository management tool.
 * [aurora](https://github.com/xuri/aurora) - Cross-platform web-based Beanstalkd queue server console.
+* [awless](https://github.com/wallix/awless) - A powerful, innovative and small surface command line interface to manage Amazon Web Services (AWS).
 * [awsenv](https://github.com/soniah/awsenv) - Small binary that loads Amazon (AWS) environment variables for a profile.
 * [Banshee](https://github.com/eleme/banshee) - Anomalies detection system for periodic metrics.
 * [Blast](https://github.com/dave/blast) - A simple tool for API load testing and batch jobs.


### PR DESCRIPTION
Hi, 
I propose again to add `awless` to awesome-go as we now have more than 3.7k stars on Github, and we refactored our code to improve the go-report-card score. Note that the test coverage score is not very good, but it is mostly because of big generated files (they are based on `aws-sdk-go` interfaces) and some parts are tested directly against AWS cloud in [integration tests](https://github.com/wallix/awless/blob/master/smoke_tests/smoke_test.sh). Godoc is not on our repo, as we do not build a library but a CLI tool and we favor clear code and well-chosen names, rather than adding comments.

---

**Please provide package links to:**

- github.com repo: https://github.com/wallix/awless
- godoc.org: https://godoc.org/github.com/wallix/awless/template
- goreportcard.com: https://goreportcard.com/report/github.com/wallix/awless
- coverage service link: [![Coverage Status](https://coveralls.io/repos/github/wallix/awless/badge.svg?branch=master)](https://coveralls.io/github/wallix/awless?branch=master)

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [ ] I have added godoc link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Thanks for this repo, you're awesome! :+1:
