### PR TITLE
Remove port-midi:

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,6 @@ _Libraries for manipulating audio._
 - [music-theory](https://github.com/go-music-theory/music-theory) - Music theory models in Go.
 - [Oto](https://github.com/hajimehoshi/oto) - A low-level library to play sound on multiple platforms.
 - [PortAudio](https://github.com/gordonklaus/portaudio) - Go bindings for the PortAudio audio I/O library.
-- [portmidi](https://github.com/rakyll/portmidi) - Go bindings for PortMidi.
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
- Development is mostly over 2 years old
- Many open issues
- No report card
- No code coverage

Port-midi is scheduled to be removed by March 21, 2022. @rakyll, please respond with fixes to your repo that will bring the repo up to current awesome-go quality standards if you would like to keep portmidi on awesome-go.