### PR TITLE
Add `go.szostok.io/version` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ _Libraries for building standard or basic Command Line applications._
 - [ts](https://github.com/liujianping/ts) - Timestamp convert & compare tool.
 - [ukautz/clif](https://github.com/ukautz/clif) - Small command line interface framework.
 - [urfave/cli](https://github.com/urfave/cli) - Simple, fast, and fun package for building command line apps in Go (formerly codegangsta/cli).
+- [version](https://github.com/mszostok/version) - Collects and displays CLI version information in multiple formats along with upgrade notice.
 - [wlog](https://github.com/dixonwille/wlog) - Simple logging interface that supports cross-platform color and concurrency.
 - [wmenu](https://github.com/dixonwille/wmenu) - Easy to use menu structure for cli applications that prompts users to make choices.
 


### PR DESCRIPTION
**Please provide package links to:**

- repo link:  https://github.com/mszostok/version
- pkg.go.dev: https://pkg.go.dev/go.szostok.io/version
- goreportcard.com: https://goreportcard.com/report/go.szostok.io/version
- coverage service link: https://coveralls.io/github/mszostok/version
   - More about testing: https://szostok.io/projects/version/community/testing/

Checklist:
- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] The authors of the project do not commit directly to the repo, but rather use pull requests that run the continuous-integration process.


Thanks! 