### PR TITLE
Remove oauth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,6 @@ _Libraries for implementing authentication schemes._
 - [jwt-auth](https://github.com/adam-hanna/jwt-auth) - JWT middleware for Golang http servers with many configuration options.
 - [keto](https://github.com/ory/keto) - Open Source (Go) implementation of "Zanzibar: Google's Consistent, Global Authorization System". Ships gRPC, REST APIs, newSQL, and an easy and granular permission language. Supports ACL, RBAC, and other access models.
 - [loginsrv](https://github.com/tarent/loginsrv) - JWT login microservice with plugable backends such as OAuth2 (Github), htpasswd, osiam.
-- [oauth2](https://github.com/golang/oauth2) - Successor of goauth2. Generic OAuth 2.0 package that comes with JWT, Google APIs, Compute Engine, and App Engine support.
 - [osin](https://github.com/openshift/osin) - Golang OAuth2 server library.
 - [otpgen](https://github.com/grijul/otpgen) - Library to generate TOTP/HOTP codes.
 - [otpgo](https://github.com/jltorresm/otpgo) - Time-Based One-Time Password (TOTP) and HMAC-Based One-Time Password (HOTP) library for Go.


### PR DESCRIPTION
The library is no longer being actively maintained. It has over 110 open issues from 8 years ago, several causing it to no longer conform to the standards. There's plenty of eager maintainers with over 70 pull requests, which have not been commented or merged. This is a security (authentication) library which makes lack of maintenance even more dire. I can't see how the library would fulfill `awesome-go` criteria anymore, thus suggest it should be removed.