### PR TITLE
add Acra, database protection suite [security]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,6 +1089,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 *Libraries that are used to help make your application more secure.*
 
 * [acmetool](https://github.com/hlandau/acme) - ACME (Let's Encrypt) client tool with automatic renewal.
+* [acra](https://github.com/cossacklabs/acra) - Network encryption proxy to protect database-based applications from data leaks: strong selective encryption, SQL injections prevention, intrusion detection system.
 * [argon2pw](https://github.com/raja/argon2pw) - Argon2 password hash generation with constant-time password comparison.
 * [autocert](https://godoc.org/golang.org/x/crypto/acme/autocert) - Auto provision Let's Encrypt certificates and start a TLS server.
 * [BadActor](https://github.com/jaredfolkins/badactor) - In-memory, application-driven jailer built in the spirit of fail2ban.


### PR DESCRIPTION
[Acra](https://github.com/cossacklabs/acra) is not a single library, but a set of client-side and server-side services, working as network encryption proxy to protect database-based applications from data leaks, combining strong selective encryption, SQL injections prevention and intrusion detection system.

**Please provide package links to:**

- github.com repo: https://github.com/cossacklabs/acra/
- godoc.org: [![](https://godoc.org/github.com/cossacklabs/acra?status.svg)](https://godoc.org/github.com/cossacklabs/acra)
- goreportcard.com: [![](https://goreportcard.com/badge/github.com/cossacklabs/acra)](https://goreportcard.com/report/github.com/cossacklabs/acra)
- coverage service link  [![](https://coveralls.io/repos/github/cossacklabs/themis/badge.svg?branch=master)](https://coveralls.io/github/cossacklabs/themis)

This is coverage of cryptography library [goThemis](https://github.com/cossacklabs/themis), that Acra is using under the hood to perform crypto-computations. Due to specific of Acra functionality (network and database connections proxying), most Acra code is covered by [python integration tests](https://github.com/cossacklabs/acra/tree/master/tests).

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
