### PR TITLE
Adding github.com/mohamedattahri/pgfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1054,6 +1054,7 @@ _Libraries for handling files and file systems._
 - [parquet](https://github.com/parsyl/parquet) - Read and write [parquet](https://parquet.apache.org) files.
 - [pathtype](https://github.com/jonchun/pathtype) - Treat paths as their own type instead of using strings.
 - [pdfcpu](https://github.com/pdfcpu/pdfcpu) - PDF processor.
+- [pgfs](https://github.com/mohamedattahri/pgfs) - `fs.FS` implementation to use a Postgres database as a transactional file system using [Large Objects](https://www.postgresql.org/docs/current/largeobjects.html).
 - [skywalker](https://github.com/dixonwille/skywalker) - Package to allow one to concurrently go through a filesystem with ease.
 - [stl](https://gitlab.com/russoj88/stl) - Modules to read and write STL (stereolithography) files. Concurrent algorithm for reading.
 - [tarfs](https://github.com/posener/tarfs) - Implementation of the [`FileSystem` interface](https://godoc.org/github.com/kr/fs#FileSystem) for tar files.


### PR DESCRIPTION
Adding [pgfs](github.com/mohamedattahri/pgfs), an `fs.FS` implementation to use a Postgres database as a transactional file system using Large Objects.

- repo link (github.com, gitlab.com, etc): https://github.com/mohamedattahri/pgfs
- pkg.go.dev: https://pkg.go.dev/mohamed.attahri.com/pgfs
- goreportcard.com: https://goreportcard.com/report/mohamed.attahri.com/pgfs
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://coveralls.io/github/mohamedattahri/pgfs

# Checklist

- [X] The package has been added to the list in alphabetical order.
- [X] The package has an appropriate description with correct grammar.
- [X] As far as I know, the package has not been listed here before.
- [X] The repo documentation has a pkg.go.dev link.
- [X] The repo documentation has a coverage service link.
- [X] The repo documentation has a goreportcard link.
- [X] The repo has a version-numbered release and a go.mod file.
- [X] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [X] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [X] The authors of the project do not commit directly to the repo, but rather use pull requests that run the continuous-integration process.

