### PR TITLE
Add mimetype package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1480,6 +1480,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [mc](https://github.com/minio/mc) - Minio Client provides minimal tools to work with Amazon S3 compatible cloud storage and filesystems.
 * [mergo](https://github.com/imdario/mergo) - Helper to merge structs and maps in Golang. Useful for configuration default values, avoiding messy if-statements.
 * [mimemagic](https://github.com/zRedShift/mimemagic) - Pure Go ultra performant MIME sniffing library/utility.
+* [mimetype](https://github.com/gabriel-vasile/mimetype) - Package for MIME type detection based on magic numbers.
 * [minify](https://github.com/tdewolff/minify) - Fast minifiers for HTML, CSS, JS, XML, JSON and SVG file formats.
 * [minquery](https://github.com/icza/minquery) - MongoDB / mgo.v2 query that supports efficient pagination (cursors to continue listing documents where we left off).
 * [mmake](https://github.com/tj/mmake) - Modern Make.


### PR DESCRIPTION
Hello, these are the links to the `mimetype` package:

- github.com repo: https://github.com/gabriel-vasile/mimetype
- godoc.org: https://godoc.org/github.com/gabriel-vasile/mimetype
- goreportcard.com: https://goreportcard.com/report/github.com/gabriel-vasile/mimetype
- coverage service link: [coveralls.io/github/gabriel-vasile/mimetype](https://coveralls.io/github/gabriel-vasile/mimetype)

Thanks for your time!