### PR TITLE
Removing trie:

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,6 @@ _Generic datastructures and algorithms in Go._
 - [timedmap](https://github.com/zekroTJA/timedmap) - Map with expiring key-value pairs.
 - [treap](https://github.com/perdata/treap) - Persistent, fast ordered map using tree heaps.
 - [treemap](https://github.com/igrmk/treemap) - Generic key-sorted map using a red-black tree under the hood.
-- [trie](https://github.com/derekparker/trie) - Trie implementation in Go.
 - [ttlcache](https://github.com/ReneKroon/ttlcache) - In-memory string-interface{} cache with various time-based expiration options and callbacks.
 - [typ](https://github.com/gurukami/typ) - Null Types, Safe primitive type conversion and fetching value from complex structures.
 - [willf/bloom](https://github.com/willf/bloom) - Go package implementing Bloom filters.


### PR DESCRIPTION
- Last check in was 2 years ago
- Multiple open issues, including failing bug reports
- Does not conform to current awesome-go standards

@derekparker, trie is scheduled to be remove from awesome-go on April 7, 2022. If you would like to keep it on awesome-go, please respond to this request with updates to the trie repo that address the issues mentioned above.