### PR TITLE
Removing fasttemplate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2009,7 +2009,6 @@ _Libraries and tools for templating and lexing._
 - [damsel](https://github.com/dskinner/damsel) - Markup language featuring html outlining via css-selectors, extensible via pkg html/template and others.
 - [ego](https://github.com/benbjohnson/ego) - Lightweight templating language that lets you write templates in Go. Templates are translated into Go and compiled.
 - [extemplate](https://github.com/dannyvankooten/extemplate) - Tiny wrapper around html/template to allow for easy file-based template inheritance.
-- [fasttemplate](https://github.com/valyala/fasttemplate) - Simple and fast template engine. Substitutes template placeholders up to 10x faster than [text/template](https://golang.org/pkg/text/template/).
 - [gofpdf](https://github.com/jung-kurt/gofpdf) - PDF document generator with high level support for text, drawing and images.
 - [gospin](https://github.com/m1/gospin) - Article spinning and spintax/spinning syntax engine, useful for A/B, testing pieces of text/articles and creating more natural conversations.
 - [got](https://github.com/goradd/got) - A Go code generator inspired by Hero and Fasttemplate. Has include files, custom tag definitions, injected Go code, language translation, and more.


### PR DESCRIPTION
Fasttemplate appears to be abandoned. The most recent commit was 2 years ago.

Also, fasttemplate does not conform to current awesome-go quality standards.

@valyala, please respond if you would like to keep fasttemplate on awesome-go. Please review the current quality standards.