### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/run-check.yaml
+++ b/.github/workflows/run-check.yaml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
+
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     name: Running test

--- a/.github/workflows/site-deploy.yaml
+++ b/.github/workflows/site-deploy.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'main'
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     name: Make and Deploy site

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,9 @@ on:
       - 'main'
   pull_request:
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     name: Running test


### PR DESCRIPTION
> Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Please provide package links to:**

- repo link (github.com, gitlab.com, etc):
- pkg.go.dev:
- goreportcard.com:
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), [gocover](http://gocover.io/) etc.):

**Note**: _that new categories can be added only when there are 3 packages or more._

**Make sure that you've checked the boxes below that apply before you submit PR.**
_Not every repository (project) will require every option, but most projects should. Check the Contribution Guidelines for details._

- [ ] The package has been added to the list in alphabetical order.
- [ ] The package has an appropriate description with correct grammar.
- [ ] As far as I know, the package has not been listed here before.
- [ ] The repo documentation has a pkg.go.dev link.
- [ ] The repo documentation has a coverage service link.
- [ ] The repo documentation has a goreportcard link.
- [ ] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [ ] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [ ] The authors of the project do not commit directly to the repo, but rather use pull requests that run the continuous-integration process.

Thanks for your PR, you're awesome! :+1:

----------------------------------------
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.