### PR TITLE
refactor(tests): Use net/http constants for status codes

### DIFF
--- a/stale_repositories_test.go
+++ b/stale_repositories_test.go
@@ -160,17 +160,17 @@ func testRepoState(toRun bool, href string, client *http.Client, staleRepos *[]s
 		}
 		defer resp.Body.Close()
 		json.NewDecoder(resp.Body).Decode(&repoResp)
-		if resp.StatusCode == 301 {
+		if resp.StatusCode == http.StatusMovedPermanently {
 			*staleRepos = append(*staleRepos, href+movedPermanently)
-			log.Printf("%s returned 301", href)
+			log.Printf("%s returned %d", href, resp.StatusCode)
 			isRepoAdded = true
 		}
-		if resp.StatusCode == 302 && !isRepoAdded {
+		if resp.StatusCode == http.StatusFound && !isRepoAdded {
 			*staleRepos = append(*staleRepos, href+status302)
-			log.Printf("%s returned 302", href)
+			log.Printf("%s returned %d", href, resp.StatusCode)
 			isRepoAdded = true
 		}
-		if resp.StatusCode >= 400 && !isRepoAdded {
+		if resp.StatusCode >= http.StatusBadRequest && !isRepoAdded {
 			*staleRepos = append(*staleRepos, href+deadLinkMessage)
 			log.Printf("%s might not exist!", href)
 			isRepoAdded = true


### PR DESCRIPTION
It's best to use the built-in library constants for status codes when possible as it improves readability, rather than having to look up status code definitions when otherwise changing behaviour.

---

Since this is a refactor to the repo's tests itself, I've removed the usual PR template that's meant for entries to the list.