### PR TITLE
Removing rkt: it has been archived by the CNCF :(

### DIFF
--- a/README.md
+++ b/README.md
@@ -2122,7 +2122,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [peg](https://github.com/pointlander/peg) - Peg, Parsing Expression Grammar, is an implementation of a Packrat parser generator.
 * [Pipe](https://github.com/b3log/pipe) - A small and beautiful blogging platform.
 * [restic](https://github.com/restic/restic) - De-duplicating backup program.
-* [rkt](https://github.com/coreos/rkt) - App Container runtime that integrates with init systems, is compatible with other container formats like Docker, and supports alternative execution engines like KVM.
 * [scc](https://github.com/boyter/scc) - Sloc Cloc and Code, a very fast accurate code counter with complexity calculations and COCOMO estimates.
 * [Seaweed File System](https://github.com/chrislusf/seaweedfs) - Fast, Simple and Scalable Distributed File System with O(1) disk seek.
 * [shell2http](https://github.com/msoap/shell2http) - Executing shell commands via http server (for prototyping or remote control).


### PR DESCRIPTION
This is a sad day: `rkt` has been [officially archived by the CNCF](https://www.cncf.io/blog/2019/08/16/cncf-archives-the-rkt-project/). 

It probably makes sense to remove it from this list. 😢 This diff does exactly that.
