### PR TITLE
Add Google's Go style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3354,6 +3354,7 @@ _Where to discover new Go libraries._
 - [bahlo/go-styleguide](https://github.com/bahlo/go-styleguide)
 - [CockroachDB](https://github.com/cockroachdb/cockroach/blob/master/docs/style.md)
 - [GitLab](https://docs.gitlab.com/ee/development/go_guide/)
+- [Google](https://google.github.io/styleguide/go/)
 - [Hyperledger](https://github.com/hyperledger/fabric/blob/release-1.4/docs/source/style-guides/go-style.rst)
 - [Magnetico](https://github.com/boramalper/magnetico/wiki/magnetico-Design-Specification)
 - [Sourcegraph](https://about.sourcegraph.com/handbook/engineering/go_style_guide)


### PR DESCRIPTION
Add [Google's Go style guide](https://google.github.io/styleguide/go/), as mentioned [here](https://groups.google.com/g/golang-nuts/c/8_X8O3k62pI).

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).

