### PR TITLE
Add trandoshan-io to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1151,6 +1151,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [shortid](https://github.com/teris-io/shortid) - Distributed generation of super short, unique, non-sequential, URL friendly IDs.
 * [stateless](https://github.com/qmuntal/stateless) - A fluent library for creating state machines.
 * [stats](https://github.com/go-playground/stats) - Monitors Go MemStats + System stats such as Memory, Swap and CPU and sends via UDP anywhere you want for logging etc...
+* [trandoshan-io](https://github.com/trandoshan-io) - Fast, highly configurable, distributed dark web crawler designed to run on the cloud.
 * [turtle](https://github.com/hackebrot/turtle) - Emojis for Go.
 * [url-shortener](https://github.com/pantrif/url-shortener) - A modern, powerful, and robust URL shortener microservice with mysql support.
 * [VarHandler](https://github.com/azr/generators/tree/master/varhandler) - Generate boilerplate http input and output handling.


### PR DESCRIPTION
**Please provide package links to:**

- github.com repo: https://github.com/trandoshan-io
- godoc.org: not available
- goreportcard.com: there is one report available for each projects
- coverage service link ([gocover](http://gocover.io/), [coveralls](https://coveralls.io/) etc.)

**Make sure that you've checked the boxes below before you submit PR:**
- [X] I have added my package in alphabetical order.
- [X] I have an appropriate description with correct grammar.
- [X] I know that this package was not listed before.
- [ ] I have added godoc link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request.
- [X] I have added goreportcard link to the repo and to my pull request.
- [X] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

**Note:** I don't know if you accept a whole organization as entry. Trandoshan is mainly written in Go (except for one project) so I don't know if it would fit your rules, but let's try !  