### PR TITLE
Add gnet to the networking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1183,6 +1183,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [fortio](https://github.com/fortio/fortio) - Load testing library and command line tool, advanced echo server and web UI. Allows to specify a set query-per-second load and record latency histograms and other useful stats and graph them. Tcp, Http, gRPC.
 * [ftp](https://github.com/jlaffaye/ftp) - Package ftp implements a FTP client as described in [RFC 959](http://tools.ietf.org/html/rfc959).
 * [gmqtt](https://github.com/DrmagicE/gmqtt) - Gmqtt is a flexible, high-performance MQTT broker library that fully implements the MQTT protocol V3.1.1.
+* [gnet](https://github.com/panjf2000/gnet) - `gnet` is a high-performance, lightweight, nonblocking, event-loop networking library written in pure Go.
 * [gNxI](https://github.com/google/gnxi) - A collection of tools for Network Management that use the gNMI and gNOI protocols.
 * [go-getter](https://github.com/hashicorp/go-getter) - Go library for downloading files or directories from various sources using a URL.
 * [go-stun](https://github.com/ccding/go-stun) - Go implementation of the STUN client (RFC 3489 and RFC 5389).


### PR DESCRIPTION
**gnet: A high-performance, lightweight, nonblocking, event-loop networking library written in pure Go.**

- github.com repo: https://github.com/panjf2000/gnet
- godoc.org: [![Doc for panjf2000/gnet](https://img.shields.io/badge/api-reference-blue.svg?style=flat-square)](https://gowalker.org/github.com/panjf2000/gnet?lang=en-US)
- goreportcard.com: [![Go Report Card](https://goreportcard.com/badge/github.com/panjf2000/gnet?style=flat-square)](https://goreportcard.com/report/github.com/panjf2000/gnet)
- coverage service link: [![codecov for panjf2000/gnet](https://img.shields.io/codecov/c/github/panjf2000/gnet?style=flat-square)](https://codecov.io/gh/panjf2000/gnet)


- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

