### PR TITLE
remove github.com/Syfaro/telegram-bot-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,6 @@ _Libraries for building and working with bots._
 - [tbot](https://github.com/yanzay/tbot) - Telegram bot server with API similar to net/http.
 - [telebot](https://github.com/tucnak/telebot) - Telegram bot framework is written in Go.
 - [telego](https://github.com/mymmrac/telego) - Telegram Bot API library for Golang with full one-to-one API implementation.
-- [telegram-bot-api](https://github.com/Syfaro/telegram-bot-api) - Simple and clean Telegram bot client.
 - [teleterm](https://github.com/alfiankan/teleterm) - Telegram Bot Exec Terminal Command.
 - [Tenyks](https://github.com/kyleterry/tenyks) - Service oriented IRC bot using Redis and JSON for messaging.
 - [wayback](https://github.com/wabarc/wayback) - A bot for Telegram, Mastodon, Slack, and other messaging platforms archives webpages.


### PR DESCRIPTION
## We want to ensure high quality of the packages. Make sure that you've checked the boxes below before sending a pull request.

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

*The project moved from [github.com/Syfaro/telegram-bot-api](https://github.com/Syfaro/telegram-bot-api) to [github.com/go-telegram-bot-api/telegram-bot-api](https://github.com/go-telegram-bot-api/telegram-bot-api)*

Removing github.com/Syfaro/telegram-bot-api because it's no longer maintained: 
 - last commit: Oct 20, 2022
 - last release: Dec 13, 2021
 - the project is not responding to bug reports https://github.com/go-telegram-bot-api/telegram-bot-api/issues/
 - https://github.com/go-telegram-bot-api/telegram-bot-api/issues/695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Bot Building section by removing the outdated Telegram bot client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->