### PR TITLE
Add broccoli (brotli-powered) resource embedding tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1427,6 +1427,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 ## Resource Embedding
 
+* [broccoli](https://github.com/aletheia-icu/broccoli) - Using brotli compression to embed multiple resources efficiently via `go generate` (unlike many alternatives, works with `wasm/js` architecture, too!)
 * [esc](https://github.com/mjibson/esc) - Embeds files into Go programs and provides http.FileSystem interfaces to them.
 * [fileb0x](https://github.com/UnnoTed/fileb0x) - Simple tool to embed files in go with focus on "customization" and ease to use.
 * [go-embed](https://github.com/pyros2097/go-embed) - Generates go code to embed resource files into your library or executable.


### PR DESCRIPTION
Hello!

We've recently developed a resource embedding tool called [🥦**Broccoli**](https://github.com/aletheia-icu/broccoli), it uses brotli compression for embedding. The primary motivation behind it was the fact that many existing tools (with an exception of statik maybe) either don't do any compression or don't really work on `wasm/js` target architecture, which was a big requirement for me personally.

Broccoli attracted a positive [disscussion](https://www.reddit.com/r/golang/comments/g12mfh/broccoli_we_wrote_the_most_efficient_static_file/) on Reddit (top 5 last week) and landed a front page in [#308 golang weekly](https://golangweekly.com/issues/308).

We're currently on `v1.0.3`, which means it's stable

- [Github repository](https://github.com/aletheia-icu/broccoli)
- [Documentation](https://pkg.go.dev/aletheia.icu/broccoli/fs?tab=doc)
- [A+ report card](https://goreportcard.com/report/aletheia.icu/broccoli)
- [88% codecov](https://codecov.io/gh/aletheia-icu/broccoli)

Hopefully the rather long-winded description won't hurt much. ```Using brotli compression to embed multiple resources efficiently via `go generate` (unlike many alternatives, works with `wasm/js` architecture, too!)``` (this is factually correct and as WASM Go becomes more popular, rather important to point out)

Cheers,
Ian