### PR TITLE
Making 'README.md' a bit more efficient to read

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 <a href="https://www.producthunt.com/posts/awesome-go?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-awesome-go" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=291535&theme=light" alt="awesome-go - Curated list awesome Go frameworks, libraries and software | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 
+
 ## Sponsorships
 > [![Digital Ocean](https://avelino.run/sponsors/do_logo_horizontal_blue-210.png)](https://m.do.co/c/bd3b723c0a36?utm_medium=opensource&utm_source=awesome-go)
 
@@ -119,6 +120,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
     - [Websites](#websites)
         - [Tutorials](#tutorials)
 
+**[⬆ back to top](#contents)**
+
 ## Audio and Music
 
 *Libraries for manipulating audio.*
@@ -137,7 +140,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [portmidi](https://github.com/rakyll/portmidi) - Go bindings for PortMidi.
 * [vorbis](https://github.com/mccoyst/vorbis) - "Native" Go Vorbis decoder (uses CGO, but has no dependencies).
 
-## Authentication and OAuth
+##
+
 
 *Libraries for implementing authentications schemes.*
 
@@ -175,7 +179,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [sessionup](https://github.com/swithek/sessionup) - Simple, yet effective HTTP session management and identification package.
 * [sjwt](https://github.com/brianvoe/sjwt) - Simple jwt generator and parser.
 
-## Blockchain
+##
+
 
 *Tools for building blockchains.*
 
@@ -185,6 +190,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [tendermint](https://github.com/tendermint/tendermint) - High-performance middleware for transforming a state machine written in any programming language into a Byzantine Fault Tolerant replicated state machine using the Tendermint consensus and blockchain protocols.
 
 
+
+**[⬆ back to top](#contents)**
 
 ## Bot Building
 
@@ -212,6 +219,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [telegram-bot-api](https://github.com/Syfaro/telegram-bot-api) - Simple and clean Telegram bot client.
 * [Tenyks](https://github.com/kyleterry/tenyks) - Service oriented IRC bot using Redis and JSON for messaging.
 
+**[⬆ back to top](#contents)**
+
 ## Build Automation
 
 *Libraries and tools helping with build automation.*
@@ -225,6 +234,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [realize](https://github.com/tockins/realize) - Go build system with file watchers and live reload. Run, build and watch file changes with custom paths.
 * [Task](https://github.com/go-task/task) - simple "Make" alternative.
 * [taskctl](https://github.com/taskctl/taskctl) - Concurrent task runner.
+
+**[⬆ back to top](#contents)**
 
 ## Command Line
 
@@ -273,6 +284,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [wlog](https://github.com/dixonwille/wlog) - Simple logging interface that supports cross-platform color and concurrency.
 * [wmenu](https://github.com/dixonwille/wmenu) - Easy to use menu structure for cli applications that prompts users to make choices.
 
+**[⬆ back to top](#contents)**
+
 ### Advanced Console UIs
 
 *Libraries for building Console Applications and Console User Interfaces.*
@@ -309,6 +322,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [uiprogress](https://github.com/gosuri/uiprogress) - Flexible library to render progress bars in terminal applications.
 * [uitable](https://github.com/gosuri/uitable) - Library to improve readability in terminal apps using tabular data.
 * [yacspin](https://github.com/theckman/yacspin) - Yet Another CLi Spinner package, for working with terminal spinners.
+
+**[⬆ back to top](#contents)**
 
 ## Configuration
 
@@ -363,6 +378,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [xdg](https://github.com/OpenPeeDeeP/xdg) - Cross platform package that follows the [XDG Standard](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 * [ini](https://github.com/wlevene/ini) - INI Parser & Write Library, Unmarshal to Struct,Marshal to Json,Write File,watch file.
 
+**[⬆ back to top](#contents)**
+
 ## Continuous Integration
 
 *Tools for help with continuous integration.*
@@ -376,12 +393,16 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [overalls](https://github.com/go-playground/overalls) - Multi-Package go project coverprofile for tools like goveralls.
 * [roveralls](https://github.com/LawrenceWoodman/roveralls) - Recursive coverage testing tool.
 
+**[⬆ back to top](#contents)**
+
 ## CSS Preprocessors
 
 *Libraries for preprocessing CSS files.*
 
 * [gcss](https://github.com/yosssi/gcss) - Pure Go CSS Preprocessor.
 * [go-libsass](https://github.com/wellington/go-libsass) - Go wrapper to the 100% Sass compatible libsass project.
+
+**[⬆ back to top](#contents)**
 
 ## Data Structures
 
@@ -454,6 +475,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [ttlcache](https://github.com/ReneKroon/ttlcache) - In-memory string-interface{} cache with various time-based expiration options and callbacks.
 * [typ](https://github.com/gurukami/typ) - Null Types, Safe primitive type conversion and fetching value from complex structures.
 * [willf/bloom](https://github.com/willf/bloom) - Go package implementing Bloom filters.
+
+**[⬆ back to top](#contents)**
 
 ## Database
 
@@ -570,6 +593,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [Squirrel](https://github.com/Masterminds/squirrel) - Go library that helps you build SQL queries.
 * [xo](https://github.com/knq/xo) - Generate idiomatic Go code for databases based on existing schema definitions or custom queries supporting PostgreSQL, MySQL, SQLite, Oracle, and Microsoft SQL Server.
 
+**[⬆ back to top](#contents)**
+
 ## Database Drivers
 
 *Libraries for connecting and operating databases.*
@@ -634,6 +659,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
     * [dsc](https://github.com/viant/dsc) - Datastore connectivity for SQL, NoSQL, structured files.
     * [gokv](https://github.com/philippgille/gokv) - Simple key-value store abstraction and implementations for Go (Redis, Consul, etcd, bbolt, BadgerDB, LevelDB, Memcached, DynamoDB, S3, PostgreSQL, MongoDB, CockroachDB and many more).
 
+**[⬆ back to top](#contents)**
+
 ## Date and Time
 
 *Libraries for working with dates and times.*
@@ -658,6 +685,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [timespan](https://github.com/SaidinWoT/timespan) - For interacting with intervals of time, defined as a start time and a duration.
 * [timeutil](https://github.com/leekchan/timeutil) - Useful extensions (Timedelta, Strftime, ...) to the golang's time package.
 * [tuesday](https://github.com/osteele/tuesday) - Ruby-compatible Strftime function.
+
+**[⬆ back to top](#contents)**
 
 ## Distributed Systems
 
@@ -712,6 +741,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [sleuth](https://github.com/ursiform/sleuth) - Library for master-less p2p auto-discovery and RPC between HTTP services (using [ZeroMQ](https://github.com/zeromq/libzmq)).
 * [torrent](https://github.com/anacrolix/torrent) - BitTorrent client package.
 
+**[⬆ back to top](#contents)**
+
 ## Dynamic DNS
 
 *Tools for updating dynamic DNS records.*
@@ -719,6 +750,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [DDNS](https://github.com/skibish/ddns) - Personal DDNS client with Digital Ocean Networking DNS as backend.
 * [dyndns](https://gitlab.com/alcastle/dyndns) - Background Go process to regularly and automatically check your IP Address and make updates to (one or many) Dynamic DNS records for Google domains whenever your address changes.
 * [GoDNS](https://github.com/timothyye/godns) - A dynamic DNS client tool, supports DNSPod & HE.net, written in Go.
+
+**[⬆ back to top](#contents)**
 
 ## Email
 
@@ -741,6 +774,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [MailHog](https://github.com/mailhog/MailHog) - Email and SMTP testing with web and API interface.
 * [SendGrid](https://github.com/sendgrid/sendgrid-go) - SendGrid's Go library for sending email.
 * [smtp](https://github.com/mailhog/smtp) - SMTP server protocol state machine.
+
+**[⬆ back to top](#contents)**
 
 ## Embeddable Scripting Languages
 
@@ -765,6 +800,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [purl](https://github.com/ian-kent/purl) - Perl 5.18.2 embedded in Go.
 * [tengo](https://github.com/d5/tengo) - Bytecode compiled script language for Go.
 
+**[⬆ back to top](#contents)**
+
 ## Error Handling
 
 *Libraries for handling errors.*
@@ -781,6 +818,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [Falcon](https://github.com/SonicRoshan/falcon) - A Simple Yet Highly Powerful Package For Error Handling.
 * [go-multierror](https://github.com/hashicorp/go-multierror) - Go (golang) package for representing a list of errors as a single error.
 * [tracerr](https://github.com/ztrue/tracerr) - Golang errors with stack trace and source fragments.
+
+**[⬆ back to top](#contents)**
 
 ## File Handling
 
@@ -811,6 +850,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [todotxt](https://github.com/1set/todotxt) - Go library for Gina Trapani's [*todo.txt*](http://todotxt.org/) files, supports parsing and manipulating of task lists in the [*todo.txt* format](https://github.com/todotxt/todo.txt).
 * [vfs](https://github.com/C2FO/vfs) - A pluggable, extensible, and opinionated set of filesystem functionality for Go across a number of filesystem types such as os, S3, and GCS.
 
+**[⬆ back to top](#contents)**
+
 ## Financial
 
 *Packages for accounting and finance.*
@@ -835,6 +876,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [transaction](https://github.com/claygod/transaction) - Embedded transactional database of accounts, running in multithreaded mode.
 * [vat](https://github.com/dannyvankooten/vat) - VAT number validation & EU VAT rates.
 
+**[⬆ back to top](#contents)**
+
 ## Forms
 
 *Libraries for working with forms.*
@@ -850,6 +893,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [qs](https://github.com/sonh/qs) - Go module for encoding structs into URL query parameters.
 * [queryparam](https://github.com/tomwright/queryparam) - Decode `url.Values` into usable struct values of standard or custom types.
 
+**[⬆ back to top](#contents)**
+
 ## Functional
 
 *Packages to support functional programming in Go.*
@@ -858,6 +903,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [fuego](https://github.com/seborama/fuego) - Functional Experiment in Go.
 * [go-underscore](https://github.com/tobyhede/go-underscore) - Useful collection of helpfully functional Go collection utilities.
 * [gofp](https://github.com/rbrahul/gofp) - A lodash like powerful utility library for Golang.
+
+**[⬆ back to top](#contents)**
 
 ## Game Development
 
@@ -882,6 +929,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [termloop](https://github.com/JoelOtter/termloop) - Terminal-based game engine for Go, built on top of Termbox.
 * [tile](https://github.com/kelindar/tile) - Data-oriented and cache-friendly 2D Grid library (TileMap), includes pathfinding, observers and import/export.
 
+**[⬆ back to top](#contents)**
+
 ## Generation and Generics
 
 *Tools to enhance the language with features like generics via code generation.*
@@ -901,6 +950,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [pkgreflect](https://github.com/ungerik/pkgreflect) - Go preprocessor for package scoped reflection.
 * [typeregistry](https://github.com/xiaoxin01/typeregistry) - A library to create type dynamically.
 
+**[⬆ back to top](#contents)**
+
 ## Geographic
 
 *Geographic tools and servers*
@@ -916,6 +967,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [Tile38](https://github.com/tidwall/tile38) - Geolocation DB with spatial index and realtime geofencing.
 * [WGS84](https://github.com/wroge/wgs84) - Library for Coordinate Conversion and Transformation (ETRS89, OSGB36, NAD83, RGF93, Web Mercator, UTM).
 
+**[⬆ back to top](#contents)**
+
 ## Go Compilers
 
 *Tools for compiling Go to other languages.*
@@ -924,6 +977,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [f4go](https://github.com/Konstantin8105/f4go) - Transpile FORTRAN 77 code to Go code.
 * [gopherjs](https://github.com/gopherjs/gopherjs) - Compiler from Go to JavaScript.
 * [tardisgo](https://github.com/tardisgo/tardisgo) - Golang to Haxe to CPP/CSharp/Java/JavaScript transpiler.
+
+**[⬆ back to top](#contents)**
 
 ## Goroutines
 
@@ -972,6 +1027,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [worker-pool](https://github.com/vardius/worker-pool) - goworker is a Go simple async worker pool.
 * [workerpool](https://github.com/gammazero/workerpool) - Goroutine pool that limits the concurrency of task execution, not the number of tasks queued.
 
+**[⬆ back to top](#contents)**
+
 ## GUI
 
 *Libraries for building GUI Applications.*
@@ -1003,11 +1060,15 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [zenity](https://github.com/ncruces/zenity) - Cross-platform Go library and CLI to create simple dialogs that interact graphically with the user.
 
 
+**[⬆ back to top](#contents)**
+
 ## Hardware
 
 *Libraries, tools, and tutorials for interacting with hardware.*
 
 See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive list.
+
+**[⬆ back to top](#contents)**
 
 ## Images
 
@@ -1056,6 +1117,8 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [tga](https://github.com/ftrvxmtrx/tga) - Package tga is a TARGA image format decoder/encoder.
 * [webp-server](https://github.com/mehdipourfar/webp-server) - Simple and minimal image server capable of storing, resizing, converting and caching images.
 
+**[⬆ back to top](#contents)**
+
 ## IoT (Internet of Things)
 
 *Libraries for programming devices of the IoT.*
@@ -1071,6 +1134,8 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [mainflux](https://github.com/Mainflux/mainflux) - Industrial IoT Messaging and Device Management Server.
 * [periph](https://periph.io/) - Peripherals I/O to interface with low-level board facilities.
 * [sensorbee](https://github.com/sensorbee/sensorbee) - Lightweight stream processing engine for IoT.
+
+**[⬆ back to top](#contents)**
 
 ## Job Scheduler
 
@@ -1088,6 +1153,8 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [sched](https://github.com/romshark/sched) - A job scheduler with the ability to fast-forward time.
 * [scheduler](https://github.com/carlescere/scheduler) - Cronjobs scheduling made easy.
 * [tasks](https://github.com/madflojo/tasks) - An easy to use in-process scheduler for recurring tasks in Go.
+
+**[⬆ back to top](#contents)**
 
 ## JSON
 
@@ -1124,6 +1191,8 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [omg.jsonparser](https://github.com/dedalqq/omg.jsonparser) - Simple JSON parser with validation by condition via golang struct fields tags.
 * [ujson](https://github.com/olvrng/ujson) - Fast and minimal JSON parser and transformer that works on unstructured JSON.
 * [vjson](https://github.com/miladibra10/vjson) - Go package for validating JSON objects with declaring a JSON schema with fluent API.
+
+**[⬆ back to top](#contents)**
 
 ## Logging
 
@@ -1180,6 +1249,8 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [zerolog](https://github.com/rs/zerolog) - Zero-allocation JSON logger.
 * [zkits-logger](https://github.com/edoger/zkits-logger) - A powerful zero-dependency JSON logger.
 
+**[⬆ back to top](#contents)**
+
 ## Machine Learning
 
 *Libraries for Machine Learning.*
@@ -1222,6 +1293,8 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [shield](https://github.com/eaigner/shield) - Bayesian text classifier with flexible tokenizers and storage backends for Go.
 * [tfgo](https://github.com/galeone/tfgo) - Easy to use Tensorflow bindings: simplifies the usage of the official Tensorflow Go bindings. Define computational graphs in Go, load and execute models trained in Python.
 * [Varis](https://github.com/Xamber/Varis) - Golang Neural Network.
+
+**[⬆ back to top](#contents)**
 
 ## Messaging
 
@@ -1277,6 +1350,8 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [Uniqush-Push](https://github.com/uniqush/uniqush-push) - Redis backed unified push service for server-side notifications to mobile devices.
 * [zmq4](https://github.com/pebbe/zmq4) - Go interface to ZeroMQ version 4. Also available for [version 3](https://github.com/pebbe/zmq3) and [version 2](https://github.com/pebbe/zmq2).
 
+**[⬆ back to top](#contents)**
+
 ## Microsoft Office
 
 * [unioffice](https://github.com/unidoc/unioffice) - Pure go library for creating and processing Office Word (.docx), Excel (.xlsx) and Powerpoint (.pptx) documents.
@@ -1290,6 +1365,8 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [goxlsxwriter](https://github.com/fterrag/goxlsxwriter) - Golang bindings for libxlsxwriter for writing XLSX (Microsoft Excel) files.
 * [xlsx](https://github.com/tealeg/xlsx) - Library to simplify reading the XML format used by recent version of Microsoft Excel in Go programs.
 * [xlsx](https://github.com/plandem/xlsx) - Fast and safe way to read/update your existing Microsoft Excel files in Go programs.
+
+**[⬆ back to top](#contents)**
 
 ## Miscellaneous
 
@@ -1310,6 +1387,8 @@ See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive lis
 * [nject/npoint](https://github.com/BlueOwlOpenSource/nject) - A type safe, reflective framework based on types for libraries, tests, and endpoints.
 * [wire](https://github.com/Fs02/wire) - Strict Runtime Dependency Injection for Golang.
 
+**[⬆ back to top](#contents)**
+
 ### Project Layout
 
 _**Unofficial** set of patterns for structuring projects._
@@ -1326,6 +1405,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [scaffold](https://github.com/catchplay/scaffold) - Scaffold generates a starter Go project layout. Lets you focus on business logic implemented.
 * [wangyoucao577/go-project-layout](https://github.com/wangyoucao577/go-project-layout) - Set of practices and discussions on how to structure Go project layout.
 
+**[⬆ back to top](#contents)**
+
 ### Strings
 
 *Libraries for working with strings.*
@@ -1335,6 +1416,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [gobeam/Stringy](https://github.com/gobeam/Stringy) - String manipulation library to convert string to camel case, snake case, kebab case / slugify etc.
 * [strutil](https://github.com/ozgio/strutil) - String utilities.
 * [xstrings](https://github.com/huandu/xstrings) - Collection of useful string functions ported from other languages.
+
+**[⬆ back to top](#contents)**
 
 ### Uncategorized
 
@@ -1391,6 +1474,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [xdg](https://github.com/rkoesters/xdg) - FreeDesktop.org (xdg) Specs implemented in Go.
 * [xkg](https://github.com/go-xkg/xkg) - X Keyboard Grabber.
 
+**[⬆ back to top](#contents)**
+
 ## Natural Language Processing
 
 *Libraries for working with human languages.*
@@ -1436,6 +1521,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [transliterator](https://github.com/alexsergivan/transliterator) - Provides one-way string transliteration with supporting of language-specific transliteration rules.
 * [whatlanggo](https://github.com/abadojack/whatlanggo) - Natural language detection package for Go. Supports 84 languages and 24 scripts (writing systems e.g. Latin, Cyrillic, etc).
 * [when](https://github.com/olebedev/when) - Natural EN and RU language date/time parser with pluggable rules.
+
+**[⬆ back to top](#contents)**
 
 ## Networking
 
@@ -1505,6 +1592,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [winrm](https://github.com/masterzen/winrm) - Go WinRM client to remotely execute commands on Windows machines.
 * [xtcp](https://github.com/xfxdev/xtcp) - TCP Server Framework with simultaneous full duplex communication, graceful shutdown, and custom protocol.
 
+**[⬆ back to top](#contents)**
+
 ### HTTP Clients
 
 *Libraries for making HTTP requests.*
@@ -1523,6 +1612,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [rq](https://github.com/ddo/rq) - A nicer interface for golang stdlib HTTP client.
 * [sling](https://github.com/dghubble/sling) - Sling is a Go HTTP client library for creating and sending API requests.
 
+**[⬆ back to top](#contents)**
+
 ## OpenGL
 
 *Libraries for using OpenGL in Go.*
@@ -1533,6 +1624,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [goxjs/gl](https://github.com/goxjs/gl) - Go cross-platform OpenGL bindings (OS X, Linux, Windows, browsers, iOS, Android).
 * [goxjs/glfw](https://github.com/goxjs/glfw) - Go cross-platform glfw library for creating an OpenGL context and receiving events.
 * [mathgl](https://github.com/go-gl/mathgl) - Pure Go math package specialized for 3D math, with inspiration from GLM.
+
+**[⬆ back to top](#contents)**
 
 ## ORM
 
@@ -1559,6 +1652,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [upper.io/db](https://github.com/upper/db) - Single interface for interacting with different data sources through the use of adapters that wrap mature database drivers.
 * [XORM](https://gitea.com/xorm/xorm) - Simple and powerful ORM for Go. (Support: MySQL, MyMysql, PostgreSQL, Tidb, SQLite3, MsSql and Oracle).
 * [Zoom](https://github.com/albrow/zoom) - Blazing-fast datastore and querying engine built on Redis.
+
+**[⬆ back to top](#contents)**
 
 ## Package Management
 
@@ -1587,6 +1682,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [nut](https://github.com/jingweno/nut) - Vendor Go dependencies.
 * [VenGO](https://github.com/DamnWidget/VenGO) - create and manage exportable isolated go virtual environments.
 
+**[⬆ back to top](#contents)**
+
 ## Performance
 
 * [jaeger](https://github.com/jaegertracing/jaeger) - A distributed tracing system.
@@ -1594,6 +1691,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [profile](https://github.com/pkg/profile) - Simple profiling support package for Go.
 * [statsviz](https://github.com/arl/statsviz) - Live visualization of your Go application runtime statistics.
 * [tracer](https://github.com/kamilsk/tracer) - Simple, lightweight tracing.
+
+**[⬆ back to top](#contents)**
 
 ## Query Language
 
@@ -1612,6 +1711,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [rqp](https://github.com/timsolov/rest-query-parser) - Query Parser for REST API. Filtering, validations, both `AND`, `OR` operations are supported directly in the query.
 * [straf](https://github.com/SonicRoshan/straf) - Easily Convert Golang structs to GraphQL objects.
 
+**[⬆ back to top](#contents)**
+
 ## Resource Embedding
 
 * [debme](https://github.com/leaanthony/debme) - Create an `embed.FS` from an existing `embed.FS` subdirectory.
@@ -1626,6 +1727,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [statik](https://github.com/rakyll/statik) - Embeds static files into a Go executable.
 * [templify](https://github.com/wlbr/templify) - Embed external template files into Go code to create single file binaries.
 * [vfsgen](https://github.com/shurcooL/vfsgen) - Generates a vfsdata.go file that statically implements the given virtual filesystem.
+
+**[⬆ back to top](#contents)**
 
 ## Science and Data Analysis
 
@@ -1665,6 +1768,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [TextRank](https://github.com/DavidBelicza/TextRank) - TextRank implementation in Golang with extendable features (summarization, weighting, phrase extraction) and multithreading (goroutine) support.
 * [triangolatte](https://github.com/tchayen/triangolatte) - 2D triangulation library. Allows translating lines and polygons (both based on points) to the language of GPUs.
 
+**[⬆ back to top](#contents)**
+
 ## Security
 
 *Libraries that are used to help make your application more secure.*
@@ -1698,6 +1803,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [themis](https://github.com/cossacklabs/themis) - high-level cryptographic library for solving typical data security tasks (secure data storage, secure messaging, zero-knowledge proof authentication), available for 14 languages, best fit for multi-platform apps.
 
 
+**[⬆ back to top](#contents)**
+
 ## Serialization
 
 *Libraries and tools for binary serialization.*
@@ -1723,6 +1830,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [pletter](https://github.com/vimeda/pletter) - A standard way to wrap a proto message for message brokers.
 * [structomap](https://github.com/tuvistavie/structomap) - Library to easily and dynamically generate maps from static structures.
 * [unitpacking](https://github.com/recolude/unitpacking) - Library to pack unit vectors into as fewest bytes as possible.
+
+**[⬆ back to top](#contents)**
 
 ## Server Applications
 
@@ -1755,6 +1864,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [Trickster](https://github.com/tricksterproxy/trickster) - HTTP reverse proxy cache and time series accelerator.
 
 
+**[⬆ back to top](#contents)**
+
 ## Stream Processing
 
 *Libraries and tools for stream processing and reactive programming.*
@@ -1762,6 +1873,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [go-streams](https://github.com/reugn/go-streams) - Go stream processing library.
 * [machine](https://github.com/whitaker-io/machine) - Go library for writing and generating stream workers with built in metrics and traceability.
 * [stream](https://github.com/youthlin/stream) - Go Stream, like Java 8 Stream: Filter/Map/FlatMap/Peek/Sorted/ForEach/Reduce...
+
+**[⬆ back to top](#contents)**
 
 ## Template Engines
 
@@ -1790,6 +1903,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [sprig](https://github.com/Masterminds/sprig) - Useful template functions for Go templates.
 * [tbd](https://github.com/lucasepe/tbd) - A really simple way to create text templates with placeholders - exposes extra builtin Git repo metadata
 * [velvet](https://github.com/gobuffalo/velvet) - Complete handlebars implementation in Go.
+
+**[⬆ back to top](#contents)**
 
 ## Testing
 
@@ -1881,6 +1996,8 @@ _**Unofficial** set of patterns for structuring projects._
 * Fail injection
     * [failpoint](https://github.com/pingcap/failpoint) - An implementation of [failpoints](http://www.freebsd.org/cgi/man.cgi?query=fail) for Golang.
 
+**[⬆ back to top](#contents)**
+
 ## Text Processing
 
 *Libraries for parsing and manipulating texts.*
@@ -1951,6 +2068,8 @@ _**Unofficial** set of patterns for structuring projects._
     * [TySug](https://github.com/Dynom/TySug) - Alternative suggestions with respect to keyboard layouts.
     * [xj2go](https://github.com/stackerzzq/xj2go) - Convert xml or json to go struct.
     * [xurls](https://github.com/mvdan/xurls) - Extract urls from text.
+
+**[⬆ back to top](#contents)**
 
 ## Third-party APIs
 
@@ -2047,6 +2166,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [wit-go](https://github.com/wit-ai/wit-go) - Go client for wit.ai HTTP API.
 * [ynab](https://github.com/brunomvsouza/ynab.go) - Go wrapper for the YNAB API.
 * [zooz](https://github.com/gojuno/go-zooz) - Go client for the Zooz API.
+
+**[⬆ back to top](#contents)**
 
 ## Utilities
 
@@ -2202,6 +2323,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [wuzz](https://github.com/asciimoo/wuzz) - Interactive cli tool for HTTP inspection.
 * [xferspdy](https://github.com/monmohan/xferspdy) - Xferspdy provides binary diff and patch library in golang.
 
+**[⬆ back to top](#contents)**
+
 ## UUID
 
 *Libraries for working with UUIDs.*
@@ -2217,6 +2340,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [uuid](https://github.com/gofrs/uuid) - Implementation of Universally Unique Identifier (UUID). Supports both creation and parsing of UUIDs. Actively maintained fork of satori uuid.
 * [uuid](https://github.com/google/uuid) - Go package for UUIDs based on RFC 4122 and DCE 1.1: Authentication and Security Services.
 * [wuid](https://github.com/edwingeng/wuid) - An extremely fast unique number generator, 10-135 times faster than UUID.
+
+**[⬆ back to top](#contents)**
 
 ## Validation
 
@@ -2234,6 +2359,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [validate](https://github.com/gobuffalo/validate) - This package provides a framework for writing validations for Go applications.
 * [validator](https://github.com/go-playground/validator) - Go Struct and Field validation, including Cross Field, Cross Struct, Map, Slice and Array diving.
 
+**[⬆ back to top](#contents)**
+
 ## Version Control
 
 *Libraries for version control.*
@@ -2245,6 +2372,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [go-vcs](https://github.com/sourcegraph/go-vcs) - manipulate and inspect VCS repositories in Go.
 * [hercules](https://github.com/src-d/hercules) - gaining advanced insights from Git repository history.
 * [hgo](https://github.com/beyang/hgo) - Hgo is a collection of Go packages providing read-access to local Mercurial repositories.
+
+**[⬆ back to top](#contents)**
 
 ## Video
 
@@ -2262,6 +2391,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [libvlc-go](https://github.com/adrg/libvlc-go) - Go bindings for libvlc 2.X/3.X/4.X (used by the VLC media player).
 * [m3u8](https://github.com/grafov/m3u8) - Parser and generator library of M3U8 playlists for Apple HLS.
 * [v4l](https://github.com/korandiz/v4l) - Video capture library for Linux, written in Go.
+
+**[⬆ back to top](#contents)**
 
 ## Web Frameworks
 
@@ -2315,6 +2446,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [WebGo](https://github.com/bnkamalesh/webgo) - A micro-framework to build web apps; with handler chaining, middleware and context injection. With standard library compliant HTTP handlers(i.e. http.HandlerFunc).
 * [YARF](https://github.com/yarf-framework/yarf) - Fast micro-framework designed to build REST APIs and web services in a fast and simple way.
 
+**[⬆ back to top](#contents)**
+
 ### Middlewares
 
 #### Actual middlewares
@@ -2347,6 +2480,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [rye](https://github.com/InVisionApp/rye) - Tiny Go middleware library (with canned Middlewares) that supports JWT, CORS, Statsd, and Go 1.7 context.
 * [stats](https://github.com/thoas/stats) - Go middleware that stores various information about your web application.
 
+**[⬆ back to top](#contents)**
+
 ### Routers
 
 * [alien](https://github.com/gernest/alien) - Lightweight and fast http router from outer space.
@@ -2373,6 +2508,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [xmux](https://github.com/rs/xmux) - High performance muxer based on `httprouter` with `net/context` support.
 * [xujiajun/gorouter](https://github.com/xujiajun/gorouter) - A simple and fast HTTP router for Go.
 
+**[⬆ back to top](#contents)**
+
 ## WebAssembly
 
 * [dom](https://github.com/dennwc/dom) - DOM library.
@@ -2382,11 +2519,15 @@ _**Unofficial** set of patterns for structuring projects._
 * [wasmbrowsertest](https://github.com/agnivade/wasmbrowsertest) - Run Go WASM tests in your browser.
 * [webapi](https://github.com/gowebapi/webapi) - Bindings for DOM and HTML generated from WebIDL.
 
+**[⬆ back to top](#contents)**
+
 ## Windows
 
 * [d3d9](https://github.com/gonutz/d3d9) - Go bindings for Direct3D9.
 * [go-ole](https://github.com/go-ole/go-ole) - Win32 OLE implementation for golang.
 * [gosddl](https://github.com/MonaxGT/gosddl) - Converter from SDDL-string to user-friendly JSON. SDDL consist of four part: Owner, Primary Group, DACL, SACL.
+
+**[⬆ back to top](#contents)**
 
 ## XML
 
@@ -2402,6 +2543,8 @@ _**Unofficial** set of patterns for structuring projects._
 # Tools
 
 *Go software and plugins.*
+
+**[⬆ back to top](#contents)**
 
 ## Code Analysis
 
@@ -2434,6 +2577,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [unused](https://github.com/dominikh/go-tools/tree/master/cmd/unused) - unused checks Go code for unused constants, variables, functions and types.
 * [validate](https://github.com/mccoyst/validate) - Automatically validates struct fields with tags.
 
+**[⬆ back to top](#contents)**
+
 ## Editor Plugins
 
 * [Go plugin for JetBrains IDEs](https://plugins.jetbrains.com/plugin/9568-go) - Go plugin for JetBrains IDEs.
@@ -2451,6 +2596,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [vscode-go](https://github.com/golang/vscode-go) - Extension for Visual Studio Code (VS Code) which provides support for the Go language.
 * [Watch](https://github.com/eaburns/Watch) - Runs a command in an acme win on file changes.
 
+**[⬆ back to top](#contents)**
+
 ## Go Generate Tools
 
 * [generic](https://github.com/usk81/generic) - flexible data type for Go.
@@ -2463,6 +2610,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [re2dfa](https://github.com/opennota/re2dfa) - Transform regular expressions into finite state machines and output Go source code.
 * [TOML-to-Go](https://xuri.me/toml-to-go) - Translates TOML into a Go type in the browser instantly.
 * [xgen](https://github.com/xuri/xgen) - XSD (XML Schema Definition) parser and Go/C/Java/Rust/TypeScript code generator.
+
+**[⬆ back to top](#contents)**
 
 ## Go Tools
 
@@ -2484,9 +2633,13 @@ _**Unofficial** set of patterns for structuring projects._
 * [rts](https://github.com/galeone/rts) - RTS: response to struct. Generates Go structs from server responses.
 * [typex](https://github.com/dtgorski/typex) - Examine Go types and their transitive dependencies, alternatively export results as TypeScript value objects (or types) declaration.
 
+**[⬆ back to top](#contents)**
+
 ## Software Packages
 
 *Software written in Go.*
+
+**[⬆ back to top](#contents)**
 
 ### DevOps Tools
 
@@ -2556,6 +2709,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [Wide](https://wide.b3log.org/login) - Web-based IDE for Teams using Golang.
 * [winrm-cli](https://github.com/masterzen/winrm-cli) - Cli tool to remotely execute commands on Windows machines.
 
+**[⬆ back to top](#contents)**
+
 ### Other Software
 
 * [Better Go Playground](https://goplay.tools) - Go playground with syntax highlight, code completion and other features.
@@ -2616,9 +2771,13 @@ _**Unofficial** set of patterns for structuring projects._
 * [wellington](https://github.com/wellington/wellington) - Sass project management tool, extends the language with sprite functions (like Compass).
 * [woke](https://github.com/get-woke/woke) - Detect non-inclusive language in your source code.
 
+**[⬆ back to top](#contents)**
+
 # Resources
 
 *Where to discover new Go libraries.*
+
+**[⬆ back to top](#contents)**
 
 ## Benchmarks
 
@@ -2636,6 +2795,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [kvbench](https://github.com/jimrobinson/kvbench) - Key/Value database benchmark.
 * [skynet](https://github.com/atemerev/skynet) - Skynet 1M threads microbenchmark.
 * [speedtest-resize](https://github.com/fawick/speedtest-resize) - Compare various Image resize algorithms for the Go language.
+
+**[⬆ back to top](#contents)**
 
 ## Conferences
 
@@ -2657,6 +2818,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [GopherCon Vietnam](https://gophercon.vn/) - Ho Chi Minh City, Vietnam.
 * [GothamGo](http://gothamgo.com/) - New York City, USA.
 * [GoWayFest](https://goway.io/) - Minsk, Belarus.
+
+**[⬆ back to top](#contents)**
 
 ## E-Books
 
@@ -2680,6 +2843,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [Writing A Compiler In Go](https://compilerbook.com)
 * [Writing An Interpreter In Go](https://interpreterbook.com)
 
+**[⬆ back to top](#contents)**
+
 ## Gophers
 
 * [Free Gophers Pack](https://github.com/MariaLetta/free-gophers-pack) - Gopher graphics pack by Maria Letta with illustrations and emotional characters in vector and raster.
@@ -2694,6 +2859,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [gophers](https://github.com/rogeralsing/gophers) - random gopher graphics.
 * [gophers](https://github.com/sillecelik/go-gopher) - Gopher amigurumi toy pattern.
 * [gophers](https://github.com/scraly/gophers) - Gophers by Aurélie Vache.
+
+**[⬆ back to top](#contents)**
 
 ## Meetups
 
@@ -2760,6 +2927,8 @@ _**Unofficial** set of patterns for structuring projects._
 
 *Add the group of your city/country here (send **PR**)*
 
+**[⬆ back to top](#contents)**
+
 ## Style Guides
 
 * [bahlo/go-styleguide](https://github.com/bahlo/go-styleguide)
@@ -2771,6 +2940,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [Thanos](https://thanos.io/tip/contributing/coding-style-guide.md/)
 * [Uber](https://github.com/uber-go/guide/blob/master/style.md)
 
+**[⬆ back to top](#contents)**
+
 ## Social Media
 ### Twitter
 
@@ -2780,8 +2951,12 @@ _**Unofficial** set of patterns for structuring projects._
 * [@golangflow](https://twitter.com/golangflow)
 * [@golangweekly](https://twitter.com/golangweekly)
 
+**[⬆ back to top](#contents)**
+
 ### Reddit
  * [r/golang](https://www.reddit.com/r/golang/)
+
+**[⬆ back to top](#contents)**
 
 ## Websites
 
@@ -2820,6 +2995,8 @@ _**Unofficial** set of patterns for structuring projects._
 * [studygolang](https://studygolang.com) - The community of studygolang in China.
 * [Trending Go repositories on GitHub today](https://github.com/trending?l=go) - Good place to find new Go libraries.
 * [TutorialEdge - Golang](https://tutorialedge.net/course/golang/)
+
+**[⬆ back to top](#contents)**
 
 ### Tutorials
 
@@ -2861,3 +3038,5 @@ _**Unofficial** set of patterns for structuring projects._
 * [Working with Go](https://github.com/mkaz/working-with-go) - Intro to go for experienced programmers.
 * [Your basic Go](http://yourbasic.org/golang) - Huge collection of tutorials and how to's.
 * [Learning Go by examples](https://dev.to/aurelievache/learning-go-by-examples-introduction-448n) -  Serie of article in order to learn Golang language by concrete applications as example
+
+**[⬆ back to top](#contents)**

--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [portmidi](https://github.com/rakyll/portmidi) - Go bindings for PortMidi.
 * [vorbis](https://github.com/mccoyst/vorbis) - "Native" Go Vorbis decoder (uses CGO, but has no dependencies).
 
-##
+**[⬆ back to top](#contents)**
 
+## Authentication and OAuth
 
 *Libraries for implementing authentications schemes.*
 
@@ -179,8 +180,9 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [sessionup](https://github.com/swithek/sessionup) - Simple, yet effective HTTP session management and identification package.
 * [sjwt](https://github.com/brianvoe/sjwt) - Simple jwt generator and parser.
 
-##
+**[⬆ back to top](#contents)**
 
+## Blockchain
 
 *Tools for building blockchains.*
 
@@ -188,8 +190,6 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [go-ethereum](https://github.com/ethereum/go-ethereum) - Official Go implementation of the Ethereum protocol.
 * [gossamer](https://github.com/ChainSafe/gossamer) - A Go implementation of the Polkadot Host
 * [tendermint](https://github.com/tendermint/tendermint) - High-performance middleware for transforming a state machine written in any programming language into a Byzantine Fault Tolerant replicated state machine using the Tendermint consensus and blockchain protocols.
-
-
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
Changelist:
* Added a 'back to top' hyperlink to the README.md, you can find at the end of every section that starts with ## and ###.
* Also the Hyperlinks for 'Authentication and OAuth' & 'Blockchain' were missing, I fixed those.

As I was browsing the README.md I found myself jumping between sections inefficiently, decided to add a hyperlink for "Go to top", more specifically to the Contents table.

I hope you find it useful.
Let me know if you want me to change anything.

Thank you,
