### PR TITLE
Add golang.dk to list of websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -3393,6 +3393,7 @@ _Where to discover new Go libraries._
 - [Golang Resources](https://golangresources.com) - A curation of the best articles, exercises, talks and videos to learn Go.
 - [golang-graphics](https://github.com/mholt/golang-graphics) - Collection of Go images, graphics, and art.
 - [golang-nuts](https://groups.google.com/forum/#!forum/golang-nuts) - Go mailing list.
+- [golang.dk](https://www.golang.dk) - Go courses with a focus on building for the cloud.
 - [Google Plus Community](https://plus.google.com/communities/114112804251407510571) - The Google+ community for #golang enthusiasts.
 - [Gopher Community Chat](https://invite.slack.golangbridge.org) - Join Our New Slack Community For Gophers ([Understand how it came](https://blog.gopheracademy.com/gophers-slack-community/)).
 - [Gophercises](https://gophercises.com/) - Free coding exercises for budding gophers.


### PR DESCRIPTION
This adds www.golang.dk to the list of websites. Similar to other websites on the list, it's a course website with free and paid parts. Developers can go and learn about building web apps especially for the cloud.

I'm not exactly sure how much of the contribution guidelines apply to websites like this, but I've done my best to adhere to them.

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [ ] The repo documentation has a pkg.go.dev link.
- [ ] The repo documentation has a coverage service link.
- [ ] The repo documentation has a goreportcard link.
- [ ] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [ ] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [ ] The authors of the project do not commit directly to the repo, but rather use pull requests that run the continuous-integration process.

Thanks for your PR, you're awesome! :+1:
