### PR TITLE
Adding k8s-platform-lcm to DevOps tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2172,6 +2172,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [kala](https://github.com/ajvb/kala) - Simplistic, modern, and performant job scheduler.
 * [kcli](https://github.com/cswank/kcli) - Command line tool for inspecting kafka topics/partitions/messages.
 * [kubernetes](https://github.com/kubernetes/kubernetes) - Container Cluster Manager from Google.
+* [k8s-platform-lcm](https://github.com/arminc/k8s-platform-lcm) - An easy way of tracking new versions for software and tools
 * [lstags](https://github.com/ivanilves/lstags) - Tool and API to sync Docker images across different registries.
 * [lwc](https://github.com/timdp/lwc) - A live-updating version of the UNIX wc command.
 * [manssh](https://github.com/xwjdsh/manssh) - manssh is a command line tool for managing your ssh alias config easily.


### PR DESCRIPTION
Adding http://github.com/arminc/k8s-platform-lcm

- github.com repo: http://github.com/arminc/k8s-platform-lcm
- goreportcard.com: https://goreportcard.com/report/github.com/arminc/k8s-platform-lcm