### PR TITLE
remove incorrect link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3449,7 +3449,6 @@ _Where to discover new Go libraries._
 - [Golang Lyon](https://www.meetup.com/Golang-Lyon/)
 - [Golang Marseille](https://www.meetup.com/fr-FR/Golang-Marseille/)
 - [Golang Melbourne](https://www.meetup.com/golang-mel/)
-- [Golang Mountain View](https://www.meetup.com/Golang-Mountain-View/)
 - [Golang North East](https://www.meetup.com/en-AU/Golang-North-East/)
 - [Golang Paris](https://www.meetup.com/Golang-Paris/)
 - [Golang Poland](https://www.meetup.com/Golang-Poland/)


### PR DESCRIPTION
The link redirects to a group for learners of the great board game Go, and not golang.

Could not find a corresponding group for golang, so thus removing the link for now.