### PR TITLE
Add killport - Cross-platform port management CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ _Libraries for building Console Applications and Console User Interfaces._
 - [gocui](https://github.com/jroimartin/gocui) - Minimalist Go library aimed at creating Console User Interfaces.
 - [gommon/color](https://github.com/labstack/gommon/tree/master/color) - Style terminal text.
 - [gookit/color](https://github.com/gookit/color) - Terminal color rendering tool library, support 16 colors, 256 colors, RGB color rendering output, compatible with Windows.
+- [killport](https://github.com/TNT-Likely/killport) - Cross-platform CLI to kill processes on ports with interactive mode and system tray support.
 - [lipgloss](https://github.com/charmbracelet/lipgloss) - Declaratively define styles for color, format and layout in the terminal.
 - [marker](https://github.com/cyucelen/marker) - Easiest way to match and mark strings for colorful terminal outputs.
 - [mpb](https://github.com/vbauerster/mpb) - Multi progress bar for terminal applications.


### PR DESCRIPTION
 ## killport

  - **Repository**: https://github.com/TNT-Likely/killport
  - **Description**: Cross-platform CLI to kill processes on ports
  - **Features**:
    - Simple one-command usage: `killport 3000`
    - Interactive TUI mode with search and batch operations
    - System tray support for background monitoring
    - Port protection to prevent killing important services
    - Works on Linux, macOS, and Windows

  This tool solves a common developer pain point - dealing with "port already in use" errors. Instead of googling platform-specific commands, developers can use one simple command across all
  platforms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command-line interface resource section with new tools and libraries.
  * Added killport, a cross-platform CLI tool for process management.
  * Added multiple terminal UI libraries to extend console tooling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->