### PR TITLE
Add rabbitroutine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1666,6 +1666,7 @@ _Libraries that implement messaging systems._
 - [Uniqush-Push](https://github.com/uniqush/uniqush-push) - Redis backed unified push service for server-side notifications to mobile devices.
 - [Watermill](https://github.com/ThreeDotsLabs/watermill) - Working efficiently with message streams. Building event driven applications, enabling event sourcing, RPC over messages, sagas. Can use conventional pub/sub implementations like Kafka or RabbitMQ, but also HTTP or MySQL binlog.
 - [zmq4](https://github.com/pebbe/zmq4) - Go interface to ZeroMQ version 4. Also available for [version 3](https://github.com/pebbe/zmq3) and [version 2](https://github.com/pebbe/zmq2).
+- [rabbitroutine](https://github.com/furdarius/rabbitroutine) - Lightweight library that handles RabbitMQ auto-reconnect and publishing retries. The library takes into account the need to re-declare entities in RabbitMQ after reconnection. 
 
 **[⬆ back to top](#contents)**
 

--- a/README.md
+++ b/README.md
@@ -1656,6 +1656,7 @@ _Libraries that implement messaging systems._
 - [oplog](https://github.com/dailymotion/oplog) - Generic oplog/replication system for REST APIs.
 - [pubsub](https://github.com/tuxychandru/pubsub) - Simple pubsub package for go.
 - [Quamina](https://github.com/timbray/quamina) - Fast pattern-matching for filtering messages and events.
+- [rabbitroutine](https://github.com/furdarius/rabbitroutine) - Lightweight library that handles RabbitMQ auto-reconnect and publishing retries. The library takes into account the need to re-declare entities in RabbitMQ after reconnection. 
 - [rabbus](https://github.com/rafaeljesus/rabbus) - A tiny wrapper over amqp exchanges and queues.
 - [rabtap](https://github.com/jandelgado/rabtap) - RabbitMQ swiss army knife cli app.
 - [RapidMQ](https://github.com/sybrexsys/RapidMQ) - RapidMQ is a lightweight and reliable library for managing of the local messages queue.
@@ -1666,7 +1667,6 @@ _Libraries that implement messaging systems._
 - [Uniqush-Push](https://github.com/uniqush/uniqush-push) - Redis backed unified push service for server-side notifications to mobile devices.
 - [Watermill](https://github.com/ThreeDotsLabs/watermill) - Working efficiently with message streams. Building event driven applications, enabling event sourcing, RPC over messages, sagas. Can use conventional pub/sub implementations like Kafka or RabbitMQ, but also HTTP or MySQL binlog.
 - [zmq4](https://github.com/pebbe/zmq4) - Go interface to ZeroMQ version 4. Also available for [version 3](https://github.com/pebbe/zmq3) and [version 2](https://github.com/pebbe/zmq2).
-- [rabbitroutine](https://github.com/furdarius/rabbitroutine) - Lightweight library that handles RabbitMQ auto-reconnect and publishing retries. The library takes into account the need to re-declare entities in RabbitMQ after reconnection. 
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
The library is designed to save the developer from the headache when working with RabbitMQ. The library covers the needs to auto-reconnect to RabbitMQ in case of problems and supports publish retries with backoff. It takes into account the need to re-declare entities in RabbitMQ after reconnection.

**Package links to:**

- repo link (github.com, gitlab.com, etc): https://github.com/furdarius/rabbitroutine
- pkg.go.dev: https://pkg.go.dev/github.com/furdarius/rabbitroutine
- goreportcard.com: https://goreportcard.com/report/github.com/furdarius/rabbitroutine
- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://app.codecov.io/gh/furdarius/rabbitroutine

**The boxes to check**

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] Continuous integration is used to attempt to catch issues prior to releasing this package to end-users.
