### PR TITLE
Handle build failure with error message

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,8 @@ var outSitemapFile = filepath.Join(outDir, "sitemap.xml")
 
 func main() {
 	if err := buildStaticSite(); err != nil {
-		panic(err)
+		fmt.Fprintf(os.Stderr, "build failed: %v\n", err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Replace panic with error message and exit

## We want to ensure high quality of the packages. Make sure that you've checked the boxes below before sending a pull request.

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

_Not every repository (project) will require every option, but most projects should. Check the Contribution Guidelines for details._

- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a coverage service link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo has a version-numbered release and a go.mod file.
- [x] The repo has a continuous integration process that automatically runs tests that must pass before new pull requests are merged.
- [x] Continuous integration is used to attempt to catch issues prior to releasing this package to end-users.

## Please provide some links to your package to ease the review

- [x] forge link (github.com, gitlab.com, etc):
- [x] pkg.go.dev:
- [x] goreportcard.com:
- [x] coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.):

## Pull Request content

- [x] The package has been added to the list in alphabetical order.
- [x] The package has an appropriate description with correct grammar.
- [x] As far as I know, the package has not been listed here before.

## Category quality

_Note that new categories can be added only when there are 3 packages or more._

Packages added a long time ago might not meet the current guidelines anymore. It would be very helpful if you could check 3-5 packages above and below your submission to ensure that they also still meet the Quality Standards.

Please delete one of the following lines:

- [x] The packages around my addition still meet the 


Thanks for your PR, you're awesome! :sunglasses:
