### PR TITLE
Add `invzhi/timex` in date and time

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,6 +960,7 @@ _Libraries for working with dates and times._
 - [strftime](https://github.com/awoodbeck/strftime) - C99-compatible strftime formatter.
 - [timespan](https://github.com/SaidinWoT/timespan) - For interacting with intervals of time, defined as a start time and a duration.
 - [timeutil](https://github.com/leekchan/timeutil) - Useful extensions (Timedelta, Strftime, ...) to the golang's time package.
+- [timex](https://github.com/invzhi/timex) - A Go package that extends the standard library time with dedicated date and time-of-day types. 
 - [tuesday](https://github.com/osteele/tuesday) - Ruby-compatible Strftime function.
 
 **[⬆ back to top](#contents)**


### PR DESCRIPTION
https://github.com/invzhi/timex
pkg.go.dev: https://pkg.go.dev/github.com/invzhi/timex
goreportcard.com: https://goreportcard.com/report/github.com/invzhi/timex
Coverage: https://codecov.io/gh/invzhi/timex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Date and Time library entry: timex, a Go package that extends the standard library time with dedicated date and time-of-day types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->