### PR TITLE
Removing go-cache:

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,6 @@ _Databases implemented in Go._
 - [eliasdb](https://github.com/krotik/eliasdb) - Dependency-free, transactional graph database with REST API, phrase search and SQL-like query language.
 - [fastcache](https://github.com/VictoriaMetrics/fastcache) - fast thread-safe inmemory cache for big number of entries. Minimizes GC overhead.
 - [GCache](https://github.com/bluele/gcache) - Cache library with support for expirable Cache, LFU, LRU and ARC.
-- [go-cache](https://github.com/pmylund/go-cache) - In-memory key:value store/cache (similar to Memcached) library for Go, suitable for single-machine applications.
 - [godis](https://github.com/hdt3213/godis) - A Golang implemented high-performance Redis server and cluster.
 - [goleveldb](https://github.com/syndtr/goleveldb) - Implementation of the [LevelDB](https://github.com/google/leveldb) key/value database in Go.
 - [groupcache](https://github.com/golang/groupcache) - Groupcache is a caching and cache-filling library, intended as a replacement for memcached in many cases.


### PR DESCRIPTION
- Last release was 5 years ago
- Many open issues
- Does not conform to current awesome-go standards

@patrickmn, go-cache is scheduled to be removed from awesome-go on April 8, 2022. If you would like to keep go-cache on awesome-go, please reply to this request with fixes for the above issues.