### PR TITLE
- add igo (github.com/rocketlaunchr/igo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2187,6 +2187,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [godbg](https://github.com/tylerwince/godbg) - Implementation of Rusts `dbg!` macro for quick and easy debugging during development.
 * [gomodrun](https://github.com/dustinblackman/gomodrun/) - Go tool that executes and caches binaries included in go.mod files.
 * [gothanks](https://github.com/psampaz/gothanks) - GoThanks automatically stars your go.mod github dependencies, sending this way some love to their maintainers.
+* [igo](https://github.com/rocketlaunchr/igo) - An igo to go transpiler (new language features for Go language!)
 * [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through go files efficiently with the OctoLinker browser extension for GitHub.
 * [richgo](https://github.com/kyoh86/richgo) - Enrich `go test` outputs with text decorations.
 * [rts](https://github.com/galeone/rts) - RTS: response to struct. Generates Go structs from server responses.


### PR DESCRIPTION
- github.com repo: https://github.com/rocketlaunchr/igo
- pkg.go.dev: N/A
- goreportcard.com: N/A
- coverage service link N/A

`igo` is a transpiler that converts igo files (go files with some new syntax and other language features) into standard go files which you can then compile.

**It is not a package for others to use.**

There is a unit test provided for converting a "sample" igo file to a standard go file which you can then then run. Peruse/run the 1 unit test in the parent directory.