### PR TITLE
Remove goflake

### DIFF
--- a/README.md
+++ b/README.md
@@ -2668,7 +2668,6 @@ _General utilities and tools to make your life easier._
 
 _Libraries for working with UUIDs._
 
-- [goflake](https://github.com/hart87/GoFlake) - A small, scalable, & serverless unique ID generator for use in distributed systems. Inspired by Twitters Snowflake.
 - [goid](https://github.com/jakehl/goid) - Generate and Parse RFC4122 compliant V4 UUIDs.
 - [gouid](https://github.com/twharmon/gouid) - Generate cryptographically secure random string IDs with just one allocation.
 - [nanoid](https://github.com/aidarkhanov/nanoid) - A tiny and efficient Go unique string ID generator.


### PR DESCRIPTION
Remove [goflake](https://github.com/hart87/GoFlake) due to the repository being **inaccessible** or **deleted**.