### PR TITLE
Add triangolatte

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,7 +1093,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [stats](https://github.com/montanaflynn/stats) - Statistics package with common functions missing from the Golang standard library.
 * [streamtools](https://github.com/nytlabs/streamtools) - general purpose, graphical tool for dealing with streams of data.
 * [TextRank](https://github.com/DavidBelicza/TextRank) - TextRank implementation in Golang with extendable features (summarization, weighting, phrase extraction) and multithreading (goroutine) support.
-* [triangolatte](https://github.com/tchayen/triangolatte) – 2D triangulation library. Allows translating lines and polygons (both based on points) to the language of GPUs.
+* [triangolatte](https://github.com/tchayen/triangolatte) - 2D triangulation library. Allows translating lines and polygons (both based on points) to the language of GPUs.
 * [vectormath](https://github.com/spate/vectormath) - Vectormath for Go, an adaptation of the scalar C functions from Sony's Vector Math library, as found in the Bullet-2.79 source code (currently inactive).
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -1093,6 +1093,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [stats](https://github.com/montanaflynn/stats) - Statistics package with common functions missing from the Golang standard library.
 * [streamtools](https://github.com/nytlabs/streamtools) - general purpose, graphical tool for dealing with streams of data.
 * [TextRank](https://github.com/DavidBelicza/TextRank) - TextRank implementation in Golang with extendable features (summarization, weighting, phrase extraction) and multithreading (goroutine) support.
+* [triangolatte](https://github.com/tchayen/triangolatte) – 2D triangulation library. Allows translating lines and polygons (both based on points) to the language of GPUs.
 * [vectormath](https://github.com/spate/vectormath) - Vectormath for Go, an adaptation of the scalar C functions from Sony's Vector Math library, as found in the Bullet-2.79 source code (currently inactive).
 
 ## Security


### PR DESCRIPTION
Hi. I'd like to add my computational geometry library which does triangulation of lines and polygons. Below are the required things. Please let me know if you have some more requests or if something is missing.

Thanks for your time!

[triangolatte](https://github.com/tchayen/triangolatte) – 2D triangulation library. Allows translating lines and polygons (both based on points) to the language of GPUs.

[![](https://godoc.org/github.com/tchayen/triangolatte?status.svg)](https://godoc.org/github.com/tchayen/triangolatte)

[![](https://goreportcard.com/badge/github.com/tchayen/triangolatte)](https://goreportcard.com/report/github.com/tchayen/triangolatte)

[![](https://coveralls.io/repos/github/tchayen/triangolatte/badge.svg?branch=master)](https://coveralls.io/github/tchayen/triangolatte?branch=master)

- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read contribution guidelines, maintainers note and quality standards.
