### PR TITLE
Add lancet(A comprehensive, efficient, and reusable util function library of go) to Utilities section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2569,6 +2569,7 @@ _General utilities and tools to make your life easier._
 - [jump](https://github.com/gsamokovarov/jump) - Jump helps you navigate faster by learning your habits.
 - [koazee](https://github.com/wesovilabs/koazee) - Library inspired in Lazy evaluation and functional programming that takes the hassle out of working with arrays.
 - [lets-go](https://github.com/aplescia-chwy/lets-go) - Go module that provides common utilities for Cloud Native REST API development. Also contains AWS Specific utilities.
+- [lancet](https://github.com/duke-git/lancet) - A comprehensive, efficient, and reusable util function library of go.
 - [limiters](https://github.com/mennanov/limiters) - Rate limiters for distributed applications in Golang with configurable back-ends and distributed locks.
 - [lo](https://github.com/samber/lo) - A Lodash like Go library based on Go 1.18+ Generics (map, filter, contains, find...)
 - [loncha](https://github.com/kazu/loncha) - A high-performance slice Utilities.

--- a/README.md
+++ b/README.md
@@ -2568,8 +2568,8 @@ _General utilities and tools to make your life easier._
 - [jsend](https://github.com/clevergo/jsend) - JSend's implementation writen in Go.
 - [jump](https://github.com/gsamokovarov/jump) - Jump helps you navigate faster by learning your habits.
 - [koazee](https://github.com/wesovilabs/koazee) - Library inspired in Lazy evaluation and functional programming that takes the hassle out of working with arrays.
-- [lets-go](https://github.com/aplescia-chwy/lets-go) - Go module that provides common utilities for Cloud Native REST API development. Also contains AWS Specific utilities.
 - [lancet](https://github.com/duke-git/lancet) - A comprehensive, efficient, and reusable util function library of go.
+- [lets-go](https://github.com/aplescia-chwy/lets-go) - Go module that provides common utilities for Cloud Native REST API development. Also contains AWS Specific utilities.
 - [limiters](https://github.com/mennanov/limiters) - Rate limiters for distributed applications in Golang with configurable back-ends and distributed locks.
 - [lo](https://github.com/samber/lo) - A Lodash like Go library based on Go 1.18+ Generics (map, filter, contains, find...)
 - [loncha](https://github.com/kazu/loncha) - A high-performance slice Utilities.


### PR DESCRIPTION
Feat: add lancet in Utilities section

I find a good go utils function lib, it's lancet. May I add it to Utilities section? Please check blow info.

[lancet](https://github.com/duke-git/lancet)
[lancet-goreportcard](https://goreportcard.com/report/github.com/duke-git/lancet/v2)
[lancet-coverage](https://app.codecov.io/gh/duke-git/lancet)