### PR TITLE
correct beego orm link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1511,7 +1511,7 @@ _**Unofficial** set of patterns for structuring projects._
 
 *Libraries that implement Object-Relational Mapping or datamapping techniques.*
 
-* [beego orm](https://github.com/astaxie/beego/tree/master/orm) - Powerful orm framework for go. Support: pq/mysql/sqlite3.
+* [beego orm](https://github.com/beego/beego) - Powerful orm framework for go. Support: pq/mysql/sqlite3.
 * [ent](https://github.com/facebook/ent) - An entity framework for Go. Simple, yet powerful ORM for modeling and querying data.
 * [go-firestorm](https://github.com/jschoedt/go-firestorm) - A simple ORM for Google/Firebase Cloud Firestore.
 * [go-pg](https://github.com/go-pg/pg) - PostgreSQL ORM with focus on PostgreSQL specific features and performance.


### PR DESCRIPTION
Hi team,

I just saw that the link to beego seems incorrect or outdated. The link that is currently listed is `https://github.com/astaxie/beego/tree/master/orm` which is only a fork outdated by more than 100 commits of the original project `https://github.com/beego/beego`.

I have git-blamed all the commits back with all the transitions it has gone through, it seems that this was introduced with commit 96050f0d50ef3ffbfe0bb72cdda571720d24c08b.