### PR TITLE
Renaming KrakenD to Lura

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,8 +723,8 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 * [hprose](https://github.com/hprose/hprose-golang) - Very newbility RPC Library, support 25+ languages now.
 * [jsonrpc](https://github.com/osamingo/jsonrpc) - The jsonrpc package helps implement of JSON-RPC 2.0.
 * [jsonrpc](https://github.com/ybbus/jsonrpc) - JSON-RPC 2.0 HTTP client implementation.
-* [KrakenD](https://github.com/devopsfaith/krakend) - Ultra performant API Gateway framework with middlewares.
 * [liftbridge](https://github.com/liftbridge-io/liftbridge) - Lightweight, fault-tolerant message streams for NATS.
+* [lura](https://github.com/luraproject/lura) - Ultra performant API Gateway framework with middlewares.
 * [micro](https://github.com/micro/micro) - A distributed systems runtime for the cloud and beyond.
 * [NATS](https://github.com/nats-io/gnatsd) - Lightweight, high performance messaging system for microservices, IoT, and cloud native systems.
 * [outboxer](https://github.com/italolelis/outboxer) - Outboxer is a go library that implements the outbox pattern.


### PR DESCRIPTION
**Please provide package links to:**
Linux foundation [adopted Lura](https://linuxfoundation.org/en/press-release/open-source-api-gateway-krakend-becomes-linux-foundation-project/) (formerly KrakenD), and this PR fixes the link in the list. No new repository is added in the PR.

- repo link (github.com, gitlab.com, etc): https://github.com/luraproject/lura (renamed https://github.com/devopsfaith/krakend)
- pkg.go.dev: https://pkg.go.dev/github.com/luraproject/lura
- goreportcard.com: https://goreportcard.com/report/github.com/luraproject/lura
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), [gocover](http://gocover.io/) etc.) - 

Very good coverage

**Note**: _that new categories can be added only when there are 3 packages or more._

**Make sure that you've checked the boxes below before you submit PR:**
_not every repository (project) will fit into every option, but most projects should_

- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [ ] I know that this package was not listed before.
- [x] I have added pkg.go.dev link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standards).