### PR TITLE
Update resgate

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [raft](https://github.com/hashicorp/raft) - Golang implementation of the Raft consensus protocol, by HashiCorp.
 * [raft](https://github.com/coreos/etcd/tree/master/raft) - Go implementation of the Raft consensus protocol, by CoreOS.
 * [redis-lock](https://github.com/bsm/redis-lock) - Simplified distributed locking implementation using Redis.
-* [resgate](https://resgate.io/) - An open-source Realtime API Gateway, compatible with REST and RPC APIs.
+* [resgate](https://resgate.io/) - Realtime API Gateway for building REST, real time, and RPC APIs, where all clients are synchronized seamlessly.
 * [ringpop-go](https://github.com/uber/ringpop-go) - Scalable, fault-tolerant application-layer sharding for Go applications.
 * [rpcx](https://github.com/smallnest/rpcx) - Distributed pluggable RPC service framework like alibaba Dubbo.
 * [sleuth](https://github.com/ursiform/sleuth) - Library for master-less p2p auto-discovery and RPC between HTTP services (using [ZeroMQ](https://github.com/zeromq/libzmq)).


### PR DESCRIPTION
Updated the description of *resgate*, previously added by @akeyboardlife (thanks washan!).

As the developer of the project, I wanted to clarify the description:

* Removed "open-source" info to reduce verbosity. The project is clearly marked MIT licensed.
* Clarified that you use it to build REST, real time, and RPC APIs (the word *compatible* was ambiguous).
* Added main purpose: keeping clients synchronized.

Thanks for the awesome-go project!