### PR TITLE
run stale repo check as test instead

### DIFF
--- a/.github/workflows/run-check.yaml
+++ b/.github/workflows/run-check.yaml
@@ -13,6 +13,6 @@ jobs:
     - name: Get dependencies
       run: go get -v -t -d ./...
     - name: run script
-      run: go run test_stale_repositories.go scripts.go
+      run: go test stale_repositories_test.go scripts.go
       env:
         OAUTH_TOKEN: ${{secrets.OAUTH_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 tmpl/index.html
 awesome-go
+vendor
 
 # Folders
 .idea

--- a/stale_repositories_test.go
+++ b/stale_repositories_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"testing"
 	"text/template"
 	"time"
 
@@ -35,8 +37,6 @@ const deadLinkMessage = " this repository might no longer exist! (status code >=
 const movedPermanently = " status code 301 received"
 const status302 = " status code 302 received"
 const archived = " repository has been archived"
-
-var delay time.Duration = 1
 
 //LIMIT specifies the max number of repositories that are added in a single run of the script
 var LIMIT = 10
@@ -140,10 +140,7 @@ func getAllFlaggedRepositories(client *http.Client, flaggedRepositories *map[str
 }
 func containsOpenIssue(link string, openIssues map[string]bool) bool {
 	_, ok := openIssues[link]
-	if ok {
-		return true
-	}
-	return false
+	return ok
 }
 func testRepoState(toRun bool, href string, client *http.Client, staleRepos *[]string) bool {
 	if toRun {
@@ -232,7 +229,7 @@ func testStaleRepository() {
 		tokenSource := &tokenSource{
 			AccessToken: oauth,
 		}
-		client = oauth2.NewClient(oauth2.NoContext, tokenSource)
+		client = oauth2.NewClient(context.Background(), tokenSource)
 	}
 	err := getAllFlaggedRepositories(client, &addressedRepositories)
 
@@ -270,6 +267,6 @@ func testStaleRepository() {
 	createIssue(staleRepos, client)
 }
 
-func main() {
+func TestStaleRepository(t *testing.T) {
 	testStaleRepository()
 }


### PR DESCRIPTION
I think this fixes #4264. Instead of running the stale via `go run`, we can run it via `go test`.

I have run the workflow on my fork & it looks like it can work https://github.com/cglotr/awesome-go/actions.

What do you think @avelino?