### PR TITLE
Removing Ace:

### DIFF
--- a/README.md
+++ b/README.md
@@ -2004,7 +2004,6 @@ _Libraries and tools for stream processing and reactive programming._
 
 _Libraries and tools for templating and lexing._
 
-- [ace](https://github.com/yosssi/ace) - Ace is an HTML template engine for Go, inspired by Slim and Jade. Ace is a refinement of Gold.
 - [amber](https://github.com/eknkc/amber) - Amber is an elegant templating engine for Go Programming Language It is inspired from HAML and Jade.
 - [damsel](https://github.com/dskinner/damsel) - Markup language featuring html outlining via css-selectors, extensible via pkg html/template and others.
 - [ego](https://github.com/benbjohnson/ego) - Lightweight templating language that lets you write templates in Go. Templates are translated into Go and compiled.


### PR DESCRIPTION
Ace appears to be abandoned:
- The most recent commit is 4 years ago
- It has multiple open issues.

Ace also does not conform to awesome-go current quality standards.

@yosssi Please respond if you would like to keep Ace on awesome-go.