### PR TITLE
Add section for data integration frameworks and add CloudQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
   - [Configuration](#configuration)
   - [Continuous Integration](#continuous-integration)
   - [CSS Preprocessors](#css-preprocessors)
+  - [Data Integration](#data-integration)
   - [Data Structures and Algorithms](#data-structures-and-algorithms)
     - [Bit-packing and Compression](#bit-packing-and-compression)
     - [Bit Sets](#bit-sets)
@@ -506,6 +507,16 @@ _Libraries for preprocessing CSS files._
 
 - [gcss](https://github.com/yosssi/gcss) - Pure Go CSS Preprocessor.
 - [go-libsass](https://github.com/wellington/go-libsass) - Go wrapper to the 100% Sass compatible libsass project.
+
+**[⬆ back to top](#contents)**
+
+## Data Integration Frameworks
+
+_Frameworks for performing ELT / ETL_
+
+- [Benthos](https://github.com/benthosdev/benthos) - A message streaming bridge between a range of protocols.
+- [CloudQuery](http://github.com/cloudquery/cloudquery) - A high-performance ELT data integration framework with pluggable architecture.
+- [omniparser](https://github.com/jf-tech/omniparser) - A versatile ETL library that parses text input (CSV/txt/JSON/XML/EDI/X12/EDIFACT/etc) in streaming fashion and transforms data into JSON output using data-driven schema.
 
 **[⬆ back to top](#contents)**
 
@@ -1544,7 +1555,6 @@ _Libraries that implement messaging systems._
 - [APNs2](https://github.com/sideshow/apns2) - HTTP/2 Apple Push Notification provider for Go — Send push notifications to iOS, tvOS, Safari and OSX apps.
 - [Asynq](https://github.com/hibiken/asynq) - A simple, reliable, and efficient distributed task queue for Go built on top of Redis.
 - [Beaver](https://github.com/Clivern/Beaver) - A real time messaging server to build a scalable in-app notifications, multiplayer games, chat apps in web and mobile apps.
-- [Benthos](https://github.com/Jeffail/benthos) - A message streaming bridge between a range of protocols.
 - [Bus](https://github.com/mustafaturan/bus) - Minimalist message bus implementation for internal communication.
 - [Centrifugo](https://github.com/centrifugal/centrifugo) - Real-time messaging (Websockets or SockJS) server in Go.
 - [Chanify](https://github.com/chanify/chanify) - A push notification server send message to your iOS devices.
@@ -2360,7 +2370,6 @@ See also [Natural Language Processing](#natural-language-processing) and [Text A
 - [gonameparts](https://github.com/polera/gonameparts) - Parses human names into individual name parts.
 - [ltsv](https://github.com/Wing924/ltsv) - High performance [LTSV (Labeled Tab Separated Value)](http://ltsv.org/) reader for Go.
 - [normalize](https://github.com/avito-tech/normalize) - Sanitize, normalize and compare fuzzy text.
-- [omniparser](https://github.com/jf-tech/omniparser) - A versatile ETL library that parses text input (CSV/txt/JSON/XML/EDI/X12/EDIFACT/etc) in streaming fashion and transforms data into JSON output using data-driven schema.
 - [parseargs-go](https://github.com/nproc/parseargs-go) - string argument parser that understands quotes and backslashes.
 - [parth](https://github.com/codemodus/parth) - URL path segmentation parsing.
 - [sdp](https://github.com/gortc/sdp) - SDP: Session Description Protocol [[RFC 4566](https://tools.ietf.org/html/rfc4566)].

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
   - [Configuration](#configuration)
   - [Continuous Integration](#continuous-integration)
   - [CSS Preprocessors](#css-preprocessors)
-  - [Data Integration](#data-integration)
+  - [Data Integration Frameworks](#data-integration-frameworks)
   - [Data Structures and Algorithms](#data-structures-and-algorithms)
     - [Bit-packing and Compression](#bit-packing-and-compression)
     - [Bit Sets](#bit-sets)


### PR DESCRIPTION
This adds a new section for Data Integration Frameworks, moves two existing entries into it and adds a new entry (CloudQuery).

- repo link: https://github.com/cloudquery/cloudquery
- pkg.go.dev: https://pkg.go.dev/github.com/cloudquery/plugin-sdk
- goreportcard.com: https://goreportcard.com/report/github.com/cloudquery/cloudquery and  https://goreportcard.com/report/github.com/cloudquery/plugin-sdk

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link. (Yes, for the [plugin-sdk](https://github.com/cloudquery/plugin-sdk) which is what will be imported if you write a plugin)
- [ ] The repo documentation has a coverage service link. No, but code coverage can be downloaded as an artifact e.g. here https://github.com/cloudquery/plugin-sdk/actions/runs/3996239936
- [x] The repo documentation has a goreportcard link. (Yes, for the [plugin-sdk](https://github.com/cloudquery/plugin-sdk) which is what will be imported if you write a plugin)
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] The authors of the project do not commit directly to the repo, but rather use pull requests that run the continuous-integration process.
