### PR TITLE
adding github.com/samber/lo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2393,6 +2393,7 @@ _General utilities and tools to make your life easier._
 - [koazee](https://github.com/wesovilabs/koazee) - Library inspired in Lazy evaluation and functional programming that takes the hassle out of working with arrays.
 - [lets-go](https://github.com/aplescia-chwy/lets-go) - Go module that provides common utilities for Cloud Native REST API development. Also contains AWS Specific utilities.
 - [limiters](https://github.com/mennanov/limiters) - Rate limiters for distributed applications in Golang with configurable back-ends and distributed locks.
+- [lo](https://github.com/samber/lo) - A Lodash like Go library based on Go 1.18+ Generics (map, filter, contains, find...)
 - [lrserver](https://github.com/jaschaephraim/lrserver) - LiveReload server for Go.
 - [mani](https://github.com/alajmo/mani) - CLI tool to help you manage multiple repositories.
 - [mc](https://github.com/minio/mc) - Minio Client provides minimal tools to work with Amazon S3 compatible cloud storage and filesystems.


### PR DESCRIPTION
[samber/lo](https://github.com/samber/lo)

- repo link (github.com, gitlab.com, etc): https://github.com/samber/lo
- pkg.go.dev: https://pkg.go.dev/github.com/samber/lo
- goreportcard.com: https://goreportcard.com/report/github.com/samber/lo (not applicable: go 1.18+)
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), [gocover](http://gocover.io/) etc.): Not applicable (go 1.18)

Code coverage: 
![image](https://user-images.githubusercontent.com/2951285/156541937-1b40bd0b-f0e7-4ad4-947f-253bb85166ec.png)

Goreportcard or coverage services fail on generics, because it does not support go 1.18 yet.

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link.
- [ ] The repo documentation has a coverage service link.
- [x] The repo documenation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] The authors of the project do not commit directly to the repo, but rather use pull-requests that run the continuous-integration process.

Thanks for your PR, you're awesome! :+1:
