### PR TITLE
embed category: remove old entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2211,14 +2211,8 @@ _Unofficial libraries for package and dependency management._
 ## Resource Embedding
 
 - [debme](https://github.com/leaanthony/debme) - Create an `embed.FS` from an existing `embed.FS` subdirectory.
-- [fileb0x](https://github.com/UnnoTed/fileb0x) - Simple tool to embed files in go with focus on "customization" and ease to use.
-- [go-resources](https://github.com/omeid/go-resources) - Unfancy resources embedding with Go.
-- [go.rice](https://github.com/GeertJohan/go.rice) - go.rice is a Go package that makes working with resources such as HTML, JS, CSS, images, and templates very easy.
-- [mule](https://github.com/wlbr/mule) - Embed external resources like images, movies ... into Go source code to create single file binaries using `go generate`. Focused on simplicity.
-- [packr](https://github.com/gobuffalo/packr) - The simple and easy way to embed static files into Go binaries.
+- [embed](https://pkg.go.dev/embed) - Package embed provides access to files embedded in the running Go program.
 - [rebed](https://github.com/soypat/rebed) - Recreate folder structures and files from Go 1.16's `embed.FS` type
-- [statik](https://github.com/rakyll/statik) - Embeds static files into a Go executable.
-- [templify](https://github.com/wlbr/templify) - Embed external template files into Go code to create single file binaries.
 - [vfsgen](https://github.com/shurcooL/vfsgen) - Generates a vfsdata.go file that statically implements the given virtual filesystem.
 
 **[⬆ back to top](#contents)**


### PR DESCRIPTION
Removes old pre- embed (introduced in go 1.16) packages.

vfsgen - https://github.com/shurcooL/vfsgen/issues/91