### PR TITLE
Go modules are the official package management going forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -1212,7 +1212,11 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 ## Package Management
 
-*Official tooling for package management*
+*Official tooling for dependency and package management*
+
+* [go modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) - Modules are the unit of source code interchange and versioning. The go command has direct support for working with modules, including recording and resolving dependencies on other modules.
+
+*Official experimental tooling for package management*
 
 * [dep](https://github.com/golang/dep) - Go dependency tool.
 * [vgo](https://go.googlesource.com/vgo/) - Versioned Go.


### PR DESCRIPTION
As of Go v1.11, Go modules are the official, toolchain-supported mechanism for package and dependency management. They are available for use as of v1.11 and will be the default as of Go v1.13. See [this official blog post](https://blog.golang.org/modules2019) for further information.

Additionally, work on dep is now described as geared "primarily towards the development of an alternative prototype for versioning behavior in the toolchain" [_source_](https://github.com/golang/dep#dep).

As many users of Go will reference the awesome-go repo for suggestions and tooling, this PR is intended to guide users towards the official toolchain mechanism for package management.

**Links**

- github.com repo: https://github.com/golang/go/wiki/Modules
- godoc.org: N/A (https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more)
- goreportcard.com: N/A (part of Go toolchain)
- coverage service link: N/A (part of Go toolchain)

**Note**: that new categories can be added only when there are 3 packages or more.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [ ] I have added godoc link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request.
- [ ] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
