### PR TITLE
added cifuzz to Continuous Integration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ _Libraries for configuration parsing._
 _Tools for help with continuous integration._
 
 - [CDS](https://github.com/ovh/cds) - Enterprise-Grade CI/CD and DevOps Automation Open Source Platform.
+- [cifuzz](https://github.com/CodeIntelligenceTesting/cifuzz) - CLI tool that helps you to integrate and run fuzzing based tests into your project.
 - [drone](https://github.com/drone/drone) - Drone is a Continuous Integration platform built on Docker, written in Go.
 - [duci](https://github.com/duck8823/duci) - A simple ci server no needs domain specific languages.
 - [go-fuzz-action](https://github.com/jidicula/go-fuzz-action) - Use Go 1.18's built-in fuzz testing in GitHub Actions.


### PR DESCRIPTION
**Links:**
- repo link: https://github.com/CodeIntelligenceTesting/cifuzz
- pkg.go.dev: https://pkg.go.dev/code-intelligence.com/cifuzz
- goreportcard.com: https://goreportcard.com/report/code-intelligence.com/cifuzz


**Checks:**
- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] The authors of the project do not commit directly to the repo, but rather use pull requests that run the continuous-integration process.