### PR TITLE
Added gosddl package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1844,6 +1844,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 * [d3d9](https://github.com/gonutz/d3d9) - Go bindings for Direct3D9.
 * [go-ole](https://github.com/go-ole/go-ole) - Win32 OLE implementation for golang.
+* [gosddl](https://github.com/MonaxGT/gosddl) - Converter from SDDL-string to user-friendly JSON. SDDL consist of four part: Owner, Primary Group, DACL, SACL.
 
 ## XML
 


### PR DESCRIPTION
Converter from SDDL-string to user-friendly JSON. SDDL consist of four part: Owner, Primary Group, DACL, SACL. 

**Package links to:**

- github.com repo: https://github.com/MonaxGT/gosddl
- godoc.org: https://godoc.org/github.com/MonaxGT/gosddl
- goreportcard.com: https://goreportcard.com/report/github.com/MonaxGT/gosddl
- https://codeclimate.com/github/MonaxGT/gosddl/maintainability
- coverage service link : https://gocover.io/github.com/MonaxGT/gosddl