### PR TITLE
Fix goreportcard URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ If you removed our PR template you can find it [here](https://github.com/avelino
 
 ## Quality standards
 
-To be on the list, project repositories should adhere to these quality standards (http://goreportcard.com/ **github_user** / **github_repo**):
+To be on the list, project repositories should adhere to these quality standards (https://goreportcard.com/report/github.com/ **github_user** / **github_repo**):
 
 - Code functions as documented and expected
 - Generally useful to the wider community of Go programmers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ If you removed our PR template you can find it [here](https://github.com/avelino
 
 ## Quality standards
 
-To be on the list, project repositories should adhere to these quality standards (http://goreportcard.com/report/ **github_user** / **github_repo**):
+To be on the list, project repositories should adhere to these quality standards (http://goreportcard.com/ **github_user** / **github_repo**):
 
 - Code functions as documented and expected
 - Generally useful to the wider community of Go programmers


### PR DESCRIPTION
Fixed the goreportcard URL by removing the "report" part which was leading to a 404 page. Now the URL points to the homepage, I assume this is what was intended.
