### PR TITLE
Add GitLab Merge Alert - WeChat Work notification service

### DIFF
--- a/README.md
+++ b/README.md
@@ -3301,6 +3301,7 @@ _Software written in Go._
 - [ghorg](https://github.com/gabrie30/ghorg) - Quickly clone an entire org/users repositories into one directory - Supports GitHub, GitLab, Gitea, and Bitbucket.
 - [Gitea](https://github.com/go-gitea/gitea) - Fork of Gogs, entirely community driven.
 - [gitea-github-migrator](https://git.jonasfranz.software/JonasFranzDEV/gitea-github-migrator) - Migrate all your GitHub repositories, issues, milestones and labels to your Gitea instance.
+- [GitLab Merge Alert](https://github.com/Alfonsxh/gitlab-merge-alert-go) - GitLab merge request notification service with WeChat Work (企业微信) integration for real-time code review alerts.
 - [go-furnace](https://github.com/go-furnace/go-furnace) - Hosting solution written in Go. Deploy your Application with ease on AWS, GCP or DigitalOcean.
 - [go-rocket-update](https://github.com/mouuff/go-rocket-update) - A simple way to make self updating Go applications - Supports Github and Gitlab.
 - [go-selfupdate](https://github.com/sanbornm/go-selfupdate) - Enable your Go applications to self update.


### PR DESCRIPTION
Add GitLab Merge Alert to DevOps Tools section.

GitLab Merge Alert is a Go-based notification service that bridges GitLab merge requests with WeChat Work (企业微信), solving the critical communication gap for Chinese development teams using GitLab.

- Production ready with Docker support for easy deployment  
- Well documented in English and Chinese
- Actively maintained
- MIT License