### PR TITLE
Add gotestdox

### DIFF
--- a/README.md
+++ b/README.md
@@ -2779,6 +2779,7 @@ _Plugin for text editors and IDEs._
 - [go-swagger](https://github.com/go-swagger/go-swagger) - Swagger 2.0 implementation for go. Swagger is a simple yet powerful representation of your RESTful API.
 - [godbg](https://github.com/tylerwince/godbg) - Implementation of Rusts `dbg!` macro for quick and easy debugging during development.
 - [gomodrun](https://github.com/dustinblackman/gomodrun/) - Go tool that executes and caches binaries included in go.mod files.
+- [gotestdox](https://github.com/bitfield/gotestdox) - Show Go test results as readable sentences.
 - [gothanks](https://github.com/psampaz/gothanks) - GoThanks automatically stars your go.mod github dependencies, sending this way some love to their maintainers.
 - [igo](https://github.com/rocketlaunchr/igo) - An igo to go transpiler (new language features for Go language!)
 - [modver](https://github.com/bobg/modver) - Compare two versions of a Go module to check the version-number change required (major, minor, or patchlevel), according to [semver](https://semver.org/) rules.


### PR DESCRIPTION
- repo link (github.com, gitlab.com, etc): https://github.com/bitfield/gotestdox
- pkg.go.dev: https://pkg.go.dev/github.com/bitfield/gotestdox
- goreportcard.com: https://goreportcard.com/report/github.com/bitfield/gotestdox
- coverage: 96.4% 

- [X] The package has been added to the list in alphabetical order.
- [X] The package has an appropriate description with correct grammar.
- [X] As far as I know, the package has not been listed here before.
- [X] The repo documentation has a pkg.go.dev link.
- [ ] The repo documentation has a coverage service link.
- [X] The repo documenation has a goreportcard link.
- [X] The repo has a version-numbered release and a go.mod file.
- [X] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [X] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [X] The authors of the project do not commit directly to the repo, but rather use pull-requests that run the continuous-integration process.


