### PR TITLE
Add gondolier database schema migration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [darwin](https://github.com/GuiaBolso/darwin) - Database schema evolution library for Go.
 * [go-fixtures](https://github.com/RichardKnop/go-fixtures) - Django style fixtures for Golang's excellent built-in database/sql library.
 * [go-pg-migrations](https://github.com/robinjoseph08/go-pg-migrations) - A Go package to help write migrations with go-pg/pg.
+* [gondolier](https://github.com/emvi/gondolier) - Database migration library using struct decorators.
 * [goose](https://github.com/steinbacher/goose) - Database migration tool. You can manage your database's evolution by creating incremental SQL or Go scripts.
 * [gormigrate](https://github.com/go-gormigrate/gormigrate) - Database schema migration helper for Gorm ORM.
 * [migrate](https://github.com/golang-migrate/migrate) - Database migrations. CLI and Golang library.


### PR DESCRIPTION
- github.com repo: https://github.com/emvi/gondolier
- godoc.org: https://godoc.org/github.com/emvi/gondolier
- goreportcard.com: https://goreportcard.com/report/github.com/emvi/gondolier
- coverage service link: https://circleci.com/gh/emvi/gondolier (90.5%)

I've removed this library because I did not intend to support it anymore, but I changed my mind. So this PR re-adds Gondolier with updated link and some code quality improvements (100% on goreportcard + fixed CircleCI build).