### PR TITLE
docs: remove deleted treap

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,6 @@ additional ordered map implementations.
 - [merkle](https://github.com/bobg/merkle) - Space-efficient computation of Merkle root hashes and inclusion proofs.
 - [skiplist](https://github.com/MauriceGit/skiplist) - Very fast Go Skiplist implementation.
 - [skiplist](https://github.com/gansidui/skiplist) - Skiplist implementation in Go.
-- [treap](https://github.com/perdata/treap) - Persistent, fast ordered map using tree heaps.
 - [treemap](https://github.com/igrmk/treemap) - Generic key-sorted map using a red-black tree under the hood.
 
 ### Pipes


### PR DESCRIPTION
This PR removes [perdata/treap](https://github.com/perdata/treap) because it was deleted from GitHub.

```console
$ curl https://api.github.com/repos/perdata/treap
{
  "message": "Not Found",
  "documentation_url": "https://docs.github.com/rest/repos/repos#get-a-repository",
  "status": "404"
}
```

The package was added in #2457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the "treap" package entry from the "Trees" section in the Data Structures and Algorithms list in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->