### PR TITLE
Add hasgo to generate tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1962,6 +1962,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [gonerics](http://github.com/bouk/gonerics) - Idiomatic Generics in Go.
 * [gotests](https://github.com/cweill/gotests) - Generate Go tests from your source code.
 * [gounit](https://github.com/hexdigest/gounit) - Generate Go tests using your own templates.
+* [hasgo](https://github.com/DylanMeeus/hasgo) - Generate Haskell inspired functions for your slices.
 * [re2dfa](https://github.com/opennota/re2dfa) - Transform regular expressions into finite state machines and output Go source code.
 * [TOML-to-Go](https://xuri.me/toml-to-go) - Translates TOML into a Go type in the browser instantly.
 


### PR DESCRIPTION
Hasgo (A code generator for Go slices influenced by Haskell)

- github.com repo: https://github.com/DylanMeeus/hasgo
- godoc.org: https://godoc.org/github.com/DylanMeeus/hasgo
- goreportcard.com:https://goreportcard.com/report/github.com/DylanMeeus/hasgo
- coverage service link: https://gocover.io/github.com/DylanMeeus/hasgo/types

(I ran the coverage on hasgo/types because those are the actual functions that get generated rather than other folder such as examples).

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).


