### PR TITLE
Add GraphJin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1708,6 +1708,7 @@ _**Unofficial** set of patterns for structuring projects._
 * [dasel](https://github.com/tomwright/dasel) - Query and update data structures using selectors from the command line. Comparable to jq/yq but supports JSON, YAML, TOML and XML with zero runtime dependencies.
 * [gojsonq](https://github.com/thedevsaddam/gojsonq) - A simple Go package to Query over JSON Data.
 * [gqlgen](https://github.com/99designs/gqlgen) - go generate based graphql server library.
+* [graphjin](https://github.com/dosco/graphjin) – GraphJin gives you an instant secure and fast GraphQL API without code. GraphQL is automagically compiled into an efficient SQL query. Use either as a library or a standalone service.
 * [graphql](https://github.com/tmc/graphql) - graphql parser + utilities.
 * [graphql](https://github.com/neelance/graphql-go) - GraphQL server with a focus on ease of use.
 * [graphql-go](https://github.com/graphql-go/graphql) - Implementation of GraphQL for Go.


### PR DESCRIPTION
Adds GraphJin to GraphQL-related projects. It can be used both as a GraphQL-to-SQL compiler in your own Go project, as well as as a standalone service.

- repo link (github.com, gitlab.com, etc): https://github.com/dosco/graphjin
- pkg.go.dev: 
  - https://pkg.go.dev/github.com/dosco/graphjin
  - https://pkg.go.dev/github.com/dosco/graphjin/core
- goreportcard.com: https://goreportcard.com/report/github.com/dosco/graphjin
- coverage service link: -

**Make sure that you've checked the boxes below before you submit PR:**
_not every repository (project) will fit into every option, but most projects should_

- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added pkg.go.dev link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standards).

Thanks for your PR, you're awesome! :+1:
