### PR TITLE
Removed music-theory is obsolete since 2012

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [minimp3](https://github.com/tosone/minimp3) - Lightweight MP3 decoder library.
 * [mix](https://github.com/go-mix/mix) - Sequence-based Go-native audio mixer for music apps.
 * [mp3](https://github.com/tcolgate/mp3) - Native Go MP3 decoder.
-* [music-theory](https://github.com/go-music-theory/music-theory) - Music theory models in Go.
 * [PortAudio](https://github.com/gordonklaus/portaudio) - Go bindings for the PortAudio audio I/O library.
 * [portmidi](https://github.com/rakyll/portmidi) - Go bindings for PortMidi.
 * [taglib](https://github.com/wtolson/go-taglib) - Go bindings for taglib.


### PR DESCRIPTION
https://github.com/go-music-theory/music-theory is obsolete since 2015.