### PR TITLE
Deprecate github.com/toby3d/go-telegraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1377,7 +1377,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [go-myanimelist](https://github.com/nstratos/go-myanimelist) - Go client library for accessing the [MyAnimeList API](http://myanimelist.net/modules.php?go=api).
 * [go-sophos](https://github.com/esurdam/go-sophos) - Go client library for the [Sophos UTM REST API](https://www.sophos.com/en-us/medialibrary/PDFs/documentation/UTMonAWS/Sophos-UTM-RESTful-API.pdf?la=en) with zero dependencies.
 * [go-sptrans](https://github.com/sergioaugrod/go-sptrans) - Go client library for the SPTrans Olho Vivo API.
-* [go-telegraph](https://github.com/toby3d/go-telegraph) - Telegraph publishing platform API client.
 * [go-tgbot](https://github.com/olebedev/go-tgbot) - Pure Golang Telegram Bot API wrapper, generated from swagger file, session-based router and middleware.
 * [go-trending](https://github.com/andygrunwald/go-trending) - Go library for accessing [trending repositories](https://github.com/trending) and [developers](https://github.com/trending/developers) at Github.
 * [go-twitch](https://github.com/knspriggs/go-twitch) - Go client for interacting with the Twitch v3 API.


### PR DESCRIPTION
`github.com/toby3d/go-telegraph` is archived. Should we remove it?

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
