### PR TITLE
add chaindead/zerocfg, remove OpenPeeDeeP/xdg

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,6 @@ _Libraries for configuration parsing._
 - [uConfig](https://github.com/omeid/uconfig) - Lightweight, zero-dependency, and extendable configuration management.
 - [viper](https://github.com/spf13/viper) - Go configuration with fangs.
 - [xdg](https://github.com/adrg/xdg) - Go implementation of the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) and [XDG user directories](https://wiki.archlinux.org/index.php/XDG_user_directories).
-- [xdg](https://github.com/OpenPeeDeeP/xdg) - Cross platform package that follows the [XDG Standard](https://specifications.freedesktop.org/basedir-spec/latest/).
 - [yamagiconf](https://github.com/romshark/yamagiconf) - The "safe subset" of YAML for Go configs.
 - [zerocfg](https://github.com/chaindead/zerocfg) - Zero-effort, concise configuration management that avoids boilerplate and repetitive code, supports multiple sources with priority overrides.
 

--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ _Libraries for configuration parsing._
 - [xdg](https://github.com/adrg/xdg) - Go implementation of the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) and [XDG user directories](https://wiki.archlinux.org/index.php/XDG_user_directories).
 - [xdg](https://github.com/OpenPeeDeeP/xdg) - Cross platform package that follows the [XDG Standard](https://specifications.freedesktop.org/basedir-spec/latest/).
 - [yamagiconf](https://github.com/romshark/yamagiconf) - The "safe subset" of YAML for Go configs.
+- [zerocfg](https://github.com/chaindead/zerocfg) - Zero-effort, concise configuration management that avoids boilerplate and repetitive code, supports multiple sources with priority overrides.
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
## ✅ I confirm I have completed all of the following before submitting this pull request:

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] Continuous integration is used to attempt to catch issues prior to releasing this package to end-users.

## Links

- [x] forge link: https://github.com/chaindead/zerocfg
- [x] pkg.go.dev:  https://pkg.go.dev/github.com/chaindead/zerocfg
- [x] goreportcard.com: https://goreportcard.com/report/github.com/chaindead/zerocfg
- [x] coverage service link: https://codecov.io/gh/chaindead/zerocfg

## Pull Request content

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.

## Category quality
- [x] I removed package around my addition: https://github.com/OpenPeeDeeP/xdg
  * Project is unmaintained (last commit 5 years ago)  
  * Functionality overlaps with the actively maintained [`adrg/xdg`](https://github.com/adrg/xdg) mentioned above

## Additional info
This project **Migrated** from internal Bitbucket repository to GitHub and open-sourced under the MIT license 😎

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Configuration section in the README to replace the "xdg" package with "zerocfg" for configuration management library recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->