### PR TITLE
docs: update Package Management (add modup, remove unmaintained and depricated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2145,20 +2145,10 @@ _Official tooling for dependency and package management_
 
 _Unofficial libraries for package and dependency management._
 
-- [glide](https://github.com/Masterminds/glide) - Manage your golang vendor and vendored packages with ease. Inspired by tools like Maven, Bundler, and Pip.
-- [godep](https://github.com/tools/godep) - dependency tool for go, godep helps build packages reproducibly by fixing their dependencies.
-- [goop](https://github.com/nitrous-io/goop) - Simple dependency manager for Go (golang), inspired by Bundler.
-- [gop](https://github.com/lunny/gop) - Build and manage your Go applications out of GOPATH.
-- [gopm](https://github.com/gpmgo/gopm) - Go Package Manager.
-- [govendor](https://github.com/kardianos/govendor) - Go Package Manager. Go vendor tool that works with the standard vendor file.
-- [gpm](https://github.com/pote/gpm) - Barebones dependency manager for Go.
 - [gup](https://github.com/nao1215/gup) - Update binaries installed by "go install".
-- [johnny-deps](https://github.com/VividCortex/johnny-deps) - Minimal dependency version using Git.
-- [modgv](https://github.com/lucasepe/modgv) - Converts 'go mod graph' output into Graphviz's DOT language.
 - [modup](https://github.com/chaindead/modup) - Terminal UI for Go dependency updates with outdated module detection and selective upgrading.
 - [mvn-golang](https://github.com/raydac/mvn-golang) - plugin that provides way for auto-loading of Golang SDK, dependency management and start build environment in Maven project infrastructure.
 - [syft](https://github.com/anchore/syft) - A CLI tool and Go library for generating a Software Bill of Materials (SBOM) from container images and filesystems.
-- [VenGO](https://github.com/DamnWidget/VenGO) - create and manage exportable isolated go virtual environments.
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
## ✅ I confirm I have completed all of the following before submitting this pull request:

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Links

- [x] forge link: https://github.com/chaindead/modup
- [x] pkg.go.dev: https://pkg.go.dev/github.com/chaindead/modup
- [x] goreportcard.com: https://goreportcard.com/report/github.com/chaindead/modup

## Pull Request content

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.


## Category quality
- I removed packages around my addition:
  * `glide` - Unmaintained for 6 years, predates Go vendor
  * `godep` - Unmaintained for 8 years, predates Go modules  
  * `goop` - Unmaintained for 11 years, predates Go modules
  * `gop` - Unmaintained for 6 years, predates Go modules
  * `gopm` - Unmaintained for 6 years, predates Go modules
  * `govendor` - Unmaintained for 5 years, predates Go vendor
  * `gpm` - Unmaintained for 8 years, predates Go modules
  * `johnny-deps` - Unmaintained for 5 years, predates Go modules
  * `modgy` - Unmaintained for 2 years
  * `VenGO` - Unmaintained for 9 years

## Additional info
 * The project is covered by integration tests via `task test` due to its TUI nature. 
 * This project Migrated from internal Bitbucket repository to GitHub and open-sourced under the MIT license 😎



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated “Package Management” guidance: removed deprecated/legacy Go dependency tools from the unofficial libraries list.
  * Added modup, a terminal UI for Go module updates with outdated detection and selective upgrades.
  * Retained mvn-golang and syft; removed VenGO and other obsolete entries.
  * No functional changes to the product; this clarifies current recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->