### PR TITLE
Adding goradd/maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1054,6 +1054,7 @@ _Tools to enhance the language with features like generics via code generation._
 - [go-linq](https://github.com/ahmetalpbalkan/go-linq) - .NET LINQ-like query methods for Go.
 - [go-xray](https://github.com/pieterclaerhout/go-xray) - Helpers for making the use of reflection easier.
 - [goderive](https://github.com/awalterschulze/goderive) - Derives functions from input types.
+- [goradd/maps](https://github.com/goradd/maps) - A maps library using Go 1.18 generics, including safe maps and ordered maps.
 - [gotype](https://github.com/wzshiming/gotype) - Golang source code parsing, usage like reflect package.
 - [goverter](https://github.com/jmattheis/goverter) - Generate converters by defining an interface.
 - [GoWrap](https://github.com/hexdigest/gowrap) - Generate decorators for Go interfaces using simple templates.


### PR DESCRIPTION
> Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Please provide package links to:**

- repo link (github.com, gitlab.com, etc): https://github.com/goradd/maps
- pkg.go.dev: https://pkg.go.dev/github.com/goradd/maps
- goreportcard.com: https://goreportcard.com/report/github.com/goradd/maps
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), [gocover](http://gocover.io/) etc.): https://codecov.io/gh/goradd/maps

**Note**: _that new categories can be added only when there are 3 packages or more._

**Make sure that you've checked the boxes below that apply before you submit PR.**
_Not every repository (project) will require every option, but most projects should. Check the Contribution Guidelines for detials._

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a coverage service link.
- [x] The repo documenation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] The authors of the project do not commit directly to the repo, but rather use pull-requests that run the continuous-integration process.

Thanks for your PR, you're awesome! :+1:

Note that GoReportCard is reporting errors because GoReportCard does not currently support Go 1.18 generics. You will have to run go vet on a local copy under go 1.18 to confirm that the errors reported in GoReportCard are not correct.
