### PR TITLE
Add License section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3750,4 +3750,7 @@ _Add the group of your city/country here (send **PR**)_
 - [The Go Learning Path](https://tutorialedge.net/paths/golang/) - A guided learning path containing a mix of free and premium resources.
 - [The Go Skill Tree](https://labex.io/skilltrees/go) - A structured learning path that combines both free and premium resources.
 
+## License
+This project is licensed under the [MIT License](LICENSE) - see the LICENSE file for details.
+
 **[⬆ back to top](#contents)**


### PR DESCRIPTION
Added a License section in the README to reference the existing MIT License. 

The Contributing section is already present in the README, so no changes were needed there.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a License section to the README, including an MIT License notice and a link to the LICENSE file.
  - Positioned the new section after Guided Learning and before the bottom navigation for better discoverability.
  - Content-only update with no functional, API, or behavior changes.
  - Enhances clarity for users and contributors regarding project licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->