### PR TITLE
Removing scribble:

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,6 @@ _Databases implemented in Go._
 - [pudge](https://github.com/recoilme/pudge) - Fast and simple  key/value store written using Go's standard library.
 - [rosedb](https://github.com/roseduan/rosedb) - An embedded k-v database based on LSM+WAL, supports string, list, hash, set, zset.
 - [rqlite](https://github.com/rqlite/rqlite) - The lightweight, distributed, relational database built on SQLite.
-- [Scribble](https://github.com/nanobox-io/golang-scribble) - Tiny flat file JSON store.
 - [tempdb](https://github.com/rafaeljesus/tempdb) - Key-value store for temporary items.
 - [tidb](https://github.com/pingcap/tidb) - TiDB is a distributed SQL database. Inspired by the design of Google F1.
 - [tiedot](https://github.com/HouzuoGuo/tiedot) - Your NoSQL database powered by Golang.


### PR DESCRIPTION
- No official releases
- Last commit over 3 years ago
- Is a branch of another project that is diverging
- Does not conform to current awesome-go guidlines

@tylerflint, Scribble is scheduled to be removed from awesome-go on April 8, 2022. If you would like to keep Scribble on awesome-go, please respond to this request with fixes to the issues mentioned above. 