### PR TITLE
Added M-Way tree algorithms "bits" of sop library under the "Data Str…

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,8 +618,9 @@ additional ordered map implementations.
 ### Trees
 
 - [hashsplit](http://github.com/bobg/hashsplit) - Split byte streams into chunks, and arrange chunks into trees, with boundaries determined by content, not position.
+- [m-way trie](https://github.com/SharedCode/sop) - Generic key-sorted map using M-Way Trie Algorithms(i.e. - load balanced B-Tree) under the hood. Does not use "pointers" thus, Garbage Collector 
 - [merkle](https://github.com/bobg/merkle) - Space-efficient computation of Merkle root hashes and inclusion proofs.
-- [m-way trie](https://github.com/SharedCode/sop) - Generic key-sorted map using M-Way Trie Algorithms(i.e. - load balanced B-Tree) under the hood. Does not use "pointers" thus, Garbage Collector optimized.
+optimized.
 - [skiplist](https://github.com/MauriceGit/skiplist) - Very fast Go Skiplist implementation.
 - [skiplist](https://github.com/gansidui/skiplist) - Skiplist implementation in Go.
 - [treap](https://github.com/perdata/treap) - Persistent, fast ordered map using tree heaps.

--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ additional ordered map implementations.
 
 - [hashsplit](http://github.com/bobg/hashsplit) - Split byte streams into chunks, and arrange chunks into trees, with boundaries determined by content, not position.
 - [merkle](https://github.com/bobg/merkle) - Space-efficient computation of Merkle root hashes and inclusion proofs.
+- [m-way trie](https://github.com/SharedCode/sop) - Generic key-sorted map using M-Way Trie Algorithms(i.e. - load balanced B-Tree) under the hood. Does not use "pointers" thus, Garbage Collector optimized.
 - [skiplist](https://github.com/MauriceGit/skiplist) - Very fast Go Skiplist implementation.
 - [skiplist](https://github.com/gansidui/skiplist) - Skiplist implementation in Go.
 - [treap](https://github.com/perdata/treap) - Persistent, fast ordered map using tree heaps.

--- a/README.md
+++ b/README.md
@@ -618,9 +618,8 @@ additional ordered map implementations.
 ### Trees
 
 - [hashsplit](http://github.com/bobg/hashsplit) - Split byte streams into chunks, and arrange chunks into trees, with boundaries determined by content, not position.
-- [m-way trie](https://github.com/SharedCode/sop) - Generic key-sorted map using M-Way Trie Algorithms(i.e. - load balanced B-Tree) under the hood. Does not use "pointers" thus, Garbage Collector 
+- [m-way trie](https://github.com/SharedCode/sop) - Generic key-sorted map using M-Way Trie Algorithms(i.e. - load balanced B-Tree) under the hood. Does not use "pointers" thus, Garbage Collector optimized.
 - [merkle](https://github.com/bobg/merkle) - Space-efficient computation of Merkle root hashes and inclusion proofs.
-optimized.
 - [skiplist](https://github.com/MauriceGit/skiplist) - Very fast Go Skiplist implementation.
 - [skiplist](https://github.com/gansidui/skiplist) - Skiplist implementation in Go.
 - [treap](https://github.com/perdata/treap) - Persistent, fast ordered map using tree heaps.


### PR DESCRIPTION
> Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Please provide package links to:**

- repo link (github.com, gitlab.com, etc): https://github.com/SharedCode/sop
pkg.go.dev: https://pkg.go.dev/github.com/SharedCode/sop#readme-m-way-trie-algorithms-for-scaleable-object-persistence-sop
coverage: https://app.codecov.io/github/SharedCode/sop/commits
goreportcard.com: https://goreportcard.com/report/github.com/SharedCode/sop

**Note**: _that new categories can be added only when there are 3 packages or more._

**Make sure that you've checked the boxes below that apply before you submit PR.**
_Not every repository (project) will require every option, but most projects should. Check the Contribution Guidelines for details._

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] Continuous integration is used to attempt to catch issues prior to releasing this package to end-users.

Thanks for your PR, you're awesome! :+1:
