### PR TITLE
Add gomponents to Template Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2272,6 +2272,7 @@ _Libraries and tools for templating and lexing._
 - [ego](https://github.com/benbjohnson/ego) - Lightweight templating language that lets you write templates in Go. Templates are translated into Go and compiled.
 - [extemplate](https://github.com/dannyvankooten/extemplate) - Tiny wrapper around html/template to allow for easy file-based template inheritance.
 - [fasttemplate](https://github.com/valyala/fasttemplate) - Simple and fast template engine. Substitutes template placeholders up to 10x faster than [text/template](https://golang.org/pkg/text/template/).
+- [gomponents](https://www.gomponents.com) - HTML 5 components in pure Go, that look something like this: `func(name string) g.Node { return Div(Class("headline"), g.Textf("Hi %v!", name)) }`.
 - [gospin](https://github.com/m1/gospin) - Article spinning and spintax/spinning syntax engine, useful for A/B, testing pieces of text/articles and creating more natural conversations.
 - [got](https://github.com/goradd/got) - A Go code generator inspired by Hero and Fasttemplate. Has include files, custom tag definitions, injected Go code, language translation, and more.
 - [goview](https://github.com/foolin/goview) - Goview is a lightweight, minimalist and idiomatic template library based on golang html/template for building Go web application.


### PR DESCRIPTION
This adds gomponents to the list of template engines.

I've added a component example directly in the description, which I think is both informative and a bit fun. 😊 If that's frowned upon, I'd be happy to create a more traditional description.

> Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Please provide package links to:**

- repo link (github.com, gitlab.com, etc): https://github.com/maragudk/gomponents
- pkg.go.dev: https://pkg.go.dev/github.com/maragudk/gomponents
- goreportcard.com: https://goreportcard.com/report/github.com/maragudk/gomponents
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://app.codecov.io/gh/maragudk/gomponents

**Note**: _that new categories can be added only when there are 3 packages or more._

**Make sure that you've checked the boxes below that apply before you submit PR.**
_Not every repository (project) will require every option, but most projects should. Check the Contribution Guidelines for details._

- [X] The package has been added to the list in alphabetical order.
- [X] The package has an appropriate description with correct grammar.
- [X] As far as I know, the package has not been listed here before.
- [X] The repo documentation has a pkg.go.dev link.
- [X] The repo documentation has a coverage service link.
- [X] The repo documentation has a goreportcard link.
- [X] The repo has a version-numbered release and a go.mod file.
- [X] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [X] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [X] Continuous integration is used to attempt to catch issues prior to releasing this package to end-users.

Thanks for your PR, you're awesome! :+1:
