### PR TITLE
Replace go-appindicator with fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1260,7 +1260,7 @@ _Toolkits_
 
 _Interaction_
 
-- [go-appindicator](https://github.com/dawidd6/go-appindicator) - Go bindings for libappindicator3 C library.
+- [AppIndicator Go](https://github.com/gopherlibs/appindicator) - Go bindings for libappindicator3 C library.
 - [gosx-notifier](https://github.com/deckarep/gosx-notifier) - OSX Desktop Notifications library for Go.
 - [mac-activity-tracker](https://github.com/prashantgupta24/activity-tracker) - OSX library to notify about any (pluggable) activity on your machine.
 - [mac-sleep-notifier](https://github.com/prashantgupta24/mac-sleep-notifier) - OSX Sleep/Wake notifications in golang.


### PR DESCRIPTION
`go-appindicator` was abandoned and eventually archived back on 2022. In February of this year I forked the project to bring it back to life. Now called AppIndicator Go, this project will continue under this new name and URL.

