### PR TITLE
Thanos style guide - Fix broken URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2556,7 +2556,7 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [Hyperledger](https://github.com/hyperledger/fabric/blob/release-1.4/docs/source/style-guides/go-style.rst)
 * [Magnetico](https://github.com/boramalper/magnetico/wiki/magnetico-Design-Specification)
 * [Sourcegraph](https://about.sourcegraph.com/handbook/engineering/go_style_guide)
-* [Thanos](https://thanos.io/contributing/coding-style-guide.md/)
+* [Thanos](https://thanos.io/tip/contributing/coding-style-guide.md/)
 * [Uber](https://github.com/uber-go/guide/blob/master/style.md)
 
 ## Social Media


### PR DESCRIPTION
Thanos style guide link is broken - updated to the new location