### PR TITLE
Change osin URL/Remove osin?

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [jwt-go](https://github.com/dgrijalva/jwt-go) - Golang implementation of JSON Web Tokens (JWT).
 * [loginsrv](https://github.com/tarent/loginsrv) - JWT login microservice with plugable backends such as OAuth2 (Github), htpasswd, osiam.
 * [oauth2](https://github.com/golang/oauth2) - Successor of goauth2. Generic OAuth 2.0 package that comes with JWT, Google APIs, Compute Engine and App Engine support.
-* [osin](https://github.com/RangelReale/osin) - Golang OAuth2 server library.
+* [osin](https://github.com/openshift/osin) - Golang OAuth2 server library.
 * [paseto](https://github.com/o1egl/paseto) - Golang implementation of Platform-Agnostic Security Tokens (PASETO)
 * [permissions2](https://github.com/xyproto/permissions2) - Library for keeping track of users, login states and permissions. Uses secure cookies and bcrypt.
 * [rbac](https://github.com/zpatrick/rbac) - Minimalistic RBAC package for Go applications.


### PR DESCRIPTION
While searching an oauth framework, i found osin pointing to https://github.com/RangelReale/osin which has been archived. It is a fork of https://github.com/openshift/osin which is even with the fork, so the link should be changed. 

However, it does not seem very active at all. So maybe it should be removed entirely? I am interested in other opinions here.