### PR TITLE
Add ristretto memory-bound Go cache library to awesome-go:databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [piladb](https://github.com/fern4lvarez/piladb) - Lightweight RESTful database engine based on stack data structures.
 * [prometheus](https://github.com/prometheus/prometheus) - Monitoring system and time series database.
 * [pudge](https://github.com/recoilme/pudge) - Fast and simple  key/value store written using Go's standard library.
+* [ristretto](https://github.com/dgraph-io/ristretto) - A high performance memory-bound Go cache.
 * [rqlite](https://github.com/rqlite/rqlite) - The lightweight, distributed, relational database built on SQLite.
 * [Scribble](https://github.com/nanobox-io/golang-scribble) - Tiny flat file JSON store.
 * [slowpoke](https://github.com/recoilme/slowpoke) - Key-value store with persistence.


### PR DESCRIPTION
**Please provide package links to:**

- github.com repo: https://github.com/dgraph-io/ristretto
- godoc.org:https://godoc.org/github.com/dgraph-io/ristretto
- goreportcard.com:https://goreportcard.com/report/github.com/dgraph-io/ristretto
- coverage service link:[gocover](https://gocover.io/github.com/dgraph-io/ristretto)



**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
