### PR TITLE
Add rotisserie/eris to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,6 +651,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 *Libraries for handling errors.*
 
 * [emperror](https://github.com/emperror/emperror) - Error handling tools and best practices for Go libraries and applications.
+* [eris](https://github.com/rotisserie/eris) - A better way to handle, trace, and log errors in Go. Compatible with the standard error library and github.com/pkg/errors.
 * [errlog](https://github.com/snwfdhmp/errlog) - Hackable package that determines responsible source code for an error (and some other fast-debugging features). Pluggable to any logger in-place.
 * [errors](https://github.com/emperror/errors) - Drop-in replacement for the standard library errors package and github.com/pkg/errors. Provides various error handling primitives.
 * [errors](https://github.com/pkg/errors) - Package that provides simple error handling primitives.


### PR DESCRIPTION
Hi awesome folks :)

- github.com repo: https://github.com/rotisserie/eris
- godoc.org: https://godoc.org/github.com/rotisserie/eris
- goreportcard.com: https://goreportcard.com/report/github.com/rotisserie/eris
- coverage service link: https://codecov.io/gh/rotisserie/eris

- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).