### PR TITLE
Add Mattermost as a DevOps tool to awesome-go list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2277,6 +2277,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [lstags](https://github.com/ivanilves/lstags) - Tool and API to sync Docker images across different registries.
 * [lwc](https://github.com/timdp/lwc) - A live-updating version of the UNIX wc command.
 * [manssh](https://github.com/xwjdsh/manssh) - manssh is a command line tool for managing your ssh alias config easily.
+* [Mattermost](https://github.com/mattermost/mattermost-server) - Open source Slack-alternative for DevOps teams.
 * [Moby](https://github.com/moby/moby) - Collaborative project for the container ecosystem to assemble container-based systems.
 * [Mora](https://github.com/emicklei/mora) - REST server for accessing MongoDB documents and meta data.
 * [ostent](https://github.com/ostrost/ostent) - collects and displays system metrics and optionally relays to Graphite and/or InfluxDB.


### PR DESCRIPTION
Add Mattermost as a DevOps tool: https://github.com/mattermost/mattermost-server

**Please provide package links to:**

- github.com repo: https://github.com/mattermost/mattermost-server
- pkg.go.dev: https://pkg.go.dev/mod/github.com/mattermost/mattermost-server
- goreportcard.com: https://goreportcard.com/report/github.com/mattermost/mattermost-server
- coverage service link: https://codecov.io/gh/mattermost/mattermost-server

**Make sure that you've checked the boxes below before you submit PR:**
- [X] I have added my package in alphabetical order.
- [X] I have an appropriate description with correct grammar.
- [X] I know that this package was not listed before.
- [X] I have added pkg.go.dev link to the repo and to my pull request.
- [X] I have added coverage service link to the repo and to my pull request.
- [X] I have added goreportcard link to the repo and to my pull request.
- [X] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
