### PR TITLE
Add Balerter to the DevOps Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2222,6 +2222,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [aptly](https://github.com/smira/aptly) - aptly is a Debian repository management tool.
 * [aurora](https://github.com/xuri/aurora) - Cross-platform web-based Beanstalkd queue server console.
 * [awsenv](https://github.com/soniah/awsenv) - Small binary that loads Amazon (AWS) environment variables for a profile.
+* [Balerter](https://github.com/balerter/balerter) - A script based alert manager.
 * [Blast](https://github.com/dave/blast) - A simple tool for API load testing and batch jobs.
 * [bombardier](https://github.com/codesenberg/bombardier) - Fast cross-platform HTTP benchmarking tool.
 * [bosun](https://github.com/bosun-monitor/bosun) - Time Series Alerting Framework.


### PR DESCRIPTION
`balerter` is Script Based Alert Manager

- https://github.com/balerter/balerter
- https://goreportcard.com/report/github.com/balerter/balerter
- https://codecov.io/gh/balerter/balerter

- [x ] I have added my package in alphabetical order.
- [x ] I have an appropriate description with correct grammar.
- [x ] I know that this package was not listed before.
- [ ] I have added pkg.go.dev link to the repo and to my pull request.
- [x ] I have added coverage service link to the repo and to my pull request.
- [x ] I have added goreportcard link to the repo and to my pull request.
- [x ] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
