### PR TITLE
docs: add WIttyJudge/incache library

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,7 @@ _Data stores with expiring records, in-memory distributed data stores, or in-mem
 - [gocache](https://github.com/yuseferi/gocache) - A data race free Go ache library with high performance and auto pruge functionality
 - [groupcache](https://github.com/golang/groupcache) - Groupcache is a caching and cache-filling library, intended as a replacement for memcached in many cases.
 - [imcache](https://github.com/erni27/imcache) - A generic in-memory cache Go library. It supports expiration, sliding expiration, max entries limit, eviction callbacks and sharding.
+- [incache](https://github.com/WIttyJudge/incache) -  Thread-safe in-memory caching library for Go with expiration time, metrics and more.
 - [nscache](https://github.com/no-src/nscache) - A Go caching framework that supports multiple data source drivers.
 - [remember-go](https://github.com/rocketlaunchr/remember-go) - A universal interface for caching slow database queries (backed by redis, memcached, ristretto, or in-memory).
 - [theine](https://github.com/Yiling-J/theine-go) - High performance, near optimal in-memory cache with proactive TTL expiration and generics.


### PR DESCRIPTION
> Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Please provide package links to:**

- repo link (github.com, gitlab.com, etc): https://github.com/wittyJudge/incache
- pkg.go.dev: https://pkg.go.dev/github.com/wittyjudge/incache
- goreportcard.com: https://goreportcard.com/report/github.com/wittyjudge/incache
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://app.codecov.io/gh/WIttyJudge/incache

**Note**: _that new categories can be added only when there are 3 packages or more._

**Make sure that you've checked the boxes below that apply before you submit PR.**
_Not every repository (project) will require every option, but most projects should. Check the Contribution Guidelines for details._

- [X] The package has been added to the list in alphabetical order.
- [X] The package has an appropriate description with correct grammar.
- [X] As far as I know, the package has not been listed here before.
- [X] The repo documentation has a pkg.go.dev link.
- [X] The repo documentation has a coverage service link.
- [X] The repo documentation has a goreportcard link.
- [X] The repo has a version-numbered release and a go.mod file.
- [X] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [X] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [X] Continuous integration is used to attempt to catch issues prior to releasing this package to end-users.

Thanks for your PR, you're awesome! :+1:
