### PR TITLE
remove pkgreflect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,7 +1131,6 @@ _Tools that generate Go code._
 - [GoWrap](https://github.com/hexdigest/gowrap) - Generate decorators for Go interfaces using simple templates.
 - [interfaces](https://github.com/rjeczalik/interfaces) - Command line tool for generating interface definitions.
 - [jennifer](https://github.com/dave/jennifer) - Generate arbitrary Go code without templates.
-- [pkgreflect](https://github.com/ungerik/pkgreflect) - Go preprocessor for package scoped reflection.
 - [typeregistry](https://github.com/xiaoxin01/typeregistry) - A library to create type dynamically.
 
 **[⬆ back to top](#contents)**


### PR DESCRIPTION
[pkgreflect](https://github.com/ungerik/pkgreflect) is scheduled to be removed from awesome-go on May 12, 2022. If you would like it to remain, fix your repository such that it passes tests with a current version of Go and shows code coverage of 80% or more. In addition, your project is failing to meet the following criteria:

- The project does not use Go modules issued in `go 1.13`. Projects must be compatible with Go versions issued in the last year. See https://go.dev/doc/devel/release for release history.

Once completed, post here to confirm.

_Owner: @ungerik_
_Submission: https://github.com/avelino/awesome-go/pull/113_