### PR TITLE
Add riemann-relay to Server Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1349,6 +1349,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [minio](https://github.com/minio/minio) - Minio is a distributed object storage server.
 * [nginx-prometheus](https://github.com/blind-oracle/nginx-prometheus) - Nginx log parser and exporter to Prometheus.
 * [nsq](http://nsq.io/) - A realtime distributed messaging platform.
+* [riemann-relay](https://github.com/blind-oracle/riemann-relay) - Relay to load-balance Riemann events and/or convert them to Carbon.
 * [RoadRunner](https://github.com/spiral/roadrunner) - High-performance PHP application server, load-balancer and process manager.
 * [yakvs](https://git.sci4me.com/sci4me/yakvs) - Small, networked, in-memory key-value store.
 


### PR DESCRIPTION
**Please provide package links to:**
- github.com repo: https://github.com/blind-oracle/riemann-relay
- godoc.org: Not applicable (server application)
- goreportcard.com: https://goreportcard.com/report/github.com/blind-oracle/riemann-relay
- coverage service link: https://coveralls.io/github/blind-oracle/riemann-relay

**Make sure that you've checked the boxes below before you submit PR:**
- [*] I have added my package in alphabetical order.
- [*] I have an appropriate description with correct grammar.
- [*] I know that this package was not listed before.
- [*] I have added coverage service link to the repo and to my pull request.
- [*] I have added goreportcard link to the repo and to my pull request.
- [*] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
