### PR TITLE
add qframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1062,6 +1062,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [orb](https://github.com/paulmach/orb) - 2D geometry types with clipping, GeoJSON and Mapbox Vector Tile support.
 * [pagerank](https://github.com/alixaxel/pagerank) - Weighted PageRank algorithm implemented in Go.
 * [PiHex](https://github.com/claygod/PiHex) - Implementation of the "Bailey-Borwein-Plouffe" algorithm for the hexadecimal number Pi.
+* [QFrame](https://github.com/tobgu/qframe) - QFrame is an immutable data frame that support filtering, aggregation and data manipulation.
 * [sparse](https://github.com/james-bowman/sparse) - Go Sparse matrix formats for linear algebra supporting scientific and machine learning applications, compatible with gonum matrix libraries.
 * [stats](https://github.com/montanaflynn/stats) - Statistics package with common functions missing from the Golang standard library.
 * [streamtools](https://github.com/nytlabs/streamtools) - general purpose, graphical tool for dealing with streams of data.


### PR DESCRIPTION
This PR adds [QFrame](https://github.com/tobgu/qframe), an awesome Go dataframe package.

**Please provide package links to:**

- github.com repo: https://github.com/tobgu/qframe
- godoc.org: https://godoc.org/github.com/tobgu/qframe
- goreportcard.com: https://goreportcard.com/report/github.com/tobgu/qframe
- coverage service link:  [![gocover.run](https://gocover.run/github.com/tobgu/qframe.svg?style=flat&tag=1.10)](https://gocover.run?tag=1.10&repo=github.com%2Ftobgu%2Fqframe) `

**Note**: that new categories can be added only when there are 3 packages or more.

**Make sure that you've checked the boxes below before you submit PR:**

 I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

@tobgu