### PR TITLE
Removing github.com/wesovilabs/beyond for no longer being maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -2692,7 +2692,6 @@ _General utilities and tools to make your life easier._
 
 - [apm](https://github.com/topfreegames/apm) - Process manager for Golang applications with an HTTP API.
 - [backscanner](https://github.com/icza/backscanner) - A scanner similar to bufio.Scanner, but it reads and returns lines in reverse order, starting at a given position and going backward.
-- [beyond](https://github.com/wesovilabs/beyond) - The Go tool that will drive you to the AOP world!
 - [blank](https://github.com/Henry-Sarabia/blank) - Verify or remove blanks and whitespace from strings.
 - [bleep](https://github.com/sinhashubham95/bleep) - Perform any number of actions on any set of OS signals in Go.
 - [boilr](https://github.com/tmrts/boilr) - Blazingly fast CLI tool for creating projects from boilerplate templates.


### PR DESCRIPTION
Repo - https://github.com/wesovilabs/beyond

- [x] The project has not made an official release within the last year and has open issues.
    - It has been 5 years since an update to the repo
- [x] The project is not responding to bug reports issued within 6 months of submission.
   - https://github.com/wesovilabs/beyond/issues last closed issue was in 2019 
- [ ] The project is not meeting quality standards as indicated by the Go Report Card or Code Coverage tests.
- [ ] The quality standard links have been removed from the documentation.
- [ ] The project is no longer open-sourced.
- [ ] The project is incompatible with any Go version issued within the last year (there is hopefully an open PR about this at the project).

The documentation is also no longer maintained with an invalid SSL cert - http://wesovilabs.github.io/beyond


Removal issue - https://github.com/wesovilabs/beyond/issues/41