### PR TITLE
Added go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2344,9 +2344,9 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [Go Forum](https://forum.golangbridge.org) - Forum to discuss Go.
 * [Go In 5 Minutes](https://www.goin5minutes.com/) - 5 minute screencasts focused on getting one thing done.
 * [Go Projects](https://github.com/golang/go/wiki/Projects) - List of projects on the Go community wiki.
-* [Go Report Card](https://goreportcard.com) - A report card for your Go package.
-* [gocryforhelp](https://github.com/ninedraft/gocryforhelp) - Collection of Go projects that needs help. Good place to start your open-source way in Go.
+* [Go Report Card](https://goreportcard.com) - A report card for your Go package.\
 * [go.dev](https://go.dev/) - A hub for Go developers.
+* [gocryforhelp](https://github.com/ninedraft/gocryforhelp) - Collection of Go projects that needs help. Good place to start your open-source way in Go.
 * [godoc.org](https://godoc.org/) - Documentation for open source Go packages.
 * [Golang Developer Jobs](https://golangjob.xyz) - Developer Jobs exclusivly for Golang related Roles.
 * [Golang Flow](https://golangflow.io) - Post Updates, News, Packages and more.

--- a/README.md
+++ b/README.md
@@ -2346,6 +2346,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [Go Projects](https://github.com/golang/go/wiki/Projects) - List of projects on the Go community wiki.
 * [Go Report Card](https://goreportcard.com) - A report card for your Go package.
 * [gocryforhelp](https://github.com/ninedraft/gocryforhelp) - Collection of Go projects that needs help. Good place to start your open-source way in Go.
+* [go.dev](https://go.dev/) - A hub for Go developers
 * [godoc.org](https://godoc.org/) - Documentation for open source Go packages.
 * [Golang Developer Jobs](https://golangjob.xyz) - Developer Jobs exclusivly for Golang related Roles.
 * [Golang Flow](https://golangflow.io) - Post Updates, News, Packages and more.
@@ -2363,7 +2364,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [studygolang](https://studygolang.com) - The community of studygolang in China.
 * [Trending Go repositories on GitHub today](https://github.com/trending?l=go) - Good place to find new Go libraries.
 * [TutorialEdge - Golang](https://tutorialedge.net/course/golang/)
-* [go.dev](https://go.dev/) - A hub for Go developers
 
 ### Tutorials
 

--- a/README.md
+++ b/README.md
@@ -2363,6 +2363,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [studygolang](https://studygolang.com) - The community of studygolang in China.
 * [Trending Go repositories on GitHub today](https://github.com/trending?l=go) - Good place to find new Go libraries.
 * [TutorialEdge - Golang](https://tutorialedge.net/course/golang/)
+* [go.dev](https://go.dev/) - A hub for Go developers
 
 ### Tutorials
 

--- a/README.md
+++ b/README.md
@@ -2346,7 +2346,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [Go Projects](https://github.com/golang/go/wiki/Projects) - List of projects on the Go community wiki.
 * [Go Report Card](https://goreportcard.com) - A report card for your Go package.
 * [gocryforhelp](https://github.com/ninedraft/gocryforhelp) - Collection of Go projects that needs help. Good place to start your open-source way in Go.
-* [go.dev](https://go.dev/) - A hub for Go developers
+* [go.dev](https://go.dev/) - A hub for Go developers.
 * [godoc.org](https://godoc.org/) - Documentation for open source Go packages.
 * [Golang Developer Jobs](https://golangjob.xyz) - Developer Jobs exclusivly for Golang related Roles.
 * [Golang Flow](https://golangflow.io) - Post Updates, News, Packages and more.


### PR DESCRIPTION
Added the [go.dev](https://go.dev/) website [introduced lately](https://blog.golang.org/go.dev)