### PR TITLE
Remove Gomail since it's unmaintained since 2016.

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,7 +603,6 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [go-message](https://github.com/emersion/go-message) - Streaming library for the Internet Message Format and mail messages.
 * [go-premailer](https://github.com/vanng822/go-premailer) - Inline styling for HTML mail in Go.
 * [go-simple-mail](https://github.com/xhit/go-simple-mail) - Very simple package to send emails with SMTP Keep Alive and two timeouts: Connect and Send.
-* [Gomail](https://github.com/go-gomail/gomail/) - Gomail is a very simple and powerful package to send emails.
 * [Hectane](https://github.com/hectane/hectane) - Lightweight SMTP client providing an HTTP API.
 * [hermes](https://github.com/matcornic/hermes) - Golang package that generates clean, responsive HTML e-mails.
 * [mailgun-go](https://github.com/mailgun/mailgun-go) - Go library for sending mail with the Mailgun API.


### PR DESCRIPTION
Hi there!

With this PR, I would like to remove the [Gomail](https://github.com/go-gomail/gomail/) package.

It's unmaintained since 2016. Several forks exist, but I wasn't able to identify one as a valid replacement fitting the requirements to be added to the awesome list.

I'd suggest that if one of the owners of a fork wants it to be added to the list they should create a separate PR for this.

Kind regards, 3stadt