### PR TITLE
add z5labs/bedrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,7 @@ _Libraries for working with dates and times._
 _Packages that help with building Distributed Systems._
 
 - [arpc](https://github.com/lesismal/arpc) - More effective network communication, support two-way-calling, notify, broadcast.
+- [bedrock](https://github.com/z5labs/bedrock) - Provides a minimal, modular and composable foundation for quickly developing services and more use case specific frameworks in Go.
 - [celeriac](https://github.com/svcavallar/celeriac.v1) - Library for adding support for interacting and monitoring Celery workers, tasks and events in Go.
 - [consistent](https://github.com/buraksezer/consistent) - Consistent hashing with bounded loads.
 - [consistenthash](https://github.com/mbrostami/consistenthash) - Consistent hashing with configurable replicas.


### PR DESCRIPTION
**Please provide package links to:**

- repo link (github.com, gitlab.com, etc): [https://github.com/z5labs/bedrock](https://github.com/z5labs/bedrock)
- pkg.go.dev: [https://pkg.go.dev/github.com/z5labs/bedrock](https://pkg.go.dev/github.com/z5labs/bedrock)
- goreportcard.com: [https://goreportcard.com/report/github.com/z5labs/bedrock](https://goreportcard.com/report/github.com/z5labs/bedrock)
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): Go coverage is calculated from coverprofile in Github Action runner instead of using an external service. The project README has a badge displaying the coverage.

**Make sure that you've checked the boxes below that apply before you submit PR.**

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] Continuous integration is used to attempt to catch issues prior to releasing this package to end-users.
