### PR TITLE
Add OctoSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [kingshard](https://github.com/flike/kingshard) - kingshard is a high performance proxy for MySQL powered by Golang.
 * [myreplication](https://github.com/2tvenom/myreplication) - MySql binary log replication listener. Supports statement and row based replication.
 * [octillery](https://github.com/knocknote/octillery) - Go package for sharding databases ( Supports every ORM or raw SQL ).
+* [OctoSQL](https://github.com/cube2222/octosql) - OctoSQL is a query tool that allows you to join, analyse and transform data from multiple databases and file formats using SQL.
 * [orchestrator](https://github.com/github/orchestrator) - MySQL replication topology manager & visualizer.
 * [pgweb](https://github.com/sosedoff/pgweb) - Web-based PostgreSQL database browser.
 * [prep](https://github.com/hexdigest/prep) - Use prepared SQL statements without changing your code.


### PR DESCRIPTION
- github.com repo: https://github.com/cube2222/octosql
- godoc.org: https://godoc.org/github.com/cube2222/octosql
- goreportcard.com: https://goreportcard.com/report/github.com/cube2222/octosql

Tests require multiple databases to run. It's well tested overall.