### PR TITLE
Removed encoding:

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,6 @@ _Generic datastructures and algorithms in Go._
 - [deque](https://github.com/gammazero/deque) - Fast ring-buffer deque (double-ended queue).
 - [dict](https://github.com/srfrog/dict) - Python-like dictionaries (dict) for Go.
 - [dsu](https://github.com/ihebu/dsu) - Disjoint Set data structure implementation in Go.
-- [encoding](https://github.com/zhenjl/encoding) - Integer Compression Libraries for Go.
 - [fsm](https://github.com/cocoonspace/fsm) - Finite-State Machine package.
 - [gdcache](https://github.com/ulovecode/gdcache) - A pure non-intrusive cache library implemented by golang, you can use it to implement your own distributed cache.
 - [go-adaptive-radix-tree](https://github.com/plar/go-adaptive-radix-tree) - Go implementation of Adaptive Radix Tree.


### PR DESCRIPTION
- Last commit was 4 years ago
- There is a recent bug report that shows its not working with recent versions of Go, and there is no response from the author.
- It does not conform to current awesome-go standards

@zhenji, @zentures, encoding is scheduled to be removed on March 6, 2022, due to the above issues. If you would like to keep encdoing on awesome-go, please reply to this request with updates to the software.