### PR TITLE
Removing port-audio:

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ _Libraries for manipulating audio._
 - [mix](https://github.com/go-mix/mix) - Sequence-based Go-native audio mixer for music apps.
 - [music-theory](https://github.com/go-music-theory/music-theory) - Music theory models in Go.
 - [Oto](https://github.com/hajimehoshi/oto) - A low-level library to play sound on multiple platforms.
-- [PortAudio](https://github.com/gordonklaus/portaudio) - Go bindings for the PortAudio audio I/O library.
 - [portmidi](https://github.com/rakyll/portmidi) - Go bindings for PortMidi.
 
 **[⬆ back to top](#contents)**


### PR DESCRIPTION
- Many open issues including fatal error
- Serious development has been over 5 years ago
- No report card
- No code coverage

Port-audio is scheduled to be removed March 21, 2022. @gordonklaus, please reply with fixes to your repo if you would like to keep port-audio on awesome-go.