### PR TITLE
Add nlpodyssey/spago

### DIFF
--- a/README.md
+++ b/README.md
@@ -1281,6 +1281,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [sentences](https://github.com/neurosnap/sentences) - Sentence tokenizer:  converts text into a list of sentences.
 * [shamoji](https://github.com/osamingo/shamoji) - The shamoji is word filtering package written in Go.
 * [snowball](https://github.com/goodsign/snowball) - Snowball stemmer port (cgo wrapper) for Go. Provides word stem extraction functionality [Snowball native](http://snowball.tartarus.org/).
+* [spaGO](https://github.com/nlpodyssey/spago) - A beautiful and maintainable Machine Learning library designed to support relevant neural network architectures in NLP tasks (e.g. BiLSTM, BERT, etc.)
 * [stemmer](https://github.com/dchest/stemmer) - Stemmer packages for Go programming language. Includes English and German stemmers.
 * [textcat](https://github.com/pebbe/textcat) - Go package for n-gram based text categorization, with support for utf-8 and raw text.
 * [transliterator](https://github.com/alexsergivan/transliterator) - Provides one-way string transliteration with supporting of language-specific transliteration rules.


### PR DESCRIPTION
github.com repo: https://github.com/nlpodyssey/spago
pkg.go.dev: https://pkg.go.dev/github.com/nlpodyssey/spago?tab=overview
goreportcard.com: https://goreportcard.com/report/github.com/nlpodyssey/spago
coverage service link: https://codecov.io/gh/nlpodyssey/spago


- [X] I have added my package in alphabetical order.
- [X] I have an appropriate description with correct grammar.
- [X] I know that this package was not listed before.
- [X] I have added pkg.go.dev link to the repo and to my pull request.
- [X] I have added coverage service link to the repo and to my pull request.
- [X] I have added goreportcard link to the repo and to my pull request.
- [X] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).


Please note that the goreportcard.com is showing an `F` recently, instead of the previous `A`.
We haven't done anything to go from `A` -> `F`: the issue is that the go report checks are running out of memory on their server, and failing:

```
An error occurred while running this test (AddError: could not parse "_repos/src/github.com/nlpodyssey/spago/cmd/huggingfaceimporter/internal/fatal error: runtime: out of memory:1::warning: file is not gofmted with -s (gofmt)" - strconv.Atoi: parsing " runtime": invalid syntax)
```
