### PR TITLE
remove m3u8

### DIFF
--- a/README.md
+++ b/README.md
@@ -2758,7 +2758,6 @@ _Libraries for manipulating video._
 - [gst](https://github.com/ziutek/gst) - Go bindings for GStreamer.
 - [libgosubs](https://github.com/wargarblgarbl/libgosubs) - Subtitle format support for go. Supports .srt, .ttml, and .ass.
 - [libvlc-go](https://github.com/adrg/libvlc-go) - Go bindings for libvlc 2.X/3.X/4.X (used by the VLC media player).
-- [m3u8](https://github.com/grafov/m3u8) - Parser and generator library of M3U8 playlists for Apple HLS.
 - [v4l](https://github.com/korandiz/v4l) - Video capture library for Linux, written in Go.
 
 **[⬆ back to top](#contents)**


### PR DESCRIPTION
- Last commit was 3 years ago.
- Last release was 3 years ago.
- No activity on open issues.
  - https://github.com/grafov/m3u8/issues/184

Thus it does not meet awesome-go standards.

@grafov, [m3u8](https://github.com/grafov/m3u8) added in https://github.com/avelino/awesome-go/pull/2810 is scheduled to be removed from awesome-go. If you would like to keep it on awesome-go, please reply to this pull request and update it so that it conforms to current quality standards.
It is scheduled to be removed in 1 month, i.e. on 04-03-2023.

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).