### PR TITLE
Add google's dependency injection lib wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -1142,6 +1142,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [gocontainer](https://github.com/vardius/gocontainer) - Simple Dependency Injection Container.
 * [inject](https://github.com/defval/inject) - A reflection based dependency injection container with simple interface.
 * [linker](https://github.com/logrange/linker) - A reflection based dependency injection and inversion of control library with components lifecycle support.
+* [wire](https://github.com/google/wire) - Compile-time Dependency Injection for Go by google.
 * [wire](https://github.com/Fs02/wire) - Strict Runtime Dependency Injection for Golang.
 
 ### Project Layout


### PR DESCRIPTION
- github.com repo: https://github.com/google/wire
- coverage service link: https://codecov.io/gh/google/wire

