### PR TITLE
update: nbio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1598,7 +1598,7 @@ _**Unofficial** set of patterns for structuring projects._
 * [llb](https://github.com/kirillDanshin/llb) - It's a very simple but quick backend for proxy servers. Can be useful for fast redirection to predefined domain with zero memory allocation and fast response.
 * [mdns](https://github.com/hashicorp/mdns) - Simple mDNS (Multicast DNS) client/server library in Golang.
 * [mqttPaho](https://eclipse.org/paho/clients/golang/) - The Paho Go Client provides an MQTT client library for connection to MQTT brokers via TCP, TLS or WebSockets.
-* [nbio](https://github.com/lesismal/nbio) - High-performance, non-blocking, event-driven, easy-to-use, least-dependency networking framework written in Go.
+* [nbio](https://github.com/lesismal/nbio) - Pure Go 1000k+ connections solution, support tls/http1.x/websocket and basically compatible with net/http, with high-performance and low memory cost, non-blocking, event-driven, easy-to-use.
 * [NFF-Go](https://github.com/intel-go/nff-go) - Framework for rapid development of performant network functions for cloud and bare-metal (former YANFF).
 * [packet](https://github.com/aerogo/packet) - Send packets over TCP and UDP. It can buffer messages and hot-swap connections if needed.
 * [panoptes-stream](https://github.com/yahoo/panoptes-stream) - A cloud native distributed streaming network telemetry (gNMI, Juniper JTI and Cisco MDT).


### PR DESCRIPTION
[nbio](https://github.com/lesismal/nbio) is already on the list, just want to update its description, because we have implemented more features and so that:
1. Compared with other poller frameworks which does not support tls/http 1.x/websocket, [nbio](https://github.com/lesismal/nbio) has supported tls/http 1.x/websocket for both server and client sides.
2. Compared with other std-based frameworks, [nbio](https://github.com/lesismal/nbio) is the real 1000k+ connections solution without [HOLB](https://docs.solace.com/System-and-Software-Maintenance/HOL-blocking.htm) like problems.