### PR TITLE
glab moved to GitLab as the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2718,11 +2718,11 @@ _Libraries for validation._
 
 _Libraries for version control._
 
+- [cli](https://gitlab.com/gitlab-org/cli) - An open-source GitLab command line tool bringing GitLab's cool features to your command line.
 - [froggit-go](https://github.com/jfrog/froggit-go) - Froggit-Go is a Go library, allowing to perform actions on VCS providers.
 - [gh](https://github.com/rjeczalik/gh) - Scriptable server and net/http middleware for GitHub Webhooks.
 - [git2go](https://github.com/libgit2/git2go) - Go bindings for libgit2.
 - [githooks](https://github.com/gabyx/githooks) - Per-repo and shared Git hooks with version control and auto update.
-- [glab](https://github.com/profclems/glab) - An open-source GitLab command line tool bringing GitLab's cool features to your command line.
 - [go-git](https://github.com/go-git/go-git) - highly extensible Git implementation in pure Go.
 - [go-vcs](https://github.com/sourcegraph/go-vcs) - manipulate and inspect VCS repositories in Go.
 - [hercules](https://github.com/src-d/hercules) - gaining advanced insights from Git repository history.


### PR DESCRIPTION
This updates the glab entry to point to the new canonical repo on GitLab. Announcement was made in
https://github.com/profclems/glab/issues/983

> Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Please provide package links to:**

- repo link (github.com, gitlab.com, etc):
- pkg.go.dev:
- goreportcard.com:
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), [gocover](http://gocover.io/) etc.):

**Note**: _that new categories can be added only when there are 3 packages or more._

**Make sure that you've checked the boxes below that apply before you submit PR.**
_Not every repository (project) will require every option, but most projects should. Check the Contribution Guidelines for detials._

- [ ] The package has been added to the list in alphabetical order.
- [ ] The package has an appropriate description with correct grammar.
- [ ] As far as I know, the package has not been listed here before.
- [ ] The repo documentation has a pkg.go.dev link.
- [ ] The repo documentation has a coverage service link.
- [ ] The repo documentation has a goreportcard link.
- [ ] The repo has a version-numbered release and a go.mod file.
- [ ] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [ ] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [ ] The authors of the project do not commit directly to the repo, but rather use pull requests that run the continuous-integration process.

Thanks for your PR, you're awesome! :+1:
