### PR TITLE
Add newsapi-go package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2340,6 +2340,7 @@ _Libraries for accessing third party APIs._
 - [megos](https://github.com/andygrunwald/megos) - Client library for accessing an [Apache Mesos](https://mesos.apache.org/) cluster.
 - [minio-go](https://github.com/minio/minio-go) - Minio Go Library for Amazon S3 compatible cloud storage.
 - [mixpanel](https://github.com/dukex/mixpanel) - Mixpanel is a library for tracking events and sending Mixpanel profile updates to Mixpanel from your go applications.
+- [newsapi-go](https://github.com/jellydator/newsapi-go) - Go client for [NewsAPI](https://newsapi.org/).
 - [patreon-go](https://github.com/mxpv/patreon-go) - Go library for Patreon API.
 - [paypal](https://github.com/logpacker/PayPal-Go-SDK) - Wrapper for PayPal payment API.
 - [playlyfe](https://github.com/playlyfe/playlyfe-go-sdk) - The Playlyfe Rest API Go SDK.


### PR DESCRIPTION
- repo link (github.com, gitlab.com, etc): https://github.com/jellydator/newsapi-go
- pkg.go.dev:  https://pkg.go.dev/github.com/jellydator/newsapi-go
- goreportcard.com: https://goreportcard.com/report/github.com/jellydator/newsapi-go
- coverage service link: https://coveralls.io/github/jellydator/newsapi-go?branch=master

- [X] The package has been added to the list in alphabetical order.
- [X] The package has an appropriate description with correct grammar.
- [X] As far as I know, the package has not been listed here before.
- [X] The repo documentation has a pkg.go.dev link.
- [X] The repo documentation has a coverage service link.
- [X] The repo documenation has a goreportcard link.
- [X] The repo has a version-numbered release and a go.mod file.
- [X] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [X] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [X] The authors of the project do not commit directly to the repo, but rather use pull-requests that run the continuous-integration process. (Going forward from v1.0.0)