### PR TITLE
remove music-theory from Audio and Music

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,6 @@ _Libraries for manipulating audio._
 - [id3v2](https://github.com/bogem/id3v2) - ID3 decoding and encoding library for Go.
 - [malgo](https://github.com/gen2brain/malgo) - Mini audio library.
 - [minimp3](https://github.com/tosone/minimp3) - Lightweight MP3 decoder library.
-- [music-theory](https://github.com/go-music-theory/music-theory) - Music theory models in Go.
 - [Oto](https://github.com/hajimehoshi/oto) - A low-level library to play sound on multiple platforms.
 - [PortAudio](https://github.com/gordonklaus/portaudio) - Go bindings for the PortAudio audio I/O library.
 


### PR DESCRIPTION
- Last commit was 2 years ago.
- Last release was 3 years ago.
- No activity on open issues for over a year.
- Does not meet awesome-go standards.
  - CI error for 2 years
  - missing gopkg.in requirements

@charneykaye, @lamg, [music-theory](https://github.com/go-music-theory/music-theory) is scheduled to be removed from awesome-go. If you would like to keep it on awesome-go, please reply to this pull request and update it so that it conforms to current quality standards. 