### PR TITLE
Add go-flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,6 +740,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [app](https://github.com/murlokswarm/app) - Package to create apps with GO, HTML and CSS. Supports: MacOS, Windows in progress.
 * [fyne](https://github.com/fyne-io/fyne) - Cross platform native GUIs designed for Go, rendered using EFL. Supports: Linux, macOS, Windows.
 * [go-astilectron](https://github.com/asticode/go-astilectron) - Build cross platform GUI apps with GO and HTML/JS/CSS (powered by Electron).
+* [go-flutter](https://github.com/go-flutter-desktop/go-flutter) - Go bindings/embedder for [Flutter](https://flutter.dev/). Release apps to Windows, Mac OSX and Linux. Support for native/pure-Go plugins.
 * [go-gtk](http://mattn.github.io/go-gtk/) - Go bindings for GTK.
 * [go-sciter](https://github.com/sciter-sdk/go-sciter) - Go bindings for Sciter: the Embeddable HTML/CSS/script engine for modern desktop UI development. Cross platform.
 * [gotk3](https://github.com/gotk3/gotk3) - Go bindings for GTK3.


### PR DESCRIPTION
- github.com repo: https://github.com/go-flutter-desktop/go-flutter
- godoc.org: https://godoc.org/github.com/go-flutter-desktop/go-flutter
- goreportcard.com:https://goreportcard.com/report/github.com/go-flutter-desktop/go-flutter
- coverage: https://gocover.io/github.com/go-flutter-desktop/go-flutter/plugin
