### PR TITLE
Add `hashicorp/terraform`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1978,6 +1978,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [sg](https://github.com/ChristopherRabotin/sg) - Benchmarks a set of HTTP endpoints (like ab), with possibility to use the response code and data between each call for specific server stress based on its previous response.
 * [skm](https://github.com/TimothyYe/skm) - SKM is a simple and powerful SSH Keys Manager, it helps you to manage your multiple SSH keys easily!
 * [StatusOK](https://github.com/sanathp/statusok) - Monitor your Website and REST APIs.Get Notified through Slack, E-mail when your server is down or response time is more than expected.
+* [terraform](https://github.com/hashicorp/terraform) - Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.
 * [traefik](https://github.com/containous/traefik) - Reverse proxy and load balancer with support for multiple backends.
 * [Vegeta](https://github.com/tsenart/vegeta) - HTTP load testing tool and library. It's over 9000!
 * [webhook](https://github.com/adnanh/webhook) - Tool which allows user to create HTTP endpoints (hooks) that execute commands on the server.


### PR DESCRIPTION
I've noticed that Terraform hasn't been added yet.

**Please provide package links to:**

- github.com repo: https://github.com/hashicorp/terraform
- godoc.org: https://godoc.org/github.com/hashicorp/terraform
- goreportcard.com: https://goreportcard.com/report/github.com/hashicorp/terraform
- coverage service: none