### PR TITLE
Remove github.com/olebedev/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,6 @@ _Libraries for configuration parsing._
 - [cleanenv](https://github.com/ilyakaznacheev/cleanenv) - Minimalistic configuration reader (from files, ENV, and wherever you want).
 - [config](https://github.com/JeremyLoy/config) - Cloud native application configuration. Bind ENV to structs in only two lines.
 - [config](https://github.com/num30/config) - configure your app using file, environment variables, or flags in two lines of code
-- [config](https://github.com/olebedev/config) - JSON or YAML configuration wrapper with environment variables and flags parsing.
 - [configuration](https://github.com/BoRuDar/configuration) - Library for initializing configuration structs from env variables, files, flags and 'default' tag.
 - [configure](https://github.com/paked/configure) - Provides configuration through multiple sources, including JSON, flags and environment variables.
 - [configuro](https://github.com/sherifabdlnaby/configuro) - opinionated configuration loading & validation framework from ENV and Files focused towards 12-Factor compliant applications.


### PR DESCRIPTION
Repo - https://github.com/olebedev/config

- [x] The project has not made an official release within the last year and has open issues. - It has been 2 years since an update to the repo
- [x] The project is not responding to bug reports issued within 6 months of submission.
   - https://github.com/olebedev/config/issues?q=is%3Aissue+is%3Aclosed last closed issue was in 2018
- [ ] The project is not meeting quality standards as indicated by the Go Report Card or Code Coverage tests.
- [ ] The quality standard links have been removed from the documentation.
- [ ] The project is no longer open-sourced.
- [ ] The project is incompatible with any Go version issued within the last year (there is hopefully an open PR about this at the project).


Related issue: https://github.com/avelino/awesome-go/issues/5136
