### PR TITLE
Removing skiplist:

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,6 @@ additional ordered map implementations.
 
 ### Trees
 
-- [goskiplist](https://github.com/ryszard/goskiplist) - Skip list implementation in Go.
 - [hashsplit](http://github.com/bobg/hashsplit) - Split byte streams into chunks, and arrange chunks into trees, with boundaries determined by content, not position.
 - [merkle](https://github.com/bobg/merkle) - Space-efficient computation of Merkle root hashes and inclusion proofs.
 - [merkletree](https://github.com/cbergoon/merkletree) - Implementation of a merkle tree providing an efficient and secure verification of the contents of data structures.

--- a/README.md
+++ b/README.md
@@ -533,7 +533,6 @@ _Generic datastructures and algorithms in Go._
 - [gofal](https://github.com/xxjwxc/gofal) - fractional api for Go.
 - [golang-set](https://github.com/deckarep/golang-set) - Thread-Safe and Non-Thread-Safe high-performance sets for Go.
 - [goset](https://github.com/zoumo/goset) - A useful Set collection implementation for Go.
-- [goskiplist](https://github.com/ryszard/goskiplist) - Skip list implementation in Go.
 - [gostl](https://github.com/liyue201/gostl) - Data structure and algorithm library for go, designed to provide functions similar to C++ STL.
 - [gota](https://github.com/kniren/gota) - Implementation of dataframes, series, and data wrangling methods for Go.
 - [goterator](https://github.com/yaa110/goterator) - Iterator implementation to provide map and reduce functionalities.


### PR DESCRIPTION
- Last commit was 7 years ago
- There are open issues with bug reports
- Author appears to have abandoned the project
- Does not conform to current awesome-go standards


@ryszard, skiplist is scheduled to be removed on April 6, 2022. If you would like to keep skiplist on awesome-go, please update the code, addessing the issues mentioned above.