### PR TITLE
Added gomalshare package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1540,6 +1540,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [go-unsplash](https://github.com/hbagdi/go-unsplash) - Go client library for the [Unsplash.com](https://unsplash.com) API.
 * [go-xkcd](https://github.com/nishanths/go-xkcd) - Go client for the xkcd API.
 * [golyrics](https://github.com/mamal72/golyrics) - Golyrics is a Go library to fetch music lyrics data from the Wikia website.
+* [gomalshare](https://github.com/MonaxGT/gomalshare) - Go library MalShare API [malshare.com](http://www.malshare.com/)
 * [GoMusicBrainz](https://github.com/michiwend/gomusicbrainz) - Go MusicBrainz WS2 client library.
 * [google](https://github.com/google/google-api-go-client) - Auto-generated Google APIs for Go.
 * [google-analytics](https://github.com/chonthu/go-google-analytics) - Simple wrapper for easy google analytics reporting.


### PR DESCRIPTION
MalShare is a free Malware repository providing researchers access to samples, malicous feeds, and Yara results.

**Package links to:**

- github.com repo: https://github.com/MonaxGT/gomalshare
- godoc.org: https://godoc.org/github.com/MonaxGT/gomalshare
- goreportcard.com: https://goreportcard.com/report/github.com/MonaxGT/gomalshare
- https://app.codacy.com/app/MonaxGT/gomalshare?utm_source=github.com&utm_medium=referral&utm_content=MonaxGT/gomalshare&utm_campaign=Badge_Grade_Dashboard
- coverage service link : https://gocover.io/github.com/MonaxGT/gomalshare