### PR TITLE
fixed install github_flavored_markdown package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine
 
 RUN apk add --update -t build-deps curl go git libc-dev gcc libgcc
-RUN go get github.com/russross/blackfriday github.com/gorilla/mux
+RUN go get -u -v github.com/shurcooL/github_flavored_markdown/... github.com/gorilla/mux
 
 WORKDIR /srv
 


### PR DESCRIPTION
ref: #1903 

stdout:
```
awesome-go ~/awesome-go > docker-compose up webhook
Starting awesomego_webhook_1
Attaching to awesomego_webhook_1
webhook_1  | repo.go:11:2: cannot find package "github.com/shurcooL/github_flavored_markdown" in any of:
webhook_1  |    /usr/local/go/src/github.com/shurcooL/github_flavored_markdown (from $GOROOT)
webhook_1  |    /go/src/github.com/shurcooL/github_flavored_markdown (from $GOPATH)
awesomego_webhook_1 exited with code 1
```