### PR TITLE
Add Gio to list of Gui libaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,6 +926,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 
 * [app](https://github.com/murlokswarm/app) - Package to create apps with GO, HTML and CSS. Supports: MacOS, Windows in progress.
 * [fyne](https://github.com/fyne-io/fyne) - Cross platform native GUIs designed for Go based on Material Design. Supports: Linux, macOS, Windows, BSD, iOS and Android.
+* [gio](https://github.com/gioui/gio) - Gio implements portable immediate mode GUI programs in Go. Supports: iOS/tvOS, Android, Linux (Wayland/X11), macOS, Windows, FreeBSD, OpenBSD, experimental support for browsers (Webassembly/WebGL).
 * [go-astilectron](https://github.com/asticode/go-astilectron) - Build cross platform GUI apps with GO and HTML/JS/CSS (powered by Electron).
 * [go-gtk](http://mattn.github.io/go-gtk/) - Go bindings for GTK.
 * [go-sciter](https://github.com/sciter-sdk/go-sciter) - Go bindings for Sciter: the Embeddable HTML/CSS/script engine for modern desktop UI development. Cross platform.


### PR DESCRIPTION
- github.com repo: https://github.com/gioui/gio
- pkg.go.dev: https://pkg.go.dev/gioui.org
- goreportcard.com: https://goreportcard.com/report/github.com/gioui/gio
- home page: https://gioui.org/

- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added pkg.go.dev link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request. -- none found. https://gocover.io/ fails go getting it.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).
