### PR TITLE
Remove: `golang/dep` && `vgo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2136,7 +2136,6 @@ _Official tooling for dependency and package management_
 
 _Official experimental tooling for package management_
 
-- [dep](https://github.com/golang/dep) - Go dependency tool.
 - [vgo](https://go.googlesource.com/vgo/) - Versioned Go.
 
 _Unofficial libraries for package and dependency management._

--- a/README.md
+++ b/README.md
@@ -2134,10 +2134,6 @@ _Official tooling for dependency and package management_
 
 - [go modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) - Modules are the unit of source code interchange and versioning. The go command has direct support for working with modules, including recording and resolving dependencies on other modules.
 
-_Official experimental tooling for package management_
-
-- [vgo](https://go.googlesource.com/vgo/) - Versioned Go.
-
 _Unofficial libraries for package and dependency management._
 
 - [glide](https://github.com/Masterminds/glide) - Manage your golang vendor and vendored packages with ease. Inspired by tools like Maven, Bundler, and Pip.


### PR DESCRIPTION
Remove: https://github.com/golang/dep
Reason: Archived.