### PR TITLE
Removed broken Edge X Foundry style-guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2570,7 +2570,6 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 
 * [bahlo/go-styleguide](https://github.com/bahlo/go-styleguide)
 * [CockroachDB](https://github.com/cockroachdb/cockroach/blob/master/docs/style.md)
-* [Edge X Foundry](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide+-+Go+Lang)
 * [GitLab](https://docs.gitlab.com/ee/development/go_guide/)
 * [Hyperledger](https://github.com/hyperledger/fabric/blob/release-1.4/docs/source/style-guides/go-style.rst)
 * [Magnetico](https://github.com/boramalper/magnetico/wiki/magnetico-Design-Specification)


### PR DESCRIPTION
Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Please provide package links to:**

- github.com repo:
- pkg.go.dev:
- goreportcard.com:
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), [gocover](http://gocover.io/) etc.)


Very good coverage

**Note**: that new categories can be added only when there are 3 packages or more.

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] I have added my package in alphabetical order.
- [ ] I have an appropriate description with correct grammar.
- [ ] I know that this package was not listed before.
- [ ] I have added pkg.go.dev link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request.
- [ ] I have added goreportcard link to the repo and to my pull request.
- [ ] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

Thanks for your PR, you're awesome! :+1:

# Problem
The Edge X Foundry guide-style link is broken. It seems now Edge X Foundry only has [one simple paragraph](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide) about golang code style, and thus is not in the same quality level as other references.

# Solution
Removed the entry.
