### PR TITLE
Add Language Detection API Go client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1181,6 +1181,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 *Libraries for working with human languages.*
 
+* [detectlanguage](https://github.com/detectlanguage/detectlanguage-go) - Language Detection API Go Client. Supports batch requests, short phrase or single word language detection.
 * [getlang](https://github.com/rylans/getlang) - Fast natural language detection package.
 * [go-i18n](https://github.com/nicksnyder/go-i18n/) - Package and an accompanying tool to work with localized text.
 * [go-mystem](https://github.com/dveselov/mystem) - CGo bindings to Yandex.Mystem - russian morphology analyzer.


### PR DESCRIPTION
- github.com repo: https://github.com/detectlanguage/detectlanguage-go
- godoc.org: https://godoc.org/github.com/detectlanguage/detectlanguage-go
- goreportcard.com: https://goreportcard.com/report/github.com/detectlanguage/detectlanguage-go
- coverage service link: https://gocover.io/github.com/detectlanguage/detectlanguage-go
