### PR TITLE
fix: exclude h3 subcategory links from h2 category extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1261,10 +1261,10 @@ _Awesome game development libraries._
 - [engo](https://github.com/EngoEngine/engo) - Engo is an open-source 2D game engine written in Go. It follows the Entity-Component-System paradigm.
 - [fantasyname](https://github.com/s0rg/fantasyname) - Fantasy names generator.
 - [g3n](https://github.com/g3n/engine) - Go 3D Game Engine.
-- [gogpu](https://github.com/gogpu/gogpu) - GPU application framework with windowing, input, and rendering built on WebGPU — reduces 480+ lines of GPU code to ~20, zero CGO (GoGPU ecosystem: [gg](https://github.com/gogpu/gg), [ui](https://github.com/gogpu/ui), [wgpu](https://github.com/gogpu/wgpu), [naga](https://github.com/gogpu/naga)).
 - [go-astar](https://github.com/beefsack/go-astar) - Go implementation of the A\* path finding algorithm.
 - [go-sdl2](https://github.com/veandco/go-sdl2) - Go bindings for the [Simple DirectMedia Layer](https://www.libsdl.org/).
 - [go3d](https://github.com/ungerik/go3d) - Performance oriented 2D/3D math package for Go.
+- [gogpu](https://github.com/gogpu/gogpu) - GPU application framework with windowing, input, and rendering built on WebGPU — reduces 480+ lines of GPU code to ~20, zero CGO (GoGPU ecosystem: [gg](https://github.com/gogpu/gg), [ui](https://github.com/gogpu/ui), [wgpu](https://github.com/gogpu/wgpu), [naga](https://github.com/gogpu/naga)).
 - [gonet](https://github.com/xtaci/gonet) - Game server skeleton implemented with golang.
 - [goworld](https://github.com/xiaonanln/goworld) - Scalable game server engine, featuring space-entity framework and hot-swapping.
 - [grid](https://github.com/s0rg/grid) - Generic 2D grid with ray-casting, shadow-casting and path finding.
@@ -1465,7 +1465,6 @@ _Libraries for manipulating images._
 - [darkroom](https://github.com/gojek/darkroom) - An image proxy with changeable storage backends and image processing engines with focus on speed and resiliency.
 - [geopattern](https://github.com/pravj/geopattern) - Create beautiful generative image patterns from a string.
 - [gg](https://github.com/fogleman/gg) - 2D rendering in pure Go.
-- [gogpu/gg](https://github.com/gogpu/gg) - GPU-accelerated 2D rendering with Canvas-like API, zero CGO (part of [GoGPU](https://github.com/gogpu) pure Go graphics ecosystem).
 - [gift](https://github.com/disintegration/gift) - Package of image processing filters.
 - [gltf](https://github.com/qmuntal/gltf) - Efficient and robust glTF 2.0 reader, writer and validator.
 - [go-cairo](https://github.com/ungerik/go-cairo) - Go binding for the cairo graphics library.
@@ -1475,6 +1474,7 @@ _Libraries for manipulating images._
 - [go-webcolors](https://github.com/jyotiska/go-webcolors) - Port of webcolors library from Python to Go.
 - [go-webp](https://github.com/kolesa-team/go-webp) - Library for encode and decode webp pictures, using libwebp.
 - [gocv](https://github.com/hybridgroup/gocv) - Go package for computer vision using OpenCV 3.3+.
+- [gogpu/gg](https://github.com/gogpu/gg) - GPU-accelerated 2D rendering with Canvas-like API, zero CGO (part of [GoGPU](https://github.com/gogpu) pure Go graphics ecosystem).
 - [goimagehash](https://github.com/corona10/goimagehash) - Go Perceptual image hashing package.
 - [goimghdr](https://github.com/corona10/goimghdr) - The imghdr module determines the type of image contained in a file for Go.
 - [govatar](https://github.com/o1egl/govatar) - Library and CMD tool for generating funny avatars.
@@ -2527,8 +2527,8 @@ _Libraries for testing codebases and generating test data._
 - [testfixtures](https://github.com/go-testfixtures/testfixtures) - A helper for Rails' like test fixtures to test database applications.
 - [Testify](https://github.com/stretchr/testify) - Sacred extension to the standard go testing package.
 - [testsql](https://github.com/zhulongcheng/testsql) - Generate test data from SQL files before testing and clear it after finished.
-- [tparse](https://github.com/mfridman/tparse) - CLI tool for summarizing go test output. Pipe friendly. Compatible with go test flags.
 - [testza](https://github.com/MarvinJWendt/testza) - Full-featured test framework with nice colorized output.
+- [tparse](https://github.com/mfridman/tparse) - CLI tool for summarizing go test output. Pipe friendly. Compatible with go test flags.
 - [trial](https://github.com/jgroeneveld/trial) - Quick and easy extendable assertions without introducing much boilerplate.
 - [Tt](https://github.com/vcaesar/tt) - Simple and colorful test tools.
 - [wstest](https://github.com/posener/wstest) - Websocket client for unit-testing a websocket http.Handler.

--- a/README.md
+++ b/README.md
@@ -3144,8 +3144,8 @@ _Full stack web frameworks._
 - [Bxog](https://github.com/claygod/Bxog) - Simple and fast HTTP router for Go. It works with routes of varying difficulty, length and nesting. And he knows how to create a URL from the received parameters.
 - [chi](https://github.com/go-chi/chi) - Small, fast and expressive HTTP router built on net/context.
 - [fasthttprouter](https://github.com/buaazp/fasthttprouter) - High performance router forked from `httprouter`. The first router fit for `fasthttp`.
-- [fursy](https://github.com/coregx/fursy) - HTTP router with type-safe generic handlers, automatic OpenAPI 3.1 generation from code, and RFC 9457 error responses.
 - [FastRouter](https://github.com/razonyang/fastrouter) - a fast, flexible HTTP router written in Go.
+- [fursy](https://github.com/coregx/fursy) - HTTP router with type-safe generic handlers, automatic OpenAPI 3.1 generation from code, and RFC 9457 error responses.
 - [goblin](https://github.com/bmf-san/goblin) - A golang http router based on trie tree.
 - [gocraft/web](https://github.com/gocraft/web) - Mux and middleware package in Go.
 - [Goji](https://github.com/goji/goji) - Goji is a minimalistic and flexible HTTP request multiplexer with support for `net/context`.

--- a/category_extraction_test.go
+++ b/category_extraction_test.go
@@ -325,10 +325,3 @@ Also has links.
 		t.Error("Empty Category should be skipped")
 	}
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/category_extraction_test.go
+++ b/category_extraction_test.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/avelino/awesome-go/pkg/markdown"
+)
+
+func TestCategoryExtractionDoesNotIncludeSubcategories(t *testing.T) {
+	testMarkdown := `
+## Test Category
+
+This is a test category description.
+
+- [Link A](https://example.com/a) - Description A.
+- [Link B](https://example.com/b) - Description B.
+
+### Subcategory One
+
+This is subcategory one.
+
+- [Link C](https://example.com/c) - Description C.
+- [Link D](https://example.com/d) - Description D.
+
+### Subcategory Two
+
+This is subcategory two.
+
+- [Link E](https://example.com/e) - Description E.
+
+## Another Category
+
+Another category description.
+
+- [Link F](https://example.com/f) - Description F.
+`
+
+	html, err := markdown.ToHTML([]byte(testMarkdown))
+	if err != nil {
+		t.Fatalf("Failed to convert markdown to HTML: %v", err)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(html))
+	if err != nil {
+		t.Fatalf("Failed to create goquery document: %v", err)
+	}
+
+	category, err := extractCategory(doc, "#test-category")
+	if err != nil {
+		t.Fatalf("Failed to extract category: %v", err)
+	}
+
+	if category.Title != "Test Category" {
+		t.Errorf("Expected category title 'Test Category', got '%s'", category.Title)
+	}
+
+	t.Logf("Found %d links in category", len(category.Links))
+	for i, link := range category.Links {
+		t.Logf("  Link %d: %s - %s", i+1, link.Title, link.URL)
+	}
+
+	if len(category.Links) != 2 {
+		t.Errorf("Expected 2 links (A, B) but got %d links. Bug: including subcategory links!", len(category.Links))
+	}
+
+	expectedLinks := map[string]string{
+		"Link A": "https://example.com/a",
+		"Link B": "https://example.com/b",
+	}
+
+	for _, link := range category.Links {
+		if expectedURL, ok := expectedLinks[link.Title]; ok {
+			if link.URL != expectedURL {
+				t.Errorf("Expected URL %s for link %s, got %s", expectedURL, link.Title, link.URL)
+			}
+		} else {
+			t.Errorf("Unexpected link found: %s (URL: %s). This is from a subcategory!", link.Title, link.URL)
+		}
+	}
+}
+
+func TestCategoryWithoutSubcategories(t *testing.T) {
+	testMarkdown := `
+## Simple Category
+
+Category with direct links only, no subcategories.
+
+- [Tool A](https://example.com/a) - Tool A description.
+- [Tool B](https://example.com/b) - Tool B description.
+- [Tool C](https://example.com/c) - Tool C description.
+`
+
+	html, err := markdown.ToHTML([]byte(testMarkdown))
+	if err != nil {
+		t.Fatalf("Failed to convert markdown to HTML: %v", err)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(html))
+	if err != nil {
+		t.Fatalf("Failed to create goquery document: %v", err)
+	}
+
+	category, err := extractCategory(doc, "#simple-category")
+	if err != nil {
+		t.Fatalf("Failed to extract simple category: %v", err)
+	}
+
+	if category.Title != "Simple Category" {
+		t.Errorf("Expected category title 'Simple Category', got '%s'", category.Title)
+	}
+
+	if len(category.Links) != 3 {
+		t.Errorf("Expected 3 links but got %d", len(category.Links))
+	}
+
+	expectedLinks := []string{"Tool A", "Tool B", "Tool C"}
+	for i, link := range category.Links {
+		if link.Title != expectedLinks[i] {
+			t.Errorf("Expected link %d to be '%s', got '%s'", i, expectedLinks[i], link.Title)
+		}
+	}
+}
+
+func TestEmptyCategoryReturnsError(t *testing.T) {
+	testMarkdown := `
+## Empty Category
+
+This category has no links.
+
+## Next Category
+
+- [Link X](https://example.com/x) - Description X.
+`
+
+	html, err := markdown.ToHTML([]byte(testMarkdown))
+	if err != nil {
+		t.Fatalf("Failed to convert markdown to HTML: %v", err)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(html))
+	if err != nil {
+		t.Fatalf("Failed to create goquery document: %v", err)
+	}
+
+	_, err = extractCategory(doc, "#empty-category")
+	if err == nil {
+		t.Error("Expected error for empty category, got nil")
+	}
+
+	if !errors.Is(err, errCategoryNoLinks) {
+		t.Errorf("Expected errCategoryNoLinks, got: %v", err)
+	}
+}
+
+func TestCategoryOnlyWithSubcategoriesReturnsError(t *testing.T) {
+	testMarkdown := `
+## Parent Only Category
+
+This category only has subcategories, no direct links.
+
+### Subcategory A
+
+- [Link A](https://example.com/a) - Description A.
+
+### Subcategory B
+
+- [Link B](https://example.com/b) - Description B.
+
+## Next Category
+
+- [Link C](https://example.com/c) - Description C.
+`
+
+	html, err := markdown.ToHTML([]byte(testMarkdown))
+	if err != nil {
+		t.Fatalf("Failed to convert markdown to HTML: %v", err)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(html))
+	if err != nil {
+		t.Fatalf("Failed to create goquery document: %v", err)
+	}
+
+	_, err = extractCategory(doc, "#parent-only-category")
+	if err == nil {
+		t.Error("Expected error for category with only subcategories, got nil")
+	}
+
+	if !errors.Is(err, errCategoryNoLinks) {
+		t.Errorf("Expected errCategoryNoLinks, got: %v", err)
+	}
+}
+
+func TestExtractCategoriesWithTOC(t *testing.T) {
+	testMarkdown := `
+## Contents
+
+<details>
+<summary>Expand contents</summary>
+
+- [Test Categories](#test-categories)
+  - [Category A](#category-a)
+  - [Category B](#category-b)
+
+</details>
+
+## Category A
+
+Description A.
+
+- [Link A1](https://example.com/a1) - Description A1.
+- [Link A2](https://example.com/a2) - Description A2.
+
+## Category B
+
+Description B.
+
+- [Link B1](https://example.com/b1) - Description B1.
+`
+
+	html, err := markdown.ToHTML([]byte(testMarkdown))
+	if err != nil {
+		t.Fatalf("Failed to convert markdown to HTML: %v", err)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(html))
+	if err != nil {
+		t.Fatalf("Failed to create goquery document: %v", err)
+	}
+
+	categories, err := extractCategories(doc)
+	if err != nil {
+		t.Fatalf("Failed to extract categories: %v", err)
+	}
+
+	if len(categories) != 2 {
+		t.Errorf("Expected 2 categories, got %d", len(categories))
+	}
+
+	catA, ok := categories["#category-a"]
+	if !ok {
+		t.Error("Category A not found")
+	} else {
+		if catA.Title != "Category A" {
+			t.Errorf("Expected title 'Category A', got '%s'", catA.Title)
+		}
+		if len(catA.Links) != 2 {
+			t.Errorf("Expected 2 links in Category A, got %d", len(catA.Links))
+		}
+	}
+
+	catB, ok := categories["#category-b"]
+	if !ok {
+		t.Error("Category B not found")
+	} else {
+		if len(catB.Links) != 1 {
+			t.Errorf("Expected 1 link in Category B, got %d", len(catB.Links))
+		}
+	}
+}
+
+func TestExtractCategoriesSkipsEmptyCategories(t *testing.T) {
+	testMarkdown := `
+## Contents
+
+<details>
+<summary>Expand contents</summary>
+
+- [Categories](#categories)
+  - [Good Category](#good-category)
+  - [Empty Category](#empty-category)
+  - [Another Good Category](#another-good-category)
+
+</details>
+
+## Good Category
+
+Has links.
+
+- [Link 1](https://example.com/1) - Description 1.
+
+## Empty Category
+
+No links here.
+
+## Another Good Category
+
+Also has links.
+
+- [Link 2](https://example.com/2) - Description 2.
+`
+
+	html, err := markdown.ToHTML([]byte(testMarkdown))
+	if err != nil {
+		t.Fatalf("Failed to convert markdown to HTML: %v", err)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(html))
+	if err != nil {
+		t.Fatalf("Failed to create goquery document: %v", err)
+	}
+
+	categories, err := extractCategories(doc)
+	if err != nil {
+		t.Fatalf("Failed to extract categories: %v", err)
+	}
+
+	// Should only have 2 categories (empty one skipped)
+	if len(categories) != 2 {
+		t.Errorf("Expected 2 categories (empty skipped), got %d", len(categories))
+	}
+
+	if _, ok := categories["#good-category"]; !ok {
+		t.Error("Good Category should be present")
+	}
+
+	if _, ok := categories["#another-good-category"]; !ok {
+		t.Error("Another Good Category should be present")
+	}
+
+	if _, ok := categories["#empty-category"]; ok {
+		t.Error("Empty Category should be skipped")
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/main.go
+++ b/main.go
@@ -318,7 +318,7 @@ func extractCategory(doc *goquery.Document, selector string) (*Category, error) 
 
 	doc.Find(selector).EachWithBreak(func(_ int, selCatHeader *goquery.Selection) bool {
 		selDescr := selCatHeader.NextFiltered("p")
-		ul := selCatHeader.NextFilteredUntil("ul", "h2, h3")
+		ul := selCatHeader.NextFilteredUntil("ul", "h2, h3, h4")
 
 		var links []Link
 		ul.Find("li").Each(func(_ int, selLi *goquery.Selection) {

--- a/main.go
+++ b/main.go
@@ -288,8 +288,11 @@ func extractCategories(doc *goquery.Document) (map[string]Category, error) {
 
 					category, err := extractCategory(doc, selector)
 					if err != nil {
-						// Skip entries without links (e.g. #contents, #awesome-go)
-						return true
+						if err.Error() == "build a category: category does not contain links" {
+							return true
+						}
+						rootErr = fmt.Errorf("extract category: %w", err)
+						return false
 					}
 
 					categories[selector] = *category
@@ -313,10 +316,7 @@ func extractCategory(doc *goquery.Document, selector string) (*Category, error) 
 
 	doc.Find(selector).EachWithBreak(func(_ int, selCatHeader *goquery.Selection) bool {
 		selDescr := selCatHeader.NextFiltered("p")
-		// FIXME: bug. this would select links from all neighboring
-		// sub-categories until the next category. To prevent this we should
-		// find only first ul
-		ul := selCatHeader.NextFilteredUntil("ul", "h2")
+		ul := selCatHeader.NextFilteredUntil("ul", "h2, h3")
 
 		var links []Link
 		ul.Find("li").Each(func(_ int, selLi *goquery.Selection) {

--- a/main.go
+++ b/main.go
@@ -74,6 +74,8 @@ type SitemapData struct {
 	Categories map[string]Category
 	Projects   []*Project
 }
+// Sentinel errors
+var errCategoryNoLinks = errors.New("category does not contain links")
 
 // Source files
 const readmePath = "README.md"
@@ -288,7 +290,7 @@ func extractCategories(doc *goquery.Document) (map[string]Category, error) {
 
 					category, err := extractCategory(doc, selector)
 					if err != nil {
-						if err.Error() == "build a category: category does not contain links" {
+						if errors.Is(err, errCategoryNoLinks) {
 							return true
 						}
 						rootErr = fmt.Errorf("extract category: %w", err)
@@ -334,7 +336,7 @@ func extractCategory(doc *goquery.Document, selector string) (*Category, error) 
 
 		// FIXME: In this case we would have an empty category in main index.html with link to 404 page.
 		if len(links) == 0 {
-			err = errors.New("category does not contain links")
+			err = errCategoryNoLinks
 			return false
 		}
 


### PR DESCRIPTION
## Summary 
Categories with subcategories (h3) were incorrectly including all nested links. For example, "Command Line" would include links from both "Advanced Console UIs" and "Standard CLI" subcategories.

Fixes the documented bug at main.go:245-247.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved category extraction to include sub-lists under headers and to derive categories from table-of-contents structures.
  * Empty categories are now detected and skipped so processing continues instead of stopping.

* **Tests**
  * Added comprehensive tests covering subcategory exclusion, empty-category handling, TOC-driven extraction, and link-count/filtering validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->