### PR TITLE
add dbmate

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,6 +705,7 @@ _Data stores with expiring records, in-memory distributed data stores, or in-mem
 - [avro](https://github.com/khezen/avro) - Discover SQL schemas and convert them to AVRO schemas. Query SQL records into AVRO bytes.
 - [bytebase](https://github.com/bytebase/bytebase) - Safe database schema change and version control for DevOps teams.
 - [darwin](https://github.com/GuiaBolso/darwin) - Database schema evolution library for Go.
+- [dbmate](https://github.com/amacneil/dbmate) - A lightweight, framework-agnostic database migration tool.
 - [go-fixtures](https://github.com/RichardKnop/go-fixtures) - Django style fixtures for Golang's excellent built-in database/sql library.
 - [go-pg-migrate](https://github.com/lawzava/go-pg-migrate) - CLI-friendly package for go-pg migrations management.
 - [go-pg-migrations](https://github.com/robinjoseph08/go-pg-migrations) - A Go package to help write migrations with go-pg/pg.


### PR DESCRIPTION

**Please provide package links to:**

- repo link (github.com, gitlab.com, etc): https://github.com/amacneil/dbmate
- pkg.go.dev: https://pkg.go.dev/github.com/amacneil/dbmate/v2/pkg/dbmate
- goreportcard.com: https://goreportcard.com/report/github.com/amacneil/dbmate
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): n/a

**Note**: _that new categories can be added only when there are 3 packages or more._

**Make sure that you've checked the boxes below that apply before you submit PR.**
_Not every repository (project) will require every option, but most projects should. Check the Contribution Guidelines for details._

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link.
- [ ] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] The authors of the project do not commit directly to the repo, but rather use pull requests that run the continuous-integration process.

Thanks for your PR, you're awesome! :+1:

**Manual code coverage results:**

```
ok  	github.com/amacneil/dbmate/v2/pkg/dbmate	4.338s	coverage: 73.7% of statements
ok  	github.com/amacneil/dbmate/v2/pkg/dbutil	0.005s	coverage: 59.0% of statements
ok  	github.com/amacneil/dbmate/v2/pkg/driver/clickhouse	0.103s	coverage: 89.8% of statements
ok  	github.com/amacneil/dbmate/v2/pkg/driver/mysql	0.184s	coverage: 87.0% of statements
ok  	github.com/amacneil/dbmate/v2/pkg/driver/postgres	6.546s	coverage: 82.4% of statements
ok  	github.com/amacneil/dbmate/v2/pkg/driver/sqlite	0.066s	coverage: 83.1% of statements
```