### PR TITLE
Adding uber/dig

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,6 +977,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 *Libraries for working with dependency injection.*
 
 * [alice](https://github.com/magic003/alice) - Additive dependency injection container for Golang.
+* [dig](https://github.com/uber-go/dig) - A reflection based dependency injection toolkit for Go.
 * [wire](https://github.com/Fs02/wire) - Strict Runtime Dependency Injection for Golang.
 
 ### Strings


### PR DESCRIPTION
Hello, I see uber-go/dig is missing.

- github.com repo: https://github.com/uber-go/dig
- godoc.org: https://godoc.org/go.uber.org/dig
- goreportcard.com: https://goreportcard.com/report/github.com/uber-go/dig
- coverage service link https://codecov.io/gh/uber-go/dig/branch/master

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).