### PR TITLE
Remove go-couchdb: Unmantained

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,6 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
     * [dynago](https://github.com/underarmour/dynago) - Dynago is a principle of least surprise client for DynamoDB.
     * [forestdb](https://github.com/couchbase/goforestdb) - Go bindings for ForestDB.
     * [go-couchbase](https://github.com/couchbase/go-couchbase) - Couchbase client in Go.
-    * [go-couchdb](https://github.com/fjl/go-couchdb) - Yet another CouchDB HTTP API wrapper for Go.
     * [go-pilosa](https://github.com/pilosa/go-pilosa) - Go client library for Pilosa.
     * [go-rejson](https://github.com/nitishm/go-rejson) - Golang client for redislabs' ReJSON module using Redigo golang client. Store and manipulate structs as JSON objects in redis with ease.
     * [gocb](https://github.com/couchbase/gocb) - Official Couchbase Go SDK.


### PR DESCRIPTION
    - Last commit over 5 years ago
    - Author doesn't respond to requests or PRs
    - Also no OSS license (not strictly required for inclusion in awesome-go,
      but legally, this code can't be used by anyone other than the author,
      without some sort of license)
