### PR TITLE
tests: add repository maturity test

### DIFF
--- a/maturity_test.go
+++ b/maturity_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+var (
+	githubApiAuthorizationToken = os.Getenv("GITHUB_API_TOKEN")
+	minimumMaturityDate         = time.Now().AddDate(0, -5, 0)
+)
+
+func TestMaturity(t *testing.T) {
+	doc := goqueryFromReadme(t)
+	doc.Find("body li > a:first-child").Each(func(_ int, s *goquery.Selection) {
+		t.Run(s.Text(), func(t *testing.T) {
+			href, ok := s.Attr("href")
+			if !ok {
+				t.Error("expected to have href")
+			}
+
+			matches := reGithubRepo.FindStringSubmatch(href)
+			if matches == nil {
+				return
+			}
+
+			if len(matches) != 3 {
+				t.Fatalf("failed to extract repo and user from: %s, got [%v]", href, strings.Join(matches, ", "))
+			}
+
+			if err := checkRepositoryMaturity(matches[1], matches[2]); err != nil {
+				t.Fatal(err)
+			}
+		})
+	})
+}
+
+func checkRepositoryMaturity(user, repo string) error {
+	until := minimumMaturityDate.Format(time.RFC3339)
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/commits?per_page=1&until=%s", user, repo, until)
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request for `%s`, %v", url, err)
+	}
+
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	request.Header.Set("User-Agent", "avelino")
+	request.Header.Set("Authorization", "Bearer "+githubApiAuthorizationToken)
+
+	http.DefaultClient.Timeout = time.Minute
+	httpRes, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("failed to fetch commits for [%s/%s], %v", user, repo, err)
+	}
+	defer httpRes.Body.Close()
+
+	var commits []any
+	err = json.NewDecoder(httpRes.Body).Decode(&commits)
+	if err != nil {
+		return fmt.Errorf("failed to decode response for [%s/%s], %v", user, repo, err)
+	}
+
+	if len(commits) == 0 {
+		minimumDate := minimumMaturityDate.Format(time.DateOnly)
+		return fmt.Errorf("the project [%s/%s] doesn't have any commits before %s, this is a maturity violation", user, repo, minimumDate)
+	}
+
+	return nil
+}

--- a/stale_repositories_test.go
+++ b/stale_repositories_test.go
@@ -27,7 +27,7 @@ const issueTemplateContent = `
 var issueTemplate = template.Must(template.New("issue").Parse(issueTemplateContent))
 
 // FIXME: use official github client
-var reGithubRepo = regexp.MustCompile("https://github.com/[a-zA-Z0-9-._]+/[a-zA-Z0-9-._]+$")
+var reGithubRepo = regexp.MustCompile("https://github.com/([a-zA-Z0-9-._]+)/([a-zA-Z0-9-._]+)$")
 var githubGETREPO = "https://api.github.com/repos%s"
 var githubGETCOMMITS = "https://api.github.com/repos%s/commits"
 var githubPOSTISSUES = "https://api.github.com/repos/avelino/awesome-go/issues"


### PR DESCRIPTION
 **What was changed ?**
 Added a new test to check repository maturity

**Why do we need it?**
We need to check that projects listed here are seriously maintained. As we discussed at: #5473 

**How it works**
When you run the test, it reads all links from the entire README file, and for each link, uses the [github api](https://docs.github.com/en/rest?apiVersion=2022-11-28) to fetch the first commit made 5 months before the current date. If no commits were found, the test fails. 

Only links to github repositories are checked.

**How to run test?**
```bash
GITHUB_API_TOKEN="ghp_XXXXXXXXXXXXXXXXXXXXXXX" go test . -run ^TestMaturity$
```

**Why do we need an API key?**
`Rate Limit`: authenticated requests can send more requests per hour, considering that this list holds +1000 links. Not using and API key isn't an option.
>This is what worked for me, you might have a better option, correct me if I'm mistaking.

--- 

This PR only adds the code needed to run the test, when and how we should run them still needs a discussion, as stated above, we run tests against the entire link set. I don't think we must run this test on new PR because it may fail just because of rate limiting. 

I wonder if there is a way to run them only against links added in the PR. 