### PR TITLE
Replace archived defval/inject to goava/di

### DIFF
--- a/README.md
+++ b/README.md
@@ -1136,11 +1136,11 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 * [alice](https://github.com/magic003/alice) - Additive dependency injection container for Golang.
 * [container](https://github.com/golobby/container) - A powerful IoC Container with fluent and easy-to-use interface.
+* [di](https://github.com/goava/di) - A dependency injection container for go programming language.
 * [dig](https://github.com/uber-go/dig) - A reflection based dependency injection toolkit for Go.
 * [dingo](https://github.com/i-love-flamingo/dingo) - A dependency injection toolkit for Go, based on Guice.
 * [fx](https://github.com/uber-go/fx) - A dependency injection based application framework for Go (built on top of dig).
 * [gocontainer](https://github.com/vardius/gocontainer) - Simple Dependency Injection Container.
-* [inject](https://github.com/defval/inject) - A reflection based dependency injection container with simple interface.
 * [linker](https://github.com/logrange/linker) - A reflection based dependency injection and inversion of control library with components lifecycle support.
 * [wire](https://github.com/Fs02/wire) - Strict Runtime Dependency Injection for Golang.
 


### PR DESCRIPTION
Hi! My library was moved. Thx!

- github.com repo: https://github.com/goava/di
- godoc.org: https://pkg.go.dev/github.com/goava/di
- goreportcard.com: https://goreportcard.com/report/github.com/goava/di
- coverage service link: https://codecov.io/gh/goava/di