### PR TITLE
Add Textra under Go Tools - struct info extractor package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3041,6 +3041,7 @@ _Plugin for text editors and IDEs._
 - [richgo](https://github.com/kyoh86/richgo) - Enrich `go test` outputs with text decorations.
 - [roumon](https://github.com/becheran/roumon) - Monitor current state of all active goroutines via a command line interface.
 - [rts](https://github.com/galeone/rts) - RTS: response to struct. Generates Go structs from server responses.
+- [textra](https://github.com/ravsii/textra) - Extract Go struct field names, types and tags for filtering and exporting.
 - [typex](https://github.com/dtgorski/typex) - Examine Go types and their transitive dependencies, alternatively export results as TypeScript value objects (or types) declaration.
 
 **[⬆ back to top](#contents)**


### PR DESCRIPTION
**Please provide package links to:**

- repo link (github.com, gitlab.com, etc): https://github.com/ravsii/textra
- pkg.go.dev: https://pkg.go.dev/github.com/ravsii/textra
- goreportcard.com: https://goreportcard.com/report/github.com/ravsii/textra
- coverage service link: https://app.codecov.io/gh/ravsii/textra

**Note**: _that new categories can be added only when there are 3 packages or more._

**Make sure that you've checked the boxes below that apply before you submit PR.**
_Not every repository (project) will require every option, but most projects should. Check the Contribution Guidelines for details._

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged. 
- [x] The authors of the project do not commit directly to the repo, but rather use pull requests that run the continuous-integration process. _(Switched to pull requests when updating to v1.1.0)_