### PR TITLE
Removing Velvet

### DIFF
--- a/README.md
+++ b/README.md
@@ -2027,7 +2027,6 @@ _Libraries and tools for templating and lexing._
 - [Soy](https://github.com/robfig/soy) - Closure templates (aka Soy templates) for Go, following the [official spec](https://developers.google.com/closure/templates/).
 - [sprig](https://github.com/Masterminds/sprig) - Useful template functions for Go templates.
 - [tbd](https://github.com/lucasepe/tbd) - A really simple way to create text templates with placeholders - exposes extra builtin Git repo metadata.
-- [velvet](https://github.com/gobuffalo/velvet) - Complete handlebars implementation in Go.
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
Velvet appears to be abandoned.
- Most recent commit was 5 years ago.
- It does not meet current awesome-go quality standards.

@markbates, please reply if you would like to keep Velvet on awesome-go.