### PR TITLE
Add https://github.com/looshch/gouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -3013,6 +3013,7 @@ _Plugin for text editors and IDEs._
 - [gotemplate.io](https://gotemplate.io/) - Online tool to preview `text/template` templates live.
 - [gotestdox](https://github.com/bitfield/gotestdox) - Show Go test results as readable sentences.
 - [gothanks](https://github.com/psampaz/gothanks) - GoThanks automatically stars your go.mod github dependencies, sending this way some love to their maintainers.
+- [gouse](https://github.com/looshch/gouse) - toggle ‘declared but not used’ errors.
 - [igo](https://github.com/rocketlaunchr/igo) - An igo to go transpiler (new language features for Go language!)
 - [modver](https://github.com/bobg/modver) - Compare two versions of a Go module to check the version-number change required (major, minor, or patchlevel), according to [semver](https://semver.org/) rules.
 - [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through go files efficiently with the OctoLinker browser extension for GitHub.


### PR DESCRIPTION
- repo link: https://github.com/looshch/gouse
- pkg.go.dev: https://pkg.go.dev/github.com/looshch/gouse
- goreportcard.com: https://goreportcard.com/report/github.com/looshch/gouse
- coverage service link: https://app.codecov.io/gh/looshch/gouse
  Note about coverage: `TestMain` is a bunch of end-to-end tests and it implicitly covers `handle` and `main` functions. That’s the reason why main contains logic and doesn’t call something like `run()` or `start()`, and why coverage is only 39% as code coverage tools aren’t able to understand this.

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [ ] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
  Note on a continuous integration: this project doesn’t have one since right now I’m the only developer and I always run all the tests after any changes.
- [ ] The authors of the project do not commit directly to the repo, but rather use pull requests that run the continuous-integration process.
