### PR TITLE
Remove: https://github.com/davemeehan/Neo4j-GO

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,7 +905,6 @@ _Libraries for building and using SQL._
 - [mgo](https://github.com/globalsign/mgo) - (unmaintained) MongoDB driver for the Go language that implements a rich and well tested selection of features under a very simple API following standard Go idioms.
 - [mongo-go-driver](https://github.com/mongodb/mongo-go-driver) - Official MongoDB driver for the Go language.
 - [neo4j](https://github.com/cihangir/neo4j) - Neo4j Rest API Bindings for Golang.
-- [Neo4j-GO](https://github.com/davemeehan/Neo4j-GO) - Neo4j REST Client in golang.
 - [neoism](https://github.com/jmcvetta/neoism) - Neo4j client for Golang.
 - [qmgo](https://github.com/qiniu/qmgo) - The MongoDB driver for Go. It‘s based on official MongoDB driver but easier to use like Mgo.
 - [redeo](https://github.com/bsm/redeo) - Redis-protocol compatible TCP servers/services.


### PR DESCRIPTION
REMOVE: https://github.com/davemeehan/Neo4j-GO (archived)