### PR TITLE
Change tarp to blanket, blanket is on GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -2941,6 +2941,7 @@ _Source code analysis tools, also known as Static Application Security Testing (
 
 - [apicompat](https://github.com/bradleyfalzon/apicompat) - Checks recent changes to a Go project for backwards incompatible changes.
 - [asty](https://github.com/asty-org/asty) - Converts golang AST to JSON and JSON to AST.
+- [blanket](https://gitlab.com/verygoodsoftwarenotvirus/blanket) - blanket is a tool that helps you catch functions which don't have direct unit tests in your Go packages.
 - [ChainJacking](https://github.com/Checkmarx/chainjacking) - Find which of your Go lang direct GitHub dependencies is susceptible to ChainJacking attack.
 - [dupl](https://github.com/mibk/dupl) - Tool for code clone detection.
 - [errcheck](https://github.com/kisielk/errcheck) - Errcheck is a program for checking for unchecked errors in Go programs.
@@ -2962,7 +2963,6 @@ _Source code analysis tools, also known as Static Application Security Testing (
 - [lint](https://github.com/surullabs/lint) - Run linters as part of go test.
 - [php-parser](https://github.com/z7zmey/php-parser) - A Parser for PHP written in Go.
 - [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) - staticcheck is `go vet` on steroids, applying a ton of static analysis checks you might be used to from tools like ReSharper for C#.
-- [tarp](https://github.com/verygoodsoftwarenotvirus/tarp) - tarp finds functions and methods without direct unit tests in Go source code.
 - [tickgit](https://github.com/augmentable-dev/tickgit) - CLI and go package for surfacing code comment TODOs (in any language) and applying a `git blame`to identify the author.
 - [todocheck](https://github.com/preslavmihaylov/todocheck) - Static code analyser which links TODO comments in code with issues in your issue tracker.
 - [unconvert](https://github.com/mdempsky/unconvert) - Remove unnecessary type conversions from Go source.


### PR DESCRIPTION
- https://pkg.go.dev/gitlab.com/verygoodsoftwarenotvirus/blanket
- https://goreportcard.com/report/gitlab.com/verygoodsoftwarenotvirus/blanket

The repo https://github.com/verygoodsoftwarenotvirus/tarp is archived and moved by the author to https://gitlab.com/verygoodsoftwarenotvirus/blanket. This PR updates its name, link, and description.

<img width="1463" alt="image" src="https://user-images.githubusercontent.com/3228886/232234922-a136c6d2-c6bf-4247-8a3a-6b8dc076db97.png">
