### PR TITLE
remove cookiestxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,6 @@ _Libraries for implementing authentications schemes._
 - [authboss](https://github.com/volatiletech/authboss) - Modular authentication system for the web. It tries to remove as much boilerplate and "hard things" as possible so that each time you start a new web project in Go, you can plug it in, configure, and start building your app without having to build an authentication system each time.
 - [branca](https://github.com/essentialkaos/branca) - branca token [specification implementation](https://github.com/tuupola/branca-spec) for Golang 1.15+.
 - [casbin](https://github.com/hsluoyz/casbin) - Authorization library that supports access control models like ACL, RBAC, ABAC.
-- [cookiestxt](https://github.com/mengzhuo/cookiestxt) - provides parser of cookies.txt file format.
 - [go-guardian](https://github.com/shaj13/go-guardian) - Go-Guardian is a golang library that provides a simple, clean, and idiomatic way to create powerful modern API and web authentication that supports LDAP, Basic, Bearer token and Certificate based authentication.
 - [go-jose](https://github.com/square/go-jose) - Fairly complete implementation of the JOSE working group's JSON Web Token, JSON Web Signatures, and JSON Web Encryption specs.
 - [gologin](https://github.com/dghubble/gologin) - chainable handlers for login with OAuth1 and OAuth2 authentication providers.


### PR DESCRIPTION
[cookiestxt](https://github.com/mengzhuo/cookiestxt) is scheduled to be removed from awesome-go on August 20, 2022. If you would like it to remain, fix your repository such that it passes tests with a current version of Go and shows code coverage of 80% or more. In addition, your project is failing to meet the following criteria:
- Official releases should be at least once a year if the project is ongoing. The last release for `cookiestxt` was on Mar 08, 2021.
- The project does not support generics issued in go 1.18. Projects must be compatible with Go versions issued in the last year. See https://go.dev/doc/devel/release for release history.

Once completed, post here to confirm.

_Owner: @mengzhuo_
_Submission: https://github.com/avelino/awesome-go/pull/1616_
_Related: https://github.com/avelino/awesome-go/pulls?q=is%3Apr+cookiestxt+is%3Aclosed_
_Prompt: https://github.com/avelino/awesome-go/issues/4352_
_NOTE: 154 Lines of Go Code_