### PR TITLE
Add github.com/heartwilltell/log to Logging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1446,6 +1446,7 @@ _Libraries for generating and working with log files._
 - [log](https://github.com/apex/log) - Structured logging package for Go.
 - [log](https://github.com/go-playground/log) - Simple, configurable and scalable Structured Logging for Go.
 - [log](https://github.com/teris-io/log) - Structured log interface for Go cleanly separates logging facade from its implementation.
+- [log](https://github.com/heartwilltell/log) - Simple leveled logging wrapper around standard log package.
 - [log-voyage](https://github.com/firstrow/logvoyage) - Full-featured logging saas written in golang.
 - [log15](https://github.com/inconshreveable/log15) - Simple, powerful logging for Go.
 - [logdump](https://github.com/ewwwwwqm/logdump) - Package for multi-level logging.


### PR DESCRIPTION
- repo link (github.com, gitlab.com, etc): https://github.com/heartwilltell/log
- pkg.go.dev: https://pkg.go.dev/github.com/heartwilltell/log
- goreportcard.com: https://goreportcard.com/report/github.com/heartwilltell/log
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), [gocover](http://gocover.io/) etc.): https://app.codecov.io/gh/heartwilltell/log

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] The authors of the project do not commit directly to the repo, but rather use pull requests that run the continuous-integration process.