### PR TITLE
Removing Amber

### DIFF
--- a/README.md
+++ b/README.md
@@ -2005,7 +2005,6 @@ _Libraries and tools for stream processing and reactive programming._
 _Libraries and tools for templating and lexing._
 
 - [ace](https://github.com/yosssi/ace) - Ace is an HTML template engine for Go, inspired by Slim and Jade. Ace is a refinement of Gold.
-- [amber](https://github.com/eknkc/amber) - Amber is an elegant templating engine for Go Programming Language It is inspired from HAML and Jade.
 - [damsel](https://github.com/dskinner/damsel) - Markup language featuring html outlining via css-selectors, extensible via pkg html/template and others.
 - [ego](https://github.com/benbjohnson/ego) - Lightweight templating language that lets you write templates in Go. Templates are translated into Go and compiled.
 - [extemplate](https://github.com/dannyvankooten/extemplate) - Tiny wrapper around html/template to allow for easy file-based template inheritance.


### PR DESCRIPTION
Amber appears to be abandoned.
- Most recent commit is 5 years ago
- It has multiple open issues

Amber also does not conform to current awesome-go quality standards

@eknkc please respond if you would like to keep Amber on awesome-go.