### PR TITLE
add go-test-coverage service link to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 - repo link (github.com, gitlab.com, etc):
 - pkg.go.dev:
 - goreportcard.com:
-- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.):
+- coverage service link ([go-test-coverage](https://github.com/vladopajic/go-test-coverage), [codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.):
 
 **Note**: _that new categories can be added only when there are 3 packages or more._
 


### PR DESCRIPTION
this PR adds link to [go-test-coverage](https://github.com/vladopajic/go-test-coverage) in pull request template.

reasoning to include `go-test-coverage` are following:
- it provides the same level of functionality needed by repository owners (automated coverage check with badge display)
- it's free and open source
- it's easier to setup (no registration or permissions required) 

