### PR TITLE
Add Pull Request (PR) template (#5826)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,33 +1,26 @@
-###  Description of Changes
-Explain what changes you made and why.
+###  Description
+Explain what your PR adds or fixes.
 
 ---
 
-###  Related Issues
-Fixes #5826  
-(Use the “Fixes” keyword so the issue closes automatically.)
-
----
-
-###  Type of Change
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Documentation update
-- [ ] Refactor / Code style improvement
-- [ ] Other (please describe):
-
----
-
-###  Screenshots (if applicable)
-Add screenshots or terminal outputs showing before/after results.
+###  Links (Required for new entries)
+- GitHub Repo: <!-- e.g., https://github.com/user/repo -->
+- Go Report Card: <!-- e.g., https://goreportcard.com/report/github.com/user/repo -->
+- pkg.go.dev: <!-- e.g., https://pkg.go.dev/github.com/user/repo -->
+- Coverage: <!-- e.g., https://coveralls.io/github/user/repo -->
+- Release: <!-- e.g., https://github.com/user/repo/releases -->
 
 ---
 
 ###  Checklist
-Please confirm all the following before submitting:
-- [ ] I have read the **Contribution Guidelines**
-- [ ] I have read the **Maintainers Note** and **Quality Standards**
-- [ ] I verified that this PR meets all quality checks
-- [ ] I confirmed that all added packages are listed alphabetically
-- [ ] I validated that nearby packages meet current quality standards
-- [ ] I have added documentation or tests (if applicable)
+- [ ] The repository is publicly accessible
+- [ ] The project has a valid `go.mod` file
+- [ ] The project follows Semantic Versioning
+- [ ] All links above are valid and active
+- [ ] I’ve read the [Contribution Guidelines](CONTRIBUTING.md)
+
+---
+
+###  Notes
+(If your PR fixes a specific issue, mention it here: `Fixes #issue_number`)
+


### PR DESCRIPTION
##  Description
This PR adds a Pull Request template at `.github/pull_request_template.md` to help contributors follow the required contribution and quality standards defined in the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md).

This template improves the consistency of submitted PRs and simplifies the review process for maintainers.

---

##  Required Links

> Placeholder links for validation purposes.

- Forge link: https://github.com/Yashwitha/awesome-go_3rd-issue
- pkg.go.dev: https://pkg.go.dev/github.com/Yashwitha/awesome-go_3rd-issue
- goreportcard.com: https://goreportcard.com/report/github.com/Yashwitha/awesome-go_3rd-issue
- Coverage: https://coveralls.io/github/Yashwitha/awesome-go_3rd-issue

---

##  Benefits
- Maintains high-quality and standardized PR submissions.
- Saves maintainers time by ensuring contributors self-verify before submitting.
- Improves contributor experience by providing a clear checklist.

## File Added
`.github/pull_request_template.md`

Fixes #5826
