### PR TITLE
remove rbac

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,6 @@ _Libraries for implementing authentications schemes._
 - [otpgo](https://github.com/jltorresm/otpgo) - Time-Based One-Time Password (TOTP) and HMAC-Based One-Time Password (HOTP) library for Go.
 - [paseto](https://github.com/o1egl/paseto) - Golang implementation of Platform-Agnostic Security Tokens (PASETO).
 - [permissions2](https://github.com/xyproto/permissions2) - Library for keeping track of users, login states and permissions. Uses secure cookies and bcrypt.
-- [rbac](https://github.com/zpatrick/rbac) - Minimalistic RBAC package for Go applications.
 - [scope](https://github.com/SonicRoshan/scope) - Easily Manage OAuth2 Scopes In Go.
 - [scs](https://github.com/alexedwards/scs) - Session Manager for HTTP servers.
 - [securecookie](https://github.com/chmike/securecookie) - Efficient secure cookie encoding/decoding.


### PR DESCRIPTION
[rbac](https://github.com/zpatrick/rbac) is scheduled to be removed from awesome-go on August 20, 2022. If you would like it to remain, fix your repository such that it passes tests with a current version of Go and shows code coverage of 80% or more. In addition, your project is failing to meet the following criteria:
- Official releases should be at least once a year if the project is ongoing. The last release for `rbac` was **never** (last commit on Aug 29, 2018).
- The project does not use Go modules issued in go 1.13. Projects must be compatible with Go versions issued in the last year. See https://go.dev/doc/devel/release for release history.
- The project does not support generics issued in go 1.18. Projects must be compatible with Go versions issued in the last year. See https://go.dev/doc/devel/release for release history.

Once completed, post here to confirm.

_Owner: @zpatrick_
_Submission: https://github.com/avelino/awesome-go/pull/2076_
_Prompt: https://github.com/avelino/awesome-go/issues/4352_
_NOTE: 637 Lines of Go Code_