### PR TITLE
Revert "fixed warnings on travisci config"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: go
 go:
   - 1.x
 
+sudo: false
+
 install:
   - go get -t -v ./...
 
@@ -14,5 +16,6 @@ before_deploy:
 deploy:
   provider: script
   script: netlify deploy --dir=tmpl --prod
+  skip_cleanup: true
   on:
     branch: master


### PR DESCRIPTION
Reverts avelino/awesome-go#3562

Cleaning up git repository with `git stash --all`. If you need build artifacts for deployment, set `deploy.skip_cleanup: true`. See https://docs.travis-ci.com/user/deployment#Uploading-Files-and-skip_cleanup.
Saved working directory and index state WIP on (no branch): 2932cf1 fixed warnings on travisci config - root: deprecated key sudo (The key `sudo` has no effect anymore.) - deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)

```
Deploy path: /home/travis/gopath/src/github.com/avelino/awesome-go/tmpl
Deploying to main site URL...
- Hashing files...
✔ Finished hashing 49 files
- CDN diffing files...
✔ CDN requesting 0 files
- Uploading 0 files
✔ Finished uploading 0 assets
- Waiting for deploy to go live...
✔ Deploy is live!
Logs:              https://app.netlify.com/sites/awesome-go/deploys/60705070ab7eb649003b121d
Unique Deploy URL: https://60705070ab7eb649003b121d--awesome-go.netlify.app
Website URL:       https://awesome-go.com
```