### PR TITLE
Add urusai to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2298,6 +2298,7 @@ _Libraries that are used to help make your application more secure._
 - [sslmgr](https://github.com/adrianosela/sslmgr) - SSL certificates made easy with a high level wrapper around acme/autocert.
 - [teler-waf](https://github.com/kitabisa/teler-waf) - teler-waf is a Go HTTP middleware that provide teler IDS functionality to protect against web-based attacks and improve the security of Go-based web applications. It is highly configurable and easy to integrate into existing Go applications.
 - [themis](https://github.com/cossacklabs/themis) - high-level cryptographic library for solving typical data security tasks (secure data storage, secure messaging, zero-knowledge proof authentication), available for 14 languages, best fit for multi-platform apps.
+- [urusai](https://github.com/calpa/urusai) - Urusai ("noisy" in Japanese) is a Go implementation of a random HTTP/DNS traffic noise generator that helps protect privacy by creating digital smokescreens while browsing.
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
## What is this project?\n\nUrusai ("noisy" in Japanese) is a Go implementation of a random HTTP/DNS traffic noise generator that helps protect privacy by creating digital smokescreens while browsing.\n\n## Links\n\n- GitHub Repository: https://github.com/calpa/urusai\n\n## Checklist\n- [x] Has a properly descriptive title\n- [x] Has a meaningful description\n- [x] Has working links\n- [x] Has been added to the correct category (Security)\n- [x] Is in alphabetical order within the category\n- [x] Has received at least 5 stars from the community\n- [x] Has been in existence for at least 6 months\n- [x] Does not violate any laws, promote violence, contain sexually explicit content, or otherwise harm others