### PR TITLE
Add gofuckyourself

### DIFF
--- a/README.md
+++ b/README.md
@@ -1319,6 +1319,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
     * [syndfeed](https://github.com/zhengchun/syndfeed) - A syndication feed for Atom 1.0 and RSS 2.0.
     * [toml](https://github.com/BurntSushi/toml) - TOML configuration format (encoder/decoder with reflection).
 * Utility
+    * [gofuckyourself](https://github.com/JoshuaDoes/gofuckyourself) - A sanitization-based swear filter for Go.
     * [gotabulate](https://github.com/bndr/gotabulate) - Easily pretty-print your tabular data with Go.
     * [kace](https://github.com/codemodus/kace) - Common case conversions covering common initialisms.
     * [parseargs-go](https://github.com/nproc/parseargs-go) - string argument parser that understands quotes and backslashes.


### PR DESCRIPTION
Adding the `github.com/JoshuaDoes/gofuckyourself` package to `Text Processing` -> `Utility`.

**Links**:

- github.com repo: https://github.com/JoshuaDoes/gofuckyourself
- godoc.org: https://godoc.org/github.com/JoshuaDoes/gofuckyourself
- goreportcard.com: https://goreportcard.com/report/github.com/JoshuaDoes/gofuckyourself
- coverage service link: [![cover.run](https://cover.run/go/github.com/JoshuaDoes/gofuckyourself.svg?style=flat&tag=golang-1.10)](https://cover.run/go?tag=golang-1.10&repo=github.com%2FJoshuaDoes%2Fgofuckyourself)

**I confirm that**:

- [✓] I have added my package in alphabetical order.
- [✓] I have an appropriate description with proper grammar.
- [✓] I know that this package was not listed before.
- [✓] I have added the godoc link to the repo and to my pull request.
- [✓] I have added the coverage service link to the repo and to my pull request.
- [✓] I have added the goreportcard link to the repo and to my pull request.
- [✓] I have read the [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).