### PR TITLE
Add promptext - Smart code context extractor CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ _Libraries for building standard or basic Command Line applications._
 - [ops](https://github.com/nanovms/ops) - Unikernel Builder/Orchestrator.
 - [orpheus](https://github.com/agilira/orpheus) - CLI framework with security hardening, plugin storage system, and production observability features.
 - [pflag](https://github.com/spf13/pflag) - Drop-in replacement for Go's flag package, implementing POSIX/GNU-style --flags.
-- [promptext](https://github.com/1broseidon/promptext) - Smart code context extractor for AI assistants. CLI tool with intelligent filtering, relevance prioritization, accurate token counting (tiktoken), and multiple output formats (PTX, JSONL, TOON, Markdown, XML).
+- [promptext](https://github.com/1broseidon/promptext) - Extracts and formats code context for AI assistants with token counting.
 - [readline](https://github.com/reeflective/readline) - Shell library with modern and easy to use UI features.
 - [sflags](https://github.com/octago/sflags) - Struct based flags generator for flag, urfave/cli, pflag, cobra, kingpin, and other libraries.
 - [structcli](https://github.com/leodido/structcli) - Eliminate Cobra boilerplate: build powerful, feature-rich CLIs declaratively from Go structs.


### PR DESCRIPTION
## Description

Adding [Promptext](https://github.com/1broseidon/promptext) to the Standard CLI section.

**Promptext** is a production-ready Go CLI application that helps developers extract and optimize codebase context for AI assistants.

### Technical Implementation (Go):
- **Architecture**: Modular internal package structure (`internal/*`)
- **CLI Framework**: Uses `pflag` for POSIX-compliant flag parsing
- **Dependencies**: 
  - `tiktoken-go` for accurate GPT-compatible token counting
  - `go-pretty` for formatted table output
  - Go modules for dependency management
- **Testing**: Comprehensive test coverage using `testify`
- **Cross-platform**: Builds for Linux, macOS, Windows (amd64, arm64)

### Key Features:
- 🔍 **Smart Filtering**: .gitignore integration, intelligent defaults, glob patterns
- 🎯 **Relevance Prioritization**: Multi-factor scoring system
  - Filename matches: 10x weight
  - Directory matches: 5x weight
  - Import/dependency matches: 3x weight
  - Content matches: 1x weight
- 📊 **Token Counting**: Accurate estimation using tiktoken
- 💾 **Multiple Output Formats**: PTX v2.0, JSONL, TOON, Markdown, XML
- ⚡ **Token Budget Management**: Automatic file exclusion when limits exceeded
- 🤖 **Project Detection**: Auto-generates configs for 15+ frameworks

### Why it belongs here:
Promptext is a well-engineered Go CLI application that demonstrates modern Go best practices. It fits perfectly in the Standard CLI section as a practical tool for developers working with AI-assisted development workflows.

### Installation:
```bash
go install github.com/1broseidon/promptext/cmd/promptext@latest
```

### Usage Example:
```bash
# Extract API-related code within 8000 tokens
promptext --relevant "api routes handlers" --max-tokens 8000

# Generate project context
promptext -o context.ptx

# Initialize project config
promptext --init
```

### Links:
- **GitHub**: https://github.com/1broseidon/promptext
- **Latest Release**: v0.5.1
- **Documentation**: https://1broseidon.github.io/promptext/
- **Go Package**: github.com/1broseidon/promptext

### Go Version:
- Requires: Go 1.19+

Thank you for maintaining this excellent Go resources collection!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new reference for the "promptext" CLI tool in the Command Line → Standard CLI section, listed after the existing pflag entry to guide users to the new tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->