### PR TITLE
Add sslmgr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1307,6 +1307,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [secure](https://github.com/unrolled/secure) - HTTP middleware for Go that facilitates some quick security wins.
 * [simple-scrypt](https://github.com/elithrar/simple-scrypt) - Scrypt package with a simple, obvious API and automatic cost calibration built-in.
 * [ssh-vault](https://github.com/ssh-vault/ssh-vault) - encrypt/decrypt using ssh keys.
+* [sslmgr](https://github.com/adrianosela/sslmgr) - SSL certificates made easy with a high level wrapper around acme/autocert 
 
 ## Serialization
 

--- a/README.md
+++ b/README.md
@@ -1307,7 +1307,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [secure](https://github.com/unrolled/secure) - HTTP middleware for Go that facilitates some quick security wins.
 * [simple-scrypt](https://github.com/elithrar/simple-scrypt) - Scrypt package with a simple, obvious API and automatic cost calibration built-in.
 * [ssh-vault](https://github.com/ssh-vault/ssh-vault) - encrypt/decrypt using ssh keys.
-* [sslmgr](https://github.com/adrianosela/sslmgr) - SSL certificates made easy with a high level wrapper around acme/autocert 
+* [sslmgr](https://github.com/adrianosela/sslmgr) - SSL certificates made easy with a high level wrapper around acme/autocert.
 
 ## Serialization
 


### PR DESCRIPTION
A high level wrapper around acme/autocert, hoping to get everyone to always use SSL even for trivial projects.

Links:
github.com repo: https://github.com/adrianosela/sslmgr
godoc.org: https://godoc.org/github.com/adrianosela/sslmgr
goreportcard.com: https://goreportcard.com/report/github.com/adrianosela/sslmgr
Coverage Service: https://gocover.io/github.com/adrianosela/sslmgr

(Edited coverage since PR was created)
```
09:44 $ go test --cover
.............................
29 total assertions
...
32 total assertions
...
36 total assertions

PASS
coverage: 81.4% of statements
ok  	github.com/adrianosela/sslmgr	0.070s
```
Tested all testable packages

- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x]  I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read Contribution guidelines, maintainers note and Quality standard.
