### PR TITLE
Replace unmaintained go-hardware link with a selected list of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,7 +1066,12 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 
 *Libraries, tools, and tutorials for interacting with hardware.*
 
-See [go-hardware](https://github.com/rakyll/go-hardware) for a comprehensive list.
+* [emgo](https://github.com/ziutek/emgo) - Go-like language for programming embedded systems (e.g. STM32 MCU).
+* [ghw](https://github.com/jaypipes/ghw) - Golang hardware discovery/inspection library.
+* [go-osc](https://github.com/hypebeast/go-osc) - Open Sound Control (OSC) bindings for Go.
+* [go-rpio](https://github.com/stianeikeland/go-rpio) - GPIO for Go, doesn't require cgo.
+* [joystick](https://github.com/0xcafed00d/joystick) - a polled API to read the state of an attached joystick.
+* [sysinfo](https://github.com/zcalusic/sysinfo) - A pure Go library providing Linux OS / kernel / hardware system information.
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
Golang is very handy when working with hardware. It's trivial to write code that interacts with real objects by using simple protocols (like CANBUS, I2C, SPI, Mavlink), and it's also easy to write more complex libraries that handle most of the job of detecting and establishing communication with a device, sensor or actuator.

At the moment, the Hardware section of awesome-go redirects to an external repository (go-hardware) that has a couple of problems:

* it's unmaintained since 2019; no packages have been added or removed since 2 years
* listed packages are either already present in awesome-go, unmaintained, deprecated or undocumented, with the exception of some entries

I've checked every package listed in go-hardware, here's what i've found:

* [devices](https://github.com/goiot/devices) -> already listed in awesome-go
* [gobot](https://gobot.io/) -> already listed in awesome-go
* [go-gpio](https://github.com/stianeikeland/go-rpio) -> maintained and documented, should be listed in Hardware
* [embd](http://embd.io/) -> disappeared
* [fadecandy](https://github.com/scanlime/fadecandy) -> deprecated
* [godrone](https://github.com/felixge/godrone) -> lacks documentation, lacks tests
* [launchpad](https://github.com/rakyll/launchpad) -> without tests
* [littlebits](https://github.com/rakyll/littlebits) -> unmaintained since 2015
* [piCamera](https://github.com/technomancers/piCamera) -> unmaintained since 2017, no tests
* [hwio](https://github.com/mrmorphic/hwio) -> unmaintained since 2018
* [go-lepton](https://github.com/maruel/go-lepton) -> deprecated
* [go-embedded](https://github.com/SpaceLeap/go-embedded) -> unmaintained since 2015, no tests
* [go-beaglebone](https://github.com/SpaceLeap/go-beaglebone) -> unmaintained since 2015, no tests
* [go-mavlink](https://github.com/SpaceLeap/go-mavlink) -> unmaintained since 2016, no tests
* [joystick](https://github.com/SimulatedSimian/joystick) -> maintained and documented, should be listed in Hardware
* [emgo](https://github.com/ziutek/emgo) -> maintained and documented, should be listed in Hardware
* [go-rpi-rgb-led-matrix](https://github.com/mcuadros/go-rpi-rgb-led-matrix) -> unmaintained since 2018
* [go-rpi-ws281x](https://github.com/mcuadros/go-rpi-ws281x) -> unmaintained since 2018
* [ghw](https://github.com/jaypipes/ghw) -> maintained and documented, should be listed in Hardware
* [sysinfo](https://github.com/zcalusic/sysinfo) -> maintained and documented, should be listed in Hardware
* [go-gl](https://github.com/go-gl) -> already listed in awesome-go
* [go-opc](https://github.com/kellydunn/go-opc) -> unmaintained since 2014
* [go-opencv](https://github.com/go-opencv/go-opencv) -> already listed in awesome-go
* [go-sox](https://github.com/krig/go-sox) -> unmaintained since 2018
* [portaudio-go](https://code.google.com/p/portaudio-go) -> doesn't exist anymore
* [portmidi](https://github.com/rakyll/portmidi) -> lacks tests
* [go-osc](https://github.com/hypebeast/go-osc) -> maintained and documented, should be listed in Hardware
* [openvg](https://github.com/ajstarks/openvg) -> lacks tests, documentation
* [lirc](https://github.com/chbmuc/lirc) -> unmaintained since 2015
* [gocv](https://gocv.io/) -> already listed in awesome-go
* [mdns](https://github.com/hashicorp/mdns) -> already listed in awesome-go
* [gatt](https://github.com/paypal/gatt) -> unmaintained since 2015
* [go.hid](https://github.com/GeertJohan/go.hid) -> deprecated
* [goble](https://github.com/MarinX/goble) -> unmaintained since 2017
* [serial](https://github.com/tarm/serial) -> unmaintained since 2018
* [go-firmata](https://github.com/kraman/go-firmata) -> lacks tests
* [periph](https://periph.io/) -> already listed in awesome-go
* [go-cbk](https://gitlab.com/dnaf/go-ckb) -> lacks tests
* [ble](https://github.com/go-ble/ble) -> lacks tests

My proposal is to replace the go-hardware link with a list of the few go-hardware packages that respect the standards imposed on every other package listed in awesome-go.

In this way, users are able to find useful libraries without looking through an unmaintained list, developers are able to add Hardware packages again, and awesome-go maintainers are able to check hardware packages like every other package.