### PR TITLE
Add OpenFaas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1837,6 +1837,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [myLG](https://github.com/mehrdadrad/mylg) - Command Line Network Diagnostic tool written in Go.
 * [naclpipe](https://github.com/unix4fun/naclpipe) - Simple NaCL EC25519 based crypto pipe tool written in Go.
 * [nes](https://github.com/fogleman/nes) - Nintendo Entertainment System (NES) emulator written in Go.
+* [OpenFaas](https://www.openfaas.com/) - Serverless Functions framework for Docker and Kubernetes written in Go.
 * [orange-cat](https://github.com/noraesae/orange-cat) - Markdown previewer written in Go.
 * [Orbit](https://github.com/gulien/orbit) - A simple tool for running commands and generating files from templates.
 * [peg](https://github.com/pointlander/peg) - Peg, Parsing Expression Grammar, is an implementation of a Packrat parser generator.


### PR DESCRIPTION
I met OpenFaas recently. It is a framework written in Go for developing Function As A Service apps. It is one of the most popular projects on GitHub, with over 11,000 stars. It is a great project to list! :)

**Package links to:**

- [github.com repo](https://github.com/openfaas/faas)
- [godoc.org](https://godoc.org/github.com/openfaas/faas)
- [goreportcard.com](https://goreportcard.com/report/github.com/openfaas/faas)
- coverage service link:  
  [![cover.run](https://cover.run/go/https:/github.com/openfaas/faas/.svg?style=flat&tag=golang-1.10)](https://cover.run/go?tag=golang-1.10&repo=https%3A%2Fgithub.com%2Fopenfaas%2Ffaas%2F)


--
- [X] Package meets [quality standards](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard)
- [X] I have added my package in alphabetical order.
- [X] I have an appropriate description with correct grammar.
- [X] I know that this package was not listed before.
- [X] I have added godoc link to the repo and to my pull request.
- [X] I have added goreportcard link to the repo and to my pull request.
- [X] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard)
- [ ] I didn't find coverage service link at the repo, but I added the link to my pull request.
