### PR TITLE
Update main location and description of ttlcache

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [timedmap](https://github.com/zekroTJA/timedmap) - Map with expiring key-value pairs.
 * [treap](https://github.com/perdata/treap) - Persistent, fast ordered map using tree heaps.
 * [trie](https://github.com/derekparker/trie) - Trie implementation in Go.
-* [ttlcache](https://github.com/diegobernardes/ttlcache) - In-memory LRU string-interface{} map with expiration for golang.
+* [ttlcache](https://github.com/ReneKroon/ttlcache) - In-memory string-interface{} cache with various time-based expiration options and callbacks.
 * [typ](https://github.com/gurukami/typ) - Null Types, Safe primitive type conversion and fetching value from complex structures.
 * [willf/bloom](https://github.com/willf/bloom) - Go package implementing Bloom filters.
 


### PR DESCRIPTION
I was updating the link and description of the package since it changed owner a few years ago.

**Please provide package links to:**

- github.com/ReneKroon/ttlcache 
- https://pkg.go.dev/github.com/ReneKroon/ttlcache/v2?tab=doc:
- https://goreportcard.com/report/github.com/ReneKroon/ttlcache 
- https://gocover.io/github.com/ReneKroon/ttlcache (100%)

**Make sure that you've checked the boxes below before you submit PR:**
- [X ] I have added my package in alphabetical order.
- [X ] I have an appropriate description with correct grammar.
- [N/A ] This is an update so N/A - I know that this package was not listed before.
- [X ] I have added pkg.go.dev link to the repo and to my pull request.
- [X ] I have added coverage service link to the repo and to my pull request.
- [X ] I have added goreportcard link to the repo and to my pull request.
- [X ] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Thanks for your PR, you're awesome! :+1:
