### PR TITLE
Remove https://github.com/kirillDanshin/nulltime

### DIFF
--- a/README.md
+++ b/README.md
@@ -943,7 +943,6 @@ _Libraries for working with dates and times._
 - [iso8601](https://github.com/relvacode/iso8601) - Efficiently parse ISO8601 date-times without regex.
 - [kair](https://github.com/GuilhermeCaruso/kair) - Date and Time - Golang Formatting Library.
 - [now](https://github.com/jinzhu/now) - Now is a time toolkit for golang.
-- [NullTime](https://github.com/kirillDanshin/nulltime) - Nullable `time.Time`.
 - [strftime](https://github.com/awoodbeck/strftime) - C99-compatible strftime formatter.
 - [timespan](https://github.com/SaidinWoT/timespan) - For interacting with intervals of time, defined as a start time and a duration.
 - [timeutil](https://github.com/leekchan/timeutil) - Useful extensions (Timedelta, Strftime, ...) to the golang's time package.


### PR DESCRIPTION
https://github.com/kirillDanshin/nulltime

 - [x] The project has not made an official release within the last year and has open issues.
 - [ ] The project is not responding to bug reports issued within 6 months of submission.
 - [ ] The project is not meeting quality standards as indicated by the Go Report Card or Code Coverage tests.
 - [ ] The quality standard links have been removed from the documentation.
 - [ ] The project is no longer open-sourced.
 - [ ] The project is incompatible with any Go version issued within the last year (there is hopefully an open PR about this at the project).

This project is very old (7 years ago), and Go stdlib has been support [sql.NullTime](https://pkg.go.dev/database/sql#NullTime) since Go 1.13.