### PR TITLE
Remove go.uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,7 +882,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [go-resiliency](https://github.com/eapache/go-resiliency) - Resiliency patterns for golang.
 * [go-sarah](https://github.com/oklahomer/go-sarah) - Framework to build bot for desired chat services including LINE, Slack, Gitter and more.
 * [go-unarr](https://github.com/gen2brain/go-unarr) - Decompression library for RAR, TAR, ZIP and 7z archives.
-* [go.uuid](https://github.com/satori/go.uuid) - Implementation of Universally Unique Identifier (UUID). Supported both creation and parsing of UUIDs.
 * [gofakeit](https://github.com/brianvoe/gofakeit) - Random data generator written in go.
 * [goid](https://github.com/jakehl/goid) - Generate and Parse RFC4122 compliant V4 UUIDs.
 * [gommit](https://github.com/antham/gommit) - Analyze git commit messages to ensure they follow defined patterns


### PR DESCRIPTION
go.uuid is currently the most starred uuid repo for go. However, it is basically unmaintained and contained at least one critical security, which has been fixed by PR but took half a year to be merged, since the owner is not really active (satori/go.uuid#75). There is an actively maintained fork at https://github.com/gofrs/uuid which is already listed here already. go.uuid should be removed.

See 
satori/go.uuid#75
satori/go.uuid#73
https://github.com/gofrs/uuid#project-history