### PR TITLE
remove interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,7 +1147,6 @@ _Tools that generate Go code._
 - [gotype](https://github.com/wzshiming/gotype) - Golang source code parsing, usage like reflect package.
 - [goverter](https://github.com/jmattheis/goverter) - Generate converters by defining an interface.
 - [GoWrap](https://github.com/hexdigest/gowrap) - Generate decorators for Go interfaces using simple templates.
-- [interfaces](https://github.com/rjeczalik/interfaces) - Command line tool for generating interface definitions.
 - [jennifer](https://github.com/dave/jennifer) - Generate arbitrary Go code without templates.
 - [typeregistry](https://github.com/xiaoxin01/typeregistry) - A library to create type dynamically.
 


### PR DESCRIPTION
[interfaces](https://github.com/rjeczalik/interfaces) is scheduled to be removed from awesome-go on August 20, 2022. If you would like it to remain, fix your repository such that it passes tests with a current version of Go and shows code coverage of 80% or more. In addition, your project is failing to meet the following criteria:
- Official releases should be at least once a year if the project is ongoing. The last release for `interfaces` was on Nov 01, 2020.
- The project has 5 open-issues from Nov 02, 2020 and 4 prior.
- The project does not support generics issued in go 1.18. Projects must be compatible with Go versions issued in the last year. See https://go.dev/doc/devel/release for release history.

Once completed, post here to confirm.

_Owner: @rjeczalik_
_Submission: https://github.com/avelino/awesome-go/pull/769_
_NOTE: 1333 Lines of Go Code_