### PR TITLE
Adding watcher tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ _Libraries and tools helping with build automation._
 - [realize](https://github.com/tockins/realize) - Go build system with file watchers and live reload. Run, build and watch file changes with custom paths.
 - [Task](https://github.com/go-task/task) - simple "Make" alternative.
 - [taskctl](https://github.com/taskctl/taskctl) - Concurrent task runner.
+- [Watcher](https://github.com/radovskyb/watcher) - watcher is a Go package for watching for files or directory changes without using filesystem events.
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
Watcher is a cli tool that is a Go package for watching for files or directory changes without using filesystem events for your Go projects.

- https://github.com/cosmtrek/air
![Go](https://github.com/cosmtrek/air/workflows/Go/badge.svg)


- https://pkg.go.dev/github.com/cosmtrek/air 
[![Go Reference](https://pkg.go.dev/badge/github.com/cosmtrek/air.svg)](https://pkg.go.dev/github.com/cosmtrek/air)

- https://goreportcard.com/report/github.com/cosmtrek/air
 [![Go Report Card](https://goreportcard.com/badge/github.com/cosmtrek/air)](https://goreportcard.com/report/github.com/cosmtrek/air) 
- https://app.codecov.io/gh/cosmtrek/air
[![codecov](https://codecov.io/gh/cosmtrek/air/branch/master/graph/badge.svg)](https://codecov.io/gh/cosmtrek/air)


 <br>
 
- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] The authors of the project do not commit directly to the repo, but rather use pull requests that run the continuous-integration process.
