### PR TITLE
fixed warnings on travisci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: go
 go:
   - 1.x
 
-sudo: false
-
 install:
   - go get -t -v ./...
 
@@ -16,6 +14,5 @@ before_deploy:
 deploy:
   provider: script
   script: netlify deploy --dir=tmpl --prod
-  skip_cleanup: true
   on:
     branch: master


### PR DESCRIPTION
- root: deprecated key sudo (The key `sudo` has no effect anymore.)
- deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)

![Screen Shot 2021-04-09 at 09 58 22](https://user-images.githubusercontent.com/31996/114183548-3017d600-991a-11eb-9ae2-7cac77fc97e0.png)
