### PR TITLE
Add wasmtime-go in WebAssembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3138,6 +3138,7 @@ _Full stack web frameworks._
 - [tinygo](https://github.com/tinygo-org/tinygo) - Go compiler for small places. Microcontrollers, WebAssembly, and command-line tools. Based on LLVM.
 - [vert](https://github.com/norunners/vert) - Interop between Go and JS values.
 - [wasmbrowsertest](https://github.com/agnivade/wasmbrowsertest) - Run Go WASM tests in your browser.
+- [wasmtime-go](https://github.com/bytecodealliance/wasmtime-go) - Go bindings for the Wasmtime WebAssembly runtime (WASI support, JIT/AOT, secure and fast embedding).
 - [webapi](https://github.com/gowebapi/webapi) - Bindings for DOM and HTML generated from WebIDL.
 
 **[⬆ back to top](#contents)**


### PR DESCRIPTION
## We want to ensure high quality of the packages. Make sure that you've checked the boxes below before sending a pull request.

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

_Not every repository (project) will require every option, but most projects should. Check the Contribution Guidelines for details._

- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo has a version-numbered release and a go.mod file.

## Please provide some links to your package to ease the review

- [x] forge link (github.com, gitlab.com, etc): https://github.com/bytecodealliance/wasmtime-go
- [x] pkg.go.dev: https://pkg.go.dev/github.com/bytecodealliance/wasmtime-go
- [x] goreportcard: https://goreportcard.com/report/github.com/bytecodealliance/wasmtime-go
- [x] coverage: https://bytecodealliance.github.io/wasmtime-go/coverage.html#file0  

## Pull Request content

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.

## Category quality

_Note that new categories can be added only when there are 3 packages or more._

Packages added a long time ago might not meet the current guidelines anymore. It would be very helpful if you could check 3-5 packages above and below your submission to ensure that they also still meet the Quality Standards.

Please delete one of the following lines:

- [x] The packages around my addition still meet the Quality Standards.

Thanks for your PR, you're awesome! :sunglasses:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the “Full stack web frameworks” list by adding “wasmtime-go,” describing it as Go bindings for the Wasmtime WebAssembly runtime with WASI support, JIT/AOT options, and secure, fast embedding. The entry appears adjacent to existing Wasmtime items. No other sections were modified, and there are no changes to public APIs or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->