### PR TITLE
add sops (mozilla-services/sops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1364,6 +1364,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [passlib](https://github.com/hlandau/passlib) - Futureproof password hashing library.
 * [secure](https://github.com/unrolled/secure) - HTTP middleware for Go that facilitates some quick security wins.
 * [simple-scrypt](https://github.com/elithrar/simple-scrypt) - Scrypt package with a simple, obvious API and automatic cost calibration built-in.
+* [sops](https://github.com/mozilla-services/sops) - Encrypted files editor as a secrets managent solution using Shamir's Secret Sharing algorithm.
 * [ssh-vault](https://github.com/ssh-vault/ssh-vault) - encrypt/decrypt using ssh keys.
 * [sslmgr](https://github.com/adrianosela/sslmgr) - SSL certificates made easy with a high level wrapper around acme/autocert.
 


### PR DESCRIPTION
SOPS is an encryption at rest -- secrets management solution -- which allows teams to access secrets in encrypted files by having a minimum number of keys as per configuration, for example a personal PGP key and a shared AWS KMS  or GCP KMS key.

- github.com repo: https://github.com/mozilla-services/sops
- godoc.org: https://godoc.org/go.mozilla.org/sops
- goreportcard.com:  https://goreportcard.com/report/github.com/mozilla-services/sops
- coverage service link: https://gocover.io/go.mozilla.org/sops
Note that even though test coverage is hovering around the 50%, it is an in-production repository maintained by a dedicated team of professional engineers at Mozilla.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
