### PR TITLE
Add MailYak to email section

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [Hectane](https://github.com/hectane/hectane) - Lightweight SMTP client providing an HTTP API.
 * [hermes](https://github.com/matcornic/hermes) - Golang package that generates clean, responsive HTML e-mails.
 * [MailHog](https://github.com/mailhog/MailHog) - Email and SMTP testing with web and API interface.
+* [MailYak](https://github.com/domodwyer/mailyak) - Elegant MIME/SMTP email library with support for attachments.
 * [SendGrid](https://github.com/sendgrid/sendgrid-go) - SendGrid's Go library for sending email.
 * [smtp](https://github.com/mailhog/smtp) - SMTP server protocol state machine.
 


### PR DESCRIPTION
[MailYak](https://github.com/domodwyer/mailyak) is a good package and it would be nice to see it listed on awesome go.

[![Build Status](https://travis-ci.org/domodwyer/mailyak.svg?branch=master)](https://travis-ci.org/domodwyer/mailyak) [![GoDoc](https://godoc.org/github.com/domodwyer/mailyak?status.svg)](https://godoc.org/github.com/domodwyer/mailyak)


- [x] I have added the MailYak package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request.
- [ ] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-