### PR TITLE
Removing session gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,6 @@ _Libraries for implementing authentications schemes._
 - [scs](https://github.com/alexedwards/scs) - Session Manager for HTTP servers.
 - [securecookie](https://github.com/chmike/securecookie) - Efficient secure cookie encoding/decoding.
 - [session](https://github.com/icza/session) - Go session management for web servers (including support for Google App Engine - GAE).
-- [sessiongate-go](https://github.com/f0rmiga/sessiongate-go) - Go session management using the SessionGate Redis module.
 - [sessions](https://github.com/adam-hanna/sessions) - Dead simple, highly performant, highly customizable sessions service for go http servers.
 - [sessionup](https://github.com/swithek/sessionup) - Simple, yet effective HTTP session management and identification package.
 - [sjwt](https://github.com/brianvoe/sjwt) - Simple jwt generator and parser.


### PR DESCRIPTION
Removing sessiongate:

- Last commit was 4 years ago
- Current build is not passing its own tests

@f0rmiga , sessiongate is scheduled to be removed from awesome-go on May 6, 2022. If you would like to keep it here, please fix your repository to that it is passing tests with a current version of Go and shows code coverage of 80% or more, and then post here so we can confirm.