### PR TITLE
Add Githooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2181,6 +2181,7 @@ _**Unofficial** set of patterns for structuring projects._
 
 * [gh](https://github.com/rjeczalik/gh) - Scriptable server and net/http middleware for GitHub Webhooks.
 * [git2go](https://github.com/libgit2/git2go) - Go bindings for libgit2.
+* [githooks](https://github.com/gabyx/githooks) - Per-repo and shared Git hooks with version control and auto update.
 * [go-git](https://github.com/go-git/go-git) - highly extensible Git implementation in pure Go.
 * [go-vcs](https://github.com/sourcegraph/go-vcs) - manipulate and inspect VCS repositories in Go.
 * [hercules](https://github.com/src-d/hercules) - gaining advanced insights from Git repository history.


### PR DESCRIPTION
Now the missing coverage > 80% is fullfilled -> Initial proposal #3633.

Links
- github.com repo: https://github.com/gabyx/githooks
- pkg.go.dev: https://pkg.go.dev/github.com/gabyx/githooks/githooks
- goreportcard.com: https://goreportcard.com/report/github.com/gabyx/githooks
- coverage service link: https://coveralls.io/github/gabyx/Githooks?branch=main

Checks
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added pkg.go.dev link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standards).

![image](https://user-images.githubusercontent.com/647437/126911984-dacfcd89-a9d5-4602-bb75-146ae930c2df.png)

