### PR TITLE
Refactor PR template: hint to curate packages around the submission

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,26 +1,40 @@
-> Please check if what you want to add to `awesome-go` list meets [quality standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!
+## We want to ensure high quality of the packages. Make sure that you've checked the boxes below before you submit PR.
 
-**Please provide package links to:**
+- [ ] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
+- [ ] I have read the [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers)
+- [ ] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)
 
-- repo link (github.com, gitlab.com, etc):
-- pkg.go.dev:
-- goreportcard.com:
-- coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.):
-
-**Note**: _that new categories can be added only when there are 3 packages or more._
-
-**Make sure that you've checked the boxes below that apply before you submit PR.**
 _Not every repository (project) will require every option, but most projects should. Check the Contribution Guidelines for details._
 
-- [ ] The package has been added to the list in alphabetical order.
-- [ ] The package has an appropriate description with correct grammar.
-- [ ] As far as I know, the package has not been listed here before.
 - [ ] The repo documentation has a pkg.go.dev link.
 - [ ] The repo documentation has a coverage service link.
 - [ ] The repo documentation has a goreportcard link.
 - [ ] The repo has a version-numbered release and a go.mod file.
-- [ ] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines), [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers) and [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).
 - [ ] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
 - [ ] Continuous integration is used to attempt to catch issues prior to releasing this package to end-users.
 
-Thanks for your PR, you're awesome! :+1:
+## Please provide some links to your package to ease the review
+
+- [ ] forge link (github.com, gitlab.com, etc):
+- [ ] pkg.go.dev:
+- [ ] goreportcard.com:
+- [ ] coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.):
+
+## Pull Request content
+
+- [ ] The package has been added to the list in alphabetical order.
+- [ ] The package has an appropriate description with correct grammar.
+- [ ] As far as I know, the package has not been listed here before.
+
+## Category quality
+
+_Note that new categories can be added only when there are 3 packages or more._
+
+Packages added a long time ago might not meet the current guidelines anymore. It would be very helpful if you could check 3-5 packages above and below your submission to ensure that they also still meet the Quality Standards.
+
+Please delete one of the following lines:
+
+- [ ] The packages around my addition still meet the Quality Standards.
+- [ ] I removed the following packages around my addition: (please give a short reason for each removal)
+
+Thanks for your PR, you're awesome! :sunglasses:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-## We want to ensure high quality of the packages. Make sure that you've checked the boxes below before you submit PR.
+## We want to ensure high quality of the packages. Make sure that you've checked the boxes below before sending a pull request.
 
 - [ ] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
 - [ ] I have read the [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers)


### PR DESCRIPTION
Hi, in  #5224 I suggested that new Pull Requests should also check if the packages around the submission are still relevant.

I think this would allow to spread the load to check for older packages:
- spread over a larger number of people (since every user making a pull request should participate)
- spread over time for the maintainers (since every PR should only remove a couple of links, preventing stale issues because the numbers of links to check is very high)

I also took the liberty of moving some checkboxes around, to try to better categorize each step:
- read the guidelines
- ensure the submitted repo meets the quality standard
- links to the repo & services
- check of the pull-request content
- check of unmaintained packages around the submission

You can view an empty PR created with this new template at my fork: https://github.com/oliverpool/awesome-go/pull/2
Or see the pre-filled template when creating a PR: https://github.com/oliverpool/awesome-go/compare/main...patch-1

cc @phanirithvij 