### PR TITLE
Remove fluentassert/verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -2426,7 +2426,6 @@ _Libraries for testing codebases and generating test data._
 - [endly](https://github.com/viant/endly) - Declarative end to end functional testing.
 - [envite](https://github.com/PerimeterX/envite) - Dev and testing environment management framework.
 - [fixenv](https://github.com/rekby/fixenv) - Fixture manage engine, inspired by pytest fixtures.
-- [fluentassert](https://github.com/fluentassert/verify) - Extensible, type-safe, fluent assertion Go library.
 - [flute](https://github.com/suzuki-shunsuke/flute) - HTTP client testing framework.
 - [frisby](https://github.com/verdverm/frisby) - REST API testing framework.
 - [gherkingen](https://github.com/hedhyw/gherkingen) - BDD boilerplate generator and framework.


### PR DESCRIPTION
As a the library maintainer a want to remove it from the list as I find it harmful.
Per: 
- https://github.com/fluentassert/verify/pull/152
- https://github.com/fluentassert/verify/pull/153