### PR TITLE
add bbolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,9 +310,9 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 *Databases implemented in Go.*
 
 * [badger](https://github.com/dgraph-io/badger) - Fast key-value store in Go.
+* [bbolt](https://github.com/etcd-io/bbolt) - Maintained and actively developed fork of bolt.
 * [BigCache](https://github.com/allegro/bigcache) - Efficient key/value cache for gigabytes of data.
 * [bolt](https://github.com/boltdb/bolt) - Low-level key/value database for Go.
-* [bbolt](https://github.com/etcd-io/bbolt) - Maintained and actively developed fork of bolt.
 * [buntdb](https://github.com/tidwall/buntdb) - Fast, embeddable, in-memory key/value database for Go with custom indexing and spatial support.
 * [cache2go](https://github.com/muesli/cache2go) - In-memory key:value cache which supports automatic invalidation based on timeouts.
 * [clusteredBigCache](https://github.com/oaStuff/clusteredBigCache) - BigCache with clustering support and individual item expiration.

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [badger](https://github.com/dgraph-io/badger) - Fast key-value store in Go.
 * [BigCache](https://github.com/allegro/bigcache) - Efficient key/value cache for gigabytes of data.
 * [bolt](https://github.com/boltdb/bolt) - Low-level key/value database for Go.
+* [bbolt](https://github.com/etcd-io/bbolt) - Maintained and actively developed fork of bolt.
 * [buntdb](https://github.com/tidwall/buntdb) - Fast, embeddable, in-memory key/value database for Go with custom indexing and spatial support.
 * [cache2go](https://github.com/muesli/cache2go) - In-memory key:value cache which supports automatic invalidation based on timeouts.
 * [clusteredBigCache](https://github.com/oaStuff/clusteredBigCache) - BigCache with clustering support and individual item expiration.


### PR DESCRIPTION
Added bbolt as an alternative to bolt

I am not even sure if the bolt repository meets the requirements anymore. It is a stable still used database, but it is not actively maintained or developed. Since the project is complete, i would suggest to just keep it here, however it should still be discussed. (#2036)

- github.com repo: https://github.com/etcd-io/bbolt
- godoc.org: https://godoc.org/github.com/etcd-io/bbolt
- goreportcard.com: https://goreportcard.com/report/github.com/etcd-io/bbolt
- coverage service link https://codecov.io/gh/etcd-io/bbolt

