### PR TITLE
add Performance section, review some packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
     - [OpenGL](#opengl)
     - [ORM](#orm)
     - [Package Management](#package-management)
+    - [Performance](#performance)
     - [Query Language](#query-language)
     - [Resource Embedding](#resource-embedding)
     - [Science and Data Analysis](#science-and-data-analysis)
@@ -555,7 +556,6 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [gorpc](https://github.com/valyala/gorpc) - Simple, fast and scalable RPC library for high load.
 * [grpc-go](https://github.com/grpc/grpc-go) - The Go language implementation of gRPC. HTTP/2 based RPC.
 * [hprose](https://github.com/hprose/hprose-golang) - Very newbility RPC Library, support 25+ languages now.
-* [jaeger](https://github.com/jaegertracing/jaeger) - A distributed tracing system.
 * [jsonrpc](https://github.com/osamingo/jsonrpc) - The jsonrpc package helps implement of JSON-RPC 2.0.
 * [jsonrpc](https://github.com/ybbus/jsonrpc) - JSON-RPC 2.0 HTTP client implementation.
 * [KrakenD](https://github.com/devopsfaith/krakend) - Ultra performant API Gateway framework with middlewares.
@@ -1284,6 +1284,14 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [nut](https://github.com/jingweno/nut) - Vendor Go dependencies.
 * [VenGO](https://github.com/DamnWidget/VenGO) - create and manage exportable isolated go virtual environments.
 
+## Performance
+
+* [jaeger](https://github.com/jaegertracing/jaeger) - A distributed tracing system.
+* [opencensus](https://github.com/census-instrumentation/opencensus-go) - A stats collection and distributed tracing framework.
+* [opentracing](https://github.com/opentracing/opentracing-go) - OpenTracing API for Go.
+* [profile](https://github.com/pkg/profile) - Simple profiling support package for Go.
+* [tracer](https://github.com/kamilsk/tracer) - Simple, lightweight tracing.
+
 ## Query Language
 
 * [gojsonq](https://github.com/thedevsaddam/gojsonq) - A simple Go package to Query over JSON Data.
@@ -1684,7 +1692,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [go-problemdetails](https://github.com/mvmaasakkers/go-problemdetails) - Go package for working with Problem Details.
 * [go-rate](https://github.com/beefsack/go-rate) - Timed rate limiter for Go.
 * [go-sitemap-generator](https://github.com/ikeikeikeike/go-sitemap-generator) - XML Sitemap generator written in Go.
-* [go-torch](https://github.com/uber/go-torch) - Stochastic flame graph profiler for Go programs.
 * [go-trigger](https://github.com/sadlil/go-trigger) - Go-lang global event triggerer, Register Events with an id and trigger the event from anywhere from your project.
 * [goback](https://github.com/carlescere/goback) - Go simple exponential backoff package.
 * [godaemon](https://github.com/VividCortex/godaemon) - Utility to write daemons.
@@ -1724,7 +1731,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [mssqlx](https://github.com/linxGnu/mssqlx) - Database client library, proxy for any master slave, master master structures. Lightweight and auto balancing in mind.
 * [multitick](https://github.com/VividCortex/multitick) - Multiplexor for aligned tickers.
 * [myhttp](https://github.com/inancgumus/myhttp) - Simple API to make HTTP GET requests with timeout support.
-* [netbug](https://github.com/e-dard/netbug) - Easy remote profiling of your services.
 * [okrun](https://github.com/xta/okrun) - go run error steamroller.
 * [olaf](https://github.com/btnguyen2k/olaf) - Twitter Snowflake implemented in Go.
 * [onecache](https://github.com/adelowo/onecache) - Caching library with support for multiple backend stores (Redis, Memcached, filesystem etc).
@@ -1732,7 +1738,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [peco](https://github.com/peco/peco) - Simplistic interactive filtering tool.
 * [pgo](https://github.com/arthurkushman/pgo) - Convenient functions for PHP community.
 * [pm](https://github.com/VividCortex/pm) - Process (i.e. goroutine) manager with an HTTP API.
-* [profile](https://github.com/pkg/profile) - Simple profiling support package for Go.
 * [rclient](https://github.com/zpatrick/rclient) - Readable, flexible, simple-to-use client for REST APIs.
 * [realize](https://github.com/tockins/realize) - Go build system with file watchers and live reload. Run, build and watch file changes with custom paths.
 * [repeat](https://github.com/ssgreg/repeat) - Go implementation of different backoff strategies useful for retrying operations and heartbeating.
@@ -1758,7 +1763,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [structs](https://github.com/PumpkinSeed/structs) - Implement simple functions to manipulate structs.
 * [Task](https://github.com/go-task/task) - simple "Make" alternative.
 * [toolbox](https://github.com/viant/toolbox) - Slice, map, multimap, struct, function, data conversion utilities. Service router, macro evaluator, tokenizer.
-* [tracer](https://github.com/kamilsk/tracer) - Simple, lightweight tracing.
 * [ugo](https://github.com/alxrm/ugo) - ugo is slice toolbox with concise syntax for Go.
 * [UNIS](https://github.com/esemplastic/unis) - Common Architecture™ for String Utilities in Go.
 * [usql](https://github.com/knq/usql) - usql is a universal command-line interface for SQL databases.


### PR DESCRIPTION
I added new section related to performance issues.

### opentracing

- github.com repo: https://github.com/opentracing/opentracing-go
- godoc.org: https://godoc.org/github.com/opentracing/opentracing-go
- goreportcard.com: https://goreportcard.com/report/github.com/opentracing/opentracing-go
- coverage service: https://codecov.io/gh/opentracing/opentracing-go/branch/master/

### opencensus

- github.com repo: https://github.com/census-instrumentation/opencensus-go
- godoc.org: https://godoc.org/go.opencensus.io
- goreportcard.com: https://goreportcard.com/report/go.opencensus.io
- coverage service:
```
ok  go.opencensus.io/zpages                                  70.1%
ok  go.opencensus.io/trace/tracestate                        100.0%
ok  go.opencensus.io/trace/propagation                       100.0%
ok  go.opencensus.io/trace                                   60.3%
ok  go.opencensus.io/tag                                     71.4%
ok  go.opencensus.io/stats/view                              85.3%
ok  go.opencensus.io/stats                                   70.7%
ok  go.opencensus.io/resource                                79.6%
ok  go.opencensus.io/plugin/ochttp/propagation/tracecontext  86.3%
ok  go.opencensus.io/plugin/ochttp/propagation/b3            94.7%
ok  go.opencensus.io/plugin/ochttp                           74.8%
ok  go.opencensus.io/plugin/ocgrpc                           73.7%
ok  go.opencensus.io/metric/metricproducer                   100.0%
ok  go.opencensus.io/metric/metricexport                     96.4%
ok  go.opencensus.io/metric                                  96.2%
ok  go.opencensus.io/internal                                85.7%
ok  go.opencensus.io/exporter/stackdriver/propagation        79.3%
?   go.opencensus.io/zpages/internal                         0.0%
?   go.opencensus.io/trace/internal                          0.0%
?   go.opencensus.io/stats/internal                          0.0%
?   go.opencensus.io/resource/resourcekeys                   0.0%
?   go.opencensus.io/metric/metricdata                       0.0%
?   go.opencensus.io/internal/testpb                         0.0%
?   go.opencensus.io/internal/tagencoding                    0.0%
?   go.opencensus.io/internal/readme                         0.0%
?   go.opencensus.io/internal/check                          0.0%
?   go.opencensus.io                                         0.0%
total: 76.7%
```

### jaeger

- github.com repo: https://github.com/jaegertracing/jaeger
- godoc.org: https://godoc.org/github.com/jaegertracing/jaeger
- goreportcard.com: https://goreportcard.com/report/github.com/jaegertracing/jaeger
- coverage service: https://codecov.io/gh/jaegertracing/jaeger/branch/master/