### PR TITLE
gotestfmt is moving to the GoTestTools org

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ _Tools for help with continuous integration._
 - [duci](https://github.com/duck8823/duci) - A simple ci server no needs domain specific languages.
 - [go-fuzz-action](https://github.com/jidicula/go-fuzz-action) - Use Go 1.18's built-in fuzz testing in GitHub Actions.
 - [gomason](https://github.com/nikogura/gomason) - Test, Build, Sign, and Publish your go binaries from a clean workspace.
-- [gotestfmt](https://github.com/haveyoudebuggedit/gotestfmt) - go test output for humans.
+- [gotestfmt](https://github.com/GoTestTools/gotestfmt) - go test output for humans.
 - [goveralls](https://github.com/mattn/goveralls) - Go integration for Coveralls.io continuous code coverage tracking system.
 - [overalls](https://github.com/go-playground/overalls) - Multi-Package go project coverprofile for tools like goveralls.
 - [roveralls](https://github.com/LawrenceWoodman/roveralls) - Recursive coverage testing tool.


### PR DESCRIPTION
Update to gotestfmt originally submitted in #3681: this tool is moving to the [GoTestTools](https://github.com/GoTestTools/) organization, see the [announcement](https://github.com/GoTestTools/gotestfmt/discussions/46).