### PR TITLE
Add SafeHeaders-Go to Utilities: Go ports of C single-headers with co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2888,6 +2888,7 @@ _General utilities and tools to make your life easier._
 - [retry-go](https://github.com/rafaeljesus/retry-go) - Retrying made simple and easy for golang.
 - [robustly](https://github.com/VividCortex/robustly) - Runs functions resiliently, catching and restarting panics.
 - [rospo](https://github.com/ferama/rospo) - Simple and reliable ssh tunnels with embedded ssh server in Golang.
+- [SafeHeaders-Go](https://github.com/alikatgh/safeheaders-go) - Idiomatic Go ports of C single-header libraries with concurrency and safety enhancements.
 - [scan](https://github.com/blockloop/scan) - Scan golang `sql.Rows` directly to structs, slices, or primitive types.
 - [scan](https://github.com/wroge/scan) - Scan sql rows into any type powered by generics.
 - [scany](https://github.com/georgysavva/scany) - Library for scanning data from a database into Go structs and more.


### PR DESCRIPTION
Adds SafeHeaders-Go: A collection of Go ports of popular single-header C libraries (e.g., jsmn, stb_image), modernized with Go concurrency (goroutines) and safety features. Fits under Utilities as it provides drop-in tools for JSON tokenizing, image loading, etc.

Self-test:
- [x] Not a duplicate.
- [x] Useful for Go devs (safe C interop).
- [x] Actively maintained (recent commits).