### PR TITLE
add mshafiee/jalali

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,6 +857,7 @@ _Libraries for working with dates and times._
 - [go-week](https://github.com/stoewer/go-week) - An efficient package to work with ISO8601 week dates.
 - [gostradamus](https://github.com/bykof/gostradamus) - A Go package for working with dates.
 - [iso8601](https://github.com/relvacode/iso8601) - Efficiently parse ISO8601 date-times without regex.
+- [jalali](https://github.com/mshafiee/jalali) - A comprehensive package for the Jalali (Persian, Solar Hijri) calendar that is compatible with Go's standard time package.
 - [kair](https://github.com/GuilhermeCaruso/kair) - Date and Time - Golang Formatting Library.
 - [now](https://github.com/jinzhu/now) - Now is a time toolkit for golang.
 - [NullTime](https://github.com/kirillDanshin/nulltime) - Nullable `time.Time`.


### PR DESCRIPTION
> Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Please provide package links to:**

- repo link (github.com, gitlab.com, etc): https://github.com/mshafiee/jalali
- pkg.go.dev: https://pkg.go.dev/github.com/mshafiee/jalali
- goreportcard.com: https://goreportcard.com/report/github.com/mshafiee/jalali
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://app.codecov.io/github/mshafiee/jalali

**Note**: _that new categories can be added only when there are 3 packages or more._

**Make sure that you've checked the boxes below that apply before you submit PR.**
_Not every repository (project) will require every option, but most projects should. Check the Contribution Guidelines for details._

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] The authors of the project do not commit directly to the repo, but rather use pull requests that run the continuous-integration process.

Thanks for your PR, you're awesome! :+1:
