### PR TITLE
Remove spate/vectormath

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,7 +1114,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [streamtools](https://github.com/nytlabs/streamtools) - general purpose, graphical tool for dealing with streams of data.
 * [TextRank](https://github.com/DavidBelicza/TextRank) - TextRank implementation in Golang with extendable features (summarization, weighting, phrase extraction) and multithreading (goroutine) support.
 * [triangolatte](https://github.com/tchayen/triangolatte) - 2D triangulation library. Allows translating lines and polygons (both based on points) to the language of GPUs.
-* [vectormath](https://github.com/spate/vectormath) - Vectormath for Go, an adaptation of the scalar C functions from Sony's Vector Math library, as found in the Bullet-2.79 source code (currently inactive).
 
 ## Security
 


### PR DESCRIPTION
https://github.com/spate/vectormath
No docs, no tests, no #examples

closes #2044 