### PR TITLE
Add github.com/kristijorgji/goseeder as go dabase seeder

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [clickhouse-bulk](https://github.com/nikepan/clickhouse-bulk) - Collects small insterts and sends big requests to ClickHouse servers.
 * [datagen](https://github.com/codingconcepts/datagen) - A fast data generator that's multi-table aware and supports multi-row DML.
 * [dbbench](https://github.com/sj14/dbbench) - Database benchmarking tool with support for several databases and scripts.
+* [goseeder](https://github.com/kristijorgji/goseeder) - goseeder provides seeding functionality similar to Laravel seeder and with more utility functions
 * [go-mysql](https://github.com/siddontang/go-mysql) - Go toolset to handle MySQL protocol and replication.
 * [go-mysql-elasticsearch](https://github.com/siddontang/go-mysql-elasticsearch) - Sync your MySQL data into Elasticsearch automatically.
 * [kingshard](https://github.com/flike/kingshard) - kingshard is a high performance proxy for MySQL powered by Golang.


### PR DESCRIPTION
I saw searching your list for go database seeders and could not find any. I found by searching this one that I really like using and am adding here in the list too 

**Please provide package links to:**

- https://github.com/kristijorgji/goseeder
- https://pkg.go.dev/github.com/kristijorgji/goseeder
- https://goreportcard.com/report/github.com/kristijorgji/goseeder
- https://codecov.io/gh/kristijorgji/goseeder

**Make sure that you've checked the boxes below before you submit PR:**
- [ y] I have added my package in alphabetical order.
- [ y] I have an appropriate description with correct grammar.
- [y ] I know that this package was not listed before.
- [y ] I have added pkg.go.dev link to the repo and to my pull request.
- [ y] I have added coverage service link to the repo and to my pull request.
- [ y] I have added goreportcard link to the repo and to my pull request.
- [ y] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
