### PR TITLE
Fix #4939

### DIFF
--- a/.github/workflows/pull-request-first-comment.yaml
+++ b/.github/workflows/pull-request-first-comment.yaml
@@ -1,7 +1,7 @@
 name: First comment in new pull request
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
This PR fixes #4939 

The issue was described on used action repo:
- https://github.com/peter-evans/create-or-update-comment/issues/238#issuecomment-1672346754

And more details can be read there:
- https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks

There is also a described exactly this issue scenario (make a comment on opened pull request) and solution provided with explanation:
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ 

### NOTE:

It does not trigger at this PR because it's coming fork and it'll execute from main branch. Therefore it needs to be merged before the change will actually apply (or the repository author would create this PR)

Reference:
- https://stackoverflow.com/questions/76058442/pull-request-target-github-action-not-triggering 