### PR TITLE
Add google wire library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,7 +1139,9 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [gocontainer](https://github.com/vardius/gocontainer) - Simple Dependency Injection Container.
 * [inject](https://github.com/defval/inject) - A reflection based dependency injection container with simple interface.
 * [linker](https://github.com/logrange/linker) - A reflection based dependency injection and inversion of control library with components lifecycle support.
+* [wire](https://github.com/google/wire) - Compile-time Dependency Injection for Go.
 * [wire](https://github.com/Fs02/wire) - Strict Runtime Dependency Injection for Golang.
+
 
 ### Project Layout
 


### PR DESCRIPTION
Compile-time Dependency Injection for Go

- github.com repo: https://github.com/google/wire
- godoc.org: https://godoc.org/github.com/google/wire
- goreportcard.com: https://goreportcard.com/report/github.com/google/wire
- coverage service link: https://codecov.io/gh/google/wire

Very good coverage

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [ ] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Thanks for your PR, you're awesome! :+1:
