### PR TITLE
Go compilers category add go2hx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1297,8 +1297,8 @@ _Geographic tools and servers_
 _Tools for compiling Go to other languages._
 
 - [c4go](https://github.com/Konstantin8105/c4go) - Transpile C code to Go code.
+- - [go2hx](https://github.com/go2hx/go2hx) - Compiler from Go to Haxe to Javascript/C++/Java/C#.
 - [gopherjs](https://github.com/gopherjs/gopherjs) - Compiler from Go to JavaScript.
-- [go2hx](https://github.com/go2hx/go2hx) - Compiler from Go to Haxe to Javascript/C++/Java/C#.
 
 **[⬆ back to top](#contents)**
 

--- a/README.md
+++ b/README.md
@@ -1296,12 +1296,8 @@ _Geographic tools and servers_
 
 _Tools for compiling Go to other languages._
 
-- [c2go](https://github.com/goplus/c2go) - Convert C code to Go code.
 - [c4go](https://github.com/Konstantin8105/c4go) - Transpile C code to Go code.
-- [esp32](https://github.com/andygeiss/esp32-transpiler) - Transpile Go into Arduino code.
-- [f4go](https://github.com/Konstantin8105/f4go) - Transpile FORTRAN 77 code to Go code.
 - [gopherjs](https://github.com/gopherjs/gopherjs) - Compiler from Go to JavaScript.
-- [tardisgo](https://github.com/tardisgo/tardisgo) - Golang to Haxe to CPP/CSharp/Java/JavaScript transpiler.
 - [go2hx](https://github.com/go2hx/go2hx) - Compiler from Go to Haxe to Javascript/C++/Java/C#.
 
 **[⬆ back to top](#contents)**

--- a/README.md
+++ b/README.md
@@ -1297,7 +1297,7 @@ _Geographic tools and servers_
 _Tools for compiling Go to other languages._
 
 - [c4go](https://github.com/Konstantin8105/c4go) - Transpile C code to Go code.
-- - [go2hx](https://github.com/go2hx/go2hx) - Compiler from Go to Haxe to Javascript/C++/Java/C#.
+- [go2hx](https://github.com/go2hx/go2hx) - Compiler from Go to Haxe to Javascript/C++/Java/C#.
 - [gopherjs](https://github.com/gopherjs/gopherjs) - Compiler from Go to JavaScript.
 
 **[⬆ back to top](#contents)**

--- a/README.md
+++ b/README.md
@@ -1297,6 +1297,8 @@ _Geographic tools and servers_
 _Tools for compiling Go to other languages._
 
 - [c4go](https://github.com/Konstantin8105/c4go) - Transpile C code to Go code.
+- [esp32](https://github.com/andygeiss/esp32-transpiler) - Transpile Go into Arduino code.
+- [f4go](https://github.com/Konstantin8105/f4go) - Transpile FORTRAN 77 code to Go code.
 - [go2hx](https://github.com/go2hx/go2hx) - Compiler from Go to Haxe to Javascript/C++/Java/C#.
 - [gopherjs](https://github.com/gopherjs/gopherjs) - Compiler from Go to JavaScript.
 

--- a/README.md
+++ b/README.md
@@ -1302,6 +1302,7 @@ _Tools for compiling Go to other languages._
 - [f4go](https://github.com/Konstantin8105/f4go) - Transpile FORTRAN 77 code to Go code.
 - [gopherjs](https://github.com/gopherjs/gopherjs) - Compiler from Go to JavaScript.
 - [tardisgo](https://github.com/tardisgo/tardisgo) - Golang to Haxe to CPP/CSharp/Java/JavaScript transpiler.
+- [go2hx](https://github.com/go2hx/go2hx) - Compiler from Go to Haxe to Javascript/C++/Java/C#.
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
## We want to ensure high quality of the packages. Make sure that you've checked the boxes below before sending a pull request.

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

- [ ] The repo documentation has a pkg.go.dev link.
- [ ] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] Continuous integration is used to attempt to catch issues prior to releasing this package to end-users.

This project does not have a working pkg.go.dev, because the Go part of the compiler is really only used to perform reflection on the typed AST and send it to the Haxe side via JSON.

No coverage service is linked because the test coverage comes from running the Go stdlib in test mode and related unit tests from Go and Yaegi test suites using a regression system to make sure no passing test is able to regress in the future.

## Please provide some links to your package to ease the review

- [x] forge link (github.com, gitlab.com, etc): https://github.com/go2hx/go2hx
- [ ] pkg.go.dev: Not available as mentioned above.
- [ ] goreportcard.com: https://goreportcard.com/report/github.com/go2hx/go2hx
- [ ] coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): Not available as mentioned above.

## Pull Request content

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.

## Category quality

Please delete one of the following lines:

- [x] The packages around my addition still meet the Quality Standards.

- [esp32-transpiler](https://github.com/andygeiss/esp32-transpiler): because the last commit was 2 years ago, and no activity on the last made issues for more then 2 years.
- [c2go](https://github.com/goplus/c2go) archived and unfinished.
- [tardisgo](https://github.com/tardisgo/tardisgo) On ice, last commit 9 years ago.


Although the project is written overwhelming in Haxe code, I believe this project fulfills "be generally useful to the wider community of Go programmers;".

The stdgo folder is the Go stdlib compiled into Haxe code per passing commit using Github actions. This is where the huge code size comes from, and solutions are being looked into, to have the compiler compile only the needed parts each time.

Disclaimer: I am the primary dev working on the compiler submitted, and Elliott who created tardisgo is actively working on the project in question as well.

