### PR TITLE
Added grumpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2615,6 +2615,7 @@ _**Unofficial** set of patterns for structuring projects._
 * [gonerics](http://github.com/bouk/gonerics) - Idiomatic Generics in Go.
 * [gotests](https://github.com/cweill/gotests) - Generate Go tests from your source code.
 * [gounit](https://github.com/hexdigest/gounit) - Generate Go tests using your own templates.
+* [grumpy](https://github.com/google/grumpy) - Compiles Python source code to Go source code which is then compiled to native code, rather than to bytecode.
 * [hasgo](https://github.com/DylanMeeus/hasgo) - Generate Haskell inspired functions for your slices.
 * [re2dfa](https://github.com/opennota/re2dfa) - Transform regular expressions into finite state machines and output Go source code.
 * [TOML-to-Go](https://xuri.me/toml-to-go) - Translates TOML into a Go type in the browser instantly.


### PR DESCRIPTION
Adding the grumpy Code generation tool for Python to Go. Grumpy can act as a near drop-in replacement for CPython 2.7.

> Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Please provide package links to:**

- repo link (github.com, gitlab.com, etc): https://github.com/google/grumpy
- pkg.go.dev: https://pkg.go.dev/github.com/google/grumpy
- goreportcard.com: https://goreportcard.com/report/github.com/google/grumpy
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), [gocover](http://gocover.io/) etc.): https://travis-ci.org/github/google/grumpy

**Note**: _that new categories can be added only when there are 3 packages or more._

**Make sure that you've checked the boxes below before you submit PR:**
_not every repository (project) will fit into every option, but most projects should_

- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added pkg.go.dev link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standards).

Thanks for your PR, you're awesome! :+1:
