### PR TITLE
Removing gen:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,7 +1048,6 @@ _Awesome game development libraries._
 _Tools to enhance the language with features like generics via code generation._
 
 - [efaceconv](https://github.com/t0pep0/efaceconv) - Code generation tool for high performance conversion from interface{} to immutable type without allocations.
-- [gen](https://github.com/clipperhouse/gen) - Code generation tool for ‘generics’-like functionality.
 - [generis](https://github.com/senselogic/GENERIS) - Code generation tool providing generics, free-form macros, conditional compilation and HTML templating.
 - [go-enum](https://github.com/abice/go-enum) - Code generation for enums from code comments.
 - [go-linq](https://github.com/ahmetalpbalkan/go-linq) - .NET LINQ-like query methods for Go.


### PR DESCRIPTION
- Last update is over 2 years ago
- Many open issues including bug reports, that do not appear to have any activity
- Does not conform to current awesome-go guidelines

@clipperhouse: gen is scheduled to be removed from awesome-go. If you would like to keep it on awesome-go, please reply to this pull-request and update it so that it conforms to current quality standards.

gen will be removed on April 6, 2022