### PR TITLE
Removing Damsel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2006,7 +2006,6 @@ _Libraries and tools for templating and lexing._
 
 - [ace](https://github.com/yosssi/ace) - Ace is an HTML template engine for Go, inspired by Slim and Jade. Ace is a refinement of Gold.
 - [amber](https://github.com/eknkc/amber) - Amber is an elegant templating engine for Go Programming Language It is inspired from HAML and Jade.
-- [damsel](https://github.com/dskinner/damsel) - Markup language featuring html outlining via css-selectors, extensible via pkg html/template and others.
 - [ego](https://github.com/benbjohnson/ego) - Lightweight templating language that lets you write templates in Go. Templates are translated into Go and compiled.
 - [extemplate](https://github.com/dannyvankooten/extemplate) - Tiny wrapper around html/template to allow for easy file-based template inheritance.
 - [fasttemplate](https://github.com/valyala/fasttemplate) - Simple and fast template engine. Substitutes template placeholders up to 10x faster than [text/template](https://golang.org/pkg/text/template/).


### PR DESCRIPTION
Damsel appears to be abandoned. The most recent commit was 6 years ago.

While it appears stable, it does not correspond to current awesome-go standards. In particular, it does not have a go.mod file nor any published releases, no report card and no code coverage report.

@dskinner, please reply if you would like to keep Damsel on awesome-go.