### PR TITLE
Add WebAssembly category

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
     - [Validation](#validation)
     - [Version Control](#version-control)
     - [Video](#video)
-    - [WebAssembly](#webassembly)
     - [Web Frameworks](#web-frameworks)
         - [Middlewares](#middlewares)
             - [Actual middlewares](#actual-middlewares)
             - [Libraries for creating HTTP middlewares](#libraries-for-creating-http-middlewares)
         - [Routers](#routers)
+    - [WebAssembly](#webassembly)
     - [Windows](#windows)
     - [XML](#xml)
 
@@ -1988,15 +1988,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [m3u8](https://github.com/grafov/m3u8) - Parser and generator library of M3U8 playlists for Apple HLS.
 * [v4l](https://github.com/korandiz/v4l) - Video capture library for Linux, written in Go.
 
-## WebAssembly
-
-* [dom](https://github.com/dennwc/dom) - DOM library.
-* [go-canvas](https://github.com/markfarnan/go-canvas) - Library to use HTML5 Canvas, with all drawing within go code.
-* [tinygo](https://github.com/tinygo-org/tinygo) - Go compiler for small places. Microcontrollers, WebAssembly, and command-line tools. Based on LLVM.
-* [vert](https://github.com/norunners/vert) - Interop between Go and JS values.
-* [wasmbrowsertest](https://github.com/agnivade/wasmbrowsertest) - Run Go WASM tests in your browser.
-* [webapi](https://github.com/gowebapi/webapi) - Bindings for DOM and HTML generated from WebIDL.
-
 ## Web Frameworks
 
 *Full stack web frameworks.*
@@ -2098,6 +2089,15 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [violetear](https://github.com/nbari/violetear) - Go HTTP router.
 * [xmux](https://github.com/rs/xmux) - High performance muxer based on `httprouter` with `net/context` support.
 * [xujiajun/gorouter](https://github.com/xujiajun/gorouter) - A simple and fast HTTP router for Go.
+
+## WebAssembly
+
+* [dom](https://github.com/dennwc/dom) - DOM library.
+* [go-canvas](https://github.com/markfarnan/go-canvas) - Library to use HTML5 Canvas, with all drawing within go code.
+* [tinygo](https://github.com/tinygo-org/tinygo) - Go compiler for small places. Microcontrollers, WebAssembly, and command-line tools. Based on LLVM.
+* [vert](https://github.com/norunners/vert) - Interop between Go and JS values.
+* [wasmbrowsertest](https://github.com/agnivade/wasmbrowsertest) - Run Go WASM tests in your browser.
+* [webapi](https://github.com/gowebapi/webapi) - Bindings for DOM and HTML generated from WebIDL.
 
 ## Windows
 

--- a/README.md
+++ b/README.md
@@ -1987,6 +1987,15 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [m3u8](https://github.com/grafov/m3u8) - Parser and generator library of M3U8 playlists for Apple HLS.
 * [v4l](https://github.com/korandiz/v4l) - Video capture library for Linux, written in Go.
 
+## WebAssembly
+
+* [dom](https://github.com/dennwc/dom) - DOM library.
+* [go-canvas](https://github.com/markfarnan/go-canvas) - Library to use HTML5 Canvas, with all drawing within go code.
+* [tinygo](https://github.com/tinygo-org/tinygo) - Go compiler for small places. Microcontrollers, WebAssembly, and command-line tools. Based on LLVM.
+* [vert](https://github.com/norunners/vert) - Interop between Go and JS values.
+* [wasmbrowsertest](https://github.com/agnivade/wasmbrowsertest) - Run Go WASM tests in your browser.
+* [webapi](https://github.com/gowebapi/webapi) - Bindings for DOM and HTML generated from WebIDL.
+
 ## Web Frameworks
 
 *Full stack web frameworks.*

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
     - [Validation](#validation)
     - [Version Control](#version-control)
     - [Video](#video)
+    - [WebAssembly](#webassembly)
     - [Web Frameworks](#web-frameworks)
         - [Middlewares](#middlewares)
             - [Actual middlewares](#actual-middlewares)


### PR DESCRIPTION
Close #2933

To be honest, I'm not sure if all projects here are awesome, even if they listed [in the official guide](https://github.com/golang/go/wiki/WebAssembly). My motivation is the same as (I guess) had authors of that guide: collect what is here right now and just works, since Go compilation into wasm is relatively new and has no ecosystem around. However, I'm a bit more selective and listed only projects that work right now and have some minimal support. Anyway, let's talk.

A few projects that I can be sure are awesome:

+ https://github.com/tinygo-org/tinygo is amazing. I was surprised that it's not here yet.
+ https://github.com/agnivade/wasmbrowsertest is a must-have tool without alternative solutions. I use it actively and it works.

About other tools:

+ https://github.com/norunners/vert looks nice but I haven't tried it yet. I haven't seen alternatives, though.
+ https://github.com/dennwc/dom and https://github.com/gowebapi/webapi are quite messy but we need DOM bindings and has not a lot of alternatives. There is also https://github.com/siongui/godom but I haven't included it since the last commit in 2018. Also, I'm developing https://github.com/life4/gweb but at this point, I can't claim that it is awesome, I'll include it a bit later :)

Have I missed something?

## Links

tinygo:

+ https://github.com/tinygo-org/tinygo
+ https://goreportcard.com/report/github.com/tinygo-org/tinygo (A+)
+ https://pkg.go.dev/github.com/tinygo-org/tinygo?tab=subdirectories
+ https://tinygo.org/
+ cannot find coverage report

wasmbrowsertest:

+ https://github.com/agnivade/wasmbrowsertest
+ https://goreportcard.com/report/github.com/agnivade/wasmbrowsertest (A+)
+ no godoc, isn't intended to be used as a library
+ cannot find coverage report

vert:

+ https://github.com/norunners/vert
+ https://godoc.org/github.com/norunners/vert
+ https://goreportcard.com/report/github.com/norunners/vert (A+)
+ cannot find coverage

dom:

+ https://github.com/dennwc/dom
+ https://godoc.org/github.com/dennwc/dom
+ https://goreportcard.com/report/github.com/dennwc/dom (A+)
+ cannot find coverage

webapi:

+ https://github.com/gowebapi/webapi
+ https://goreportcard.com/report/github.com/gowebapi/webapi (A+)
+ https://godoc.org/github.com/gowebapi/webapi
+ cannot find coverage

go-canvas:

+ https://github.com/markfarnan/go-canvas
+ https://godoc.org/github.com/markfarnan/go-canvas/canvas
+ https://goreportcard.com/report/github.com/markfarnan/go-canvas (B)
+ cannot find coverage
