### PR TITLE
removed 3 repositories that were falling out of maintenance #3316

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [argv](https://github.com/cosiner/argv) - Go library to split command line string as arguments array using the bash syntax.
 * [cli](https://github.com/mkideal/cli) - Feature-rich and easy to use command-line package based on golang struct tags.
 * [cli](https://github.com/teris-io/cli) - Simple and complete API for building command line interfaces in Go.
-* [cli-init](https://github.com/tcnksm/gcli) - The easy way to start building Golang command line applications.
 * [climax](http://github.com/tucnak/climax) - Alternative CLI with "human face", in spirit of Go command.
 * [clîr](https://github.com/leaanthony/clir) - A Simple and Clear CLI library. Dependency free.
 * [cmd](https://github.com/posener/cmd) - Extends the standard `flag` package to support sub commands and more in idomatic way.
@@ -215,7 +214,6 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [commandeer](https://github.com/jaffee/commandeer) - Dev-friendly CLI apps: sets up flags, defaults, and usage based on struct fields and tags.
 * [complete](https://github.com/posener/complete) - Write bash completions in Go + Go command bash completion.
 * [Dnote](https://github.com/dnote/dnote) - A simple command line notebook with multi-device sync.
-* [docopt.go](https://github.com/docopt/docopt.go) - Command-line arguments parser that will make you smile.
 * [env](https://github.com/codingconcepts/env) - Tag-based environment configuration for structs.
 * [flag](https://github.com/cosiner/flag) - Simple but powerful command line option parsing library for Go supporting subcommand.
 * [flaggy](https://github.com/integrii/flaggy) - A robust and idiomatic flags package with excellent subcommand support.
@@ -233,7 +231,6 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [mow.cli](https://github.com/jawher/mow.cli) - Go library for building CLI applications with sophisticated flag and argument parsing and validation.
 * [ops](https://github.com/nanovms/ops) - Unikernel Builder/Orchestrator.
 * [pflag](https://github.com/spf13/pflag) - Drop-in replacement for Go's flag package, implementing POSIX/GNU-style --flags.
-* [readline](https://github.com/chzyer/readline) - Pure golang implementation that provides most features in GNU-Readline under MIT license.
 * [sand](https://github.com/Zaba505/sand) - Simple API for creating interpreters and so much more.
 * [sflags](https://github.com/octago/sflags) - Struct based flags generator for flag, urfave/cli, pflag, cobra, kingpin and other libraries.
 * [strumt](https://github.com/antham/strumt) - Library to create prompt chain.


### PR DESCRIPTION
Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Please provide package links to:**

- github.com repo:
- pkg.go.dev:
- goreportcard.com:
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), [gocover](http://gocover.io/) etc.)


Very good coverage

**Note**: that new categories can be added only when there are 3 packages or more.

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] I have added my package in alphabetical order.
- [ ] I have an appropriate description with correct grammar.
- [ ] I know that this package was not listed before.
- [ ] I have added pkg.go.dev link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request.
- [ ] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Thanks for your PR, you're awesome! :+1:

fixed: #3316 

This is a reponse to issue [#3316](https://github.com/avelino/awesome-go/issues/3316) i looked into these repositories and am giving a small report about what i found and removed some ones that were not really maintained. 

https://github.com/openshift/osin
KEPT
last push oct 25, 2019
it looks like they respond to issues and did in sept 11, 2020
 https://github.com/tcnksm/gcli
REMOVED
last push 4 years ago
last response to issue was in 2017 and since 2016 the issues don’t regularly receive attention

 https://github.com/docopt/docopt.go
REMOVED
last push 3 years ago
this was a tough one, although a lot of people still use the library it looks like mostly a bot is responding to pull requests or issues


 https://github.com/devfacet/gocmd
KEPT
last push 2 years ago
all two issues were responded to in 2018 so i’m assuming another issue would be responded to


 https://github.com/chzyer/readline
REMOVED
last push 2 years ago
many people have tried to merge things with it since 2018, but no response from the maintainers in the last two years

 https://github.com/Zaba505/sand
KEPT
last push 2 years ago
11 stars, no issues except one closed from the maintainer in 2018

 https://github.com/octago/sflags
KEPT
last push 15 months ago
issues are generally responded to, a lot of things merged with the exception of a depreciation notice on may 5 - by someone that was not a contributor

 https://github.com/liujianping/ts
KEPT
last push 16 months ago
no issues or pull request closed or otherwise to respond to

 https://github.com/ukautz/clif
KEPT
last push feb 18, 2019
no unmerged pull requests, although not all issues are responded to the last one resulted in a merge request in 2019

 https://github.com/mingrammer/cfmt
KEPT
last push dec 7, 2018
although the last issue was not responded to, all the pull requests were merged and lots of comments in 2018 from maintainer
