### PR TITLE
remove go-xray

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,7 +1141,6 @@ _Tools that generate Go code._
 - [generis](https://github.com/senselogic/GENERIS) - Code generation tool providing generics, free-form macros, conditional compilation and HTML templating.
 - [go-enum](https://github.com/abice/go-enum) - Code generation for enums from code comments.
 - [go-linq](https://github.com/ahmetalpbalkan/go-linq) - .NET LINQ-like query methods for Go.
-- [go-xray](https://github.com/pieterclaerhout/go-xray) - Helpers for making the use of reflection easier.
 - [goderive](https://github.com/awalterschulze/goderive) - Derives functions from input types.
 - [gotype](https://github.com/wzshiming/gotype) - Golang source code parsing, usage like reflect package.
 - [goverter](https://github.com/jmattheis/goverter) - Generate converters by defining an interface.


### PR DESCRIPTION
[go-xray](https://github.com/pieterclaerhout/go-xray) is scheduled to be removed from awesome-go on August 11, 2022. If you would like it to remain, fix your repository such that it passes tests with a current version of Go and shows code coverage of 80% or more. In addition, your project is failing to meet the following criteria:

- Official releases should be at least once a year if the project is ongoing. The last release for `go-xray` was on Oct 04, 2019.
- The project does not support generics issued in `go 1.18`. Projects must be compatible with Go versions issued in the last year. See https://go.dev/doc/devel/release for release history.

Once completed, post here to confirm.

_Owner: @pieterclaerhout_
_Submission: https://github.com/avelino/awesome-go/pull/2818_
_NOTE: The project contains 236 Lines Of Go Code._