### PR TITLE
Removing Kasia

### DIFF
--- a/README.md
+++ b/README.md
@@ -2001,7 +2001,6 @@ _Libraries and tools for templating and lexing._
 - [goview](https://github.com/foolin/goview) - Goview is a lightweight, minimalist and idiomatic template library based on golang html/template for building Go web application.
 - [hero](https://github.com/shiyanhui/hero) - Hero is a handy, fast and powerful go template engine.
 - [jet](https://github.com/CloudyKit/jet) - Jet template engine.
-- [kasia.go](https://github.com/ziutek/kasia.go) - Templating system for HTML and other text documents - go implementation.
 - [liquid](https://github.com/osteele/liquid) - Go implementation of Shopify Liquid templates.
 - [maroto](https://github.com/johnfercher/maroto) - A maroto way to create PDFs. Maroto is inspired in Bootstrap and uses gofpdf. Fast and simple.
 - [mustache](https://github.com/hoisie/mustache) - Go implementation of the Mustache template language.


### PR DESCRIPTION
Kasia appears to be abandoned.
- The most recent commit was 7 years ago.
- It does not have a go.mod file
- It does not conform to current awesome-go standards

@ziutek, please reply if you would like to keep kasia on awesome-go