### PR TITLE
Add m-zajac/json2go

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,6 +897,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [gojson](https://github.com/ChimeraCoder/gojson) - Automatically generate Go (golang) struct definitions from example JSON.
 * [JayDiff](https://github.com/yazgazan/jaydiff) - JSON diff utility written in Go.
 * [JSON-to-Go](https://mholt.github.io/json-to-go/) - Convert JSON to Go struct.
+* [json2go](https://m-zajac.github.io/json2go) - Advanced JSON to Go struct conversion. Provides package that can parse multiple JSON documents and create struct to fit them all.
 * [jsonapi-errors](https://github.com/AmuzaTkts/jsonapi-errors) - Go bindings based on the JSON API errors reference.
 * [jsonf](https://github.com/miolini/jsonf) - Console tool for highlighted formatting and struct query fetching JSON.
 * [jsongo](https://github.com/ricardolonga/jsongo) - Fluent API to make it easier to create Json objects.


### PR DESCRIPTION
Added https://m-zajac.github.io/json2go

I'd like to propose adding this little utility that I think is pretty convenient for go community :) 
It's a bit different than existing tools, especially works well when provided an array of docs that are not exactly the same.

Code is written purely in go, and web page uses webassembly created by go compiler. 
I've tried my best to ensure good code quality and test coverage.

Few examples to show what this tool can do can be found here: https://github.com/m-zajac/json2go#example-outputs

Thanks for maintaining this awesome repository :)
