### PR TITLE
Removing merkletree:

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,6 @@ additional ordered map implementations.
 
 - [hashsplit](http://github.com/bobg/hashsplit) - Split byte streams into chunks, and arrange chunks into trees, with boundaries determined by content, not position.
 - [merkle](https://github.com/bobg/merkle) - Space-efficient computation of Merkle root hashes and inclusion proofs.
-- [merkletree](https://github.com/cbergoon/merkletree) - Implementation of a merkle tree providing an efficient and secure verification of the contents of data structures.
 - [skiplist](https://github.com/MauriceGit/skiplist) - Very fast Go Skiplist implementation.
 - [skiplist](https://github.com/gansidui/skiplist) - Skiplist implementation in Go.
 - [treap](https://github.com/perdata/treap) - Persistent, fast ordered map using tree heaps.

--- a/README.md
+++ b/README.md
@@ -546,7 +546,6 @@ _Generic datastructures and algorithms in Go._
 - [levenshtein](https://github.com/agnivade/levenshtein) - Implementation to calculate levenshtein distance in Go.
 - [memlog](https://github.com/embano1/memlog) - An easy to use, lightweight, thread-safe and append-only in-memory data structure inspired by Apache Kafka.
 - [merkle](https://github.com/bobg/merkle) - Space-efficient computation of Merkle root hashes and inclusion proofs.
-- [merkletree](https://github.com/cbergoon/merkletree) - Implementation of a merkle tree providing an efficient and secure verification of the contents of data structures.
 - [mspm](https://github.com/BlackRabbitt/mspm) - Multi-String Pattern Matching Algorithm for information retrieval.
 - [nan](https://github.com/kak-tus/nan) - Zero allocation Nullable structures in one library with handy conversion functions, marshallers and unmarshallers.
 - [null](https://github.com/emvi/null) - Nullable Go types that can be marshalled/unmarshalled to/from JSON.


### PR DESCRIPTION
- Last commit is 3 years ago
- Project is still in alpha and not progressing
- Open issues and pull requests are not being responded to
- Has no code coverage report

@cbergoon, merkletree is scheduled to be removed from awesome-go on April 6, 2022. If you would like to keep it on awesome-go, please update the code, addressing the issues mentioned above.