### PR TITLE
Add implementation of Python's module "textwrap"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1572,6 +1572,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
     * [parth](https://github.com/codemodus/parth) - URL path segmentation parsing.
     * [radix](https://github.com/yourbasic/radix) - fast string sorting algorithm.
     * [Tagify](https://github.com/zoomio/tagify) - Produces a set of tags from given source.
+	* [textwrap](https://github.com/isbm/textwrap) - Implementation of `textwrap` module from Python.
     * [TySug](https://github.com/Dynom/TySug) - Alternative suggestions with respect to keyboard layouts.
     * [xj2go](https://github.com/stackerzzq/xj2go) - Convert xml or json to go struct.
     * [xurls](https://github.com/mvdan/xurls) - Extract urls from text.


### PR DESCRIPTION
Note: I don't use any online coverage services, except local tools. The coverage is either 100% or 0% where project is still in progress :-)

The godoc should update their indexes.

- github.com repo: https://github.com/isbm/textwrap
- goreportcard.com: https://goreportcard.com/report/github.com/isbm/textwrap

- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [ ] I ha e added godoc link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
