### PR TITLE
Remove mango because this isn't actively manintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -2056,7 +2056,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [Goyave](https://github.com/System-Glitch/goyave) - Feature-complete web framework aimed at clean code and fast development, with powerful built-in functionalities.
 * [hiboot](https://github.com/hidevopsio/hiboot) - hiboot is a high performance web application framework with auto configuration and dependency injection support.
 * [Macaron](https://github.com/go-macaron/macaron) - Macaron is a high productive and modular design web framework in Go.
-* [mango](https://github.com/paulbellamy/mango) - Mango is a modular web-application framework for Go, inspired by Rack, and PEP333.
 * [Microservice](https://github.com/claygod/microservice) - The framework for the creation of microservices, written in Golang.
 * [neo](https://github.com/ivpusic/neo) - Neo is minimal and fast Go Web Framework with extremely simple API.
 * [patron](https://github.com/beatlabs/patron) - Patron is a microservice framework following best cloud practices with a focus on productivity.


### PR DESCRIPTION
Remove https://github.com/paulbellamy/mango because this isn't actively maintained.

Please read the [README](https://github.com/paulbellamy/mango/blob/5dfd24323786d5c9c93cd40cf9c8be2ca56083a6/README.markdown)

> Note: Not actively maintained.

And the last update is `17 Oct 2017`.