### PR TITLE
Use hashicorp/cli fork of mitchellh/cli library

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,12 +432,12 @@ _Libraries for building standard or basic Command Line applications._
 - [go-flags](https://github.com/jessevdk/go-flags) - go command line option parser.
 - [go-getoptions](https://github.com/DavidGamba/go-getoptions) - Go option parser inspired by the flexibility of Perl’s GetOpt::Long.
 - [gocmd](https://github.com/devfacet/gocmd) - Go library for building command line applications.
+- [hashicorp/cli](https://github.com/hashicorp/cli) - Go library for implementing command-line interfaces.
 - [hiboot cli](https://github.com/hidevopsio/hiboot/tree/master/pkg/app/cli) - cli application framework with auto configuration and dependency injection.
 - [job](https://github.com/liujianping/job) - JOB, make your short-term command as a long-term job.
 - [kingpin](https://github.com/alecthomas/kingpin) - Command line and flag parser supporting sub commands (superseded by `kong`; see below).
 - [liner](https://github.com/peterh/liner) - Go readline-like library for command-line interfaces.
 - [mcli](https://github.com/jxskiss/mcli) - A minimal but very powerful cli library for Go.
-- [mitchellh/cli](https://github.com/mitchellh/cli) - Go library for implementing command-line interfaces.
 - [mkideal/cli](https://github.com/mkideal/cli) - Feature-rich and easy to use command-line package based on golang struct tags.
 - [mow.cli](https://github.com/jawher/mow.cli) - Go library for building CLI applications with sophisticated flag and argument parsing and validation.
 - [ops](https://github.com/nanovms/ops) - Unikernel Builder/Orchestrator.


### PR DESCRIPTION
@mitchellh has decided to forgo maintaining his Go libraries, and has archived his repositories. He posted [a Gist](https://gist.github.com/mitchellh/90029601268e59a29e64e55bab1c5bdc) to explain his decision and has blessed [Hashicorp's fork](https://github.com/hashicorp/cli) of [mitchellh/cli](https://github.com/mitchellh/cli). This PR simply updates it in the list.