### PR TITLE
remove efaceconv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,7 +1120,6 @@ _Awesome game development libraries._
 _Tools that generate Go code._
 
 - [copygen](https://github.com/switchupcb/copygen) - Generate type-to-type code without reflection.
-- [efaceconv](https://github.com/t0pep0/efaceconv) - Code generation tool for high performance conversion from interface{} to immutable type without allocations.
 - [generis](https://github.com/senselogic/GENERIS) - Code generation tool providing generics, free-form macros, conditional compilation and HTML templating.
 - [go-enum](https://github.com/abice/go-enum) - Code generation for enums from code comments.
 - [go-linq](https://github.com/ahmetalpbalkan/go-linq) - .NET LINQ-like query methods for Go.


### PR DESCRIPTION
[efaceconv](https://github.com/t0pep0/efaceconv) is scheduled to be removed from awesome-go on May 12, 2022. If you would like it to remain, fix your repository such that it passes tests with a current version of Go and shows code coverage of 80% or more. In addition, your project is failing to meet the following criteria:

- The project has not made an official release within the last year and it has open issues.
- The project has an open-issue from 2016.
- The project does not use Go modules issued in `go 1.13`. Projects must be compatible with Go versions issued in the last year. See https://go.dev/doc/devel/release for release history.

Once completed, post here to confirm.

_Owner: @t0pep0_
_Submission: https://github.com/avelino/awesome-go/pull/1188_