### PR TITLE
Add liquidgo to Template Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2408,6 +2408,7 @@ _Libraries and tools for templating and lexing._
 - [htmgo](https://htmgo.dev) - build simple and scalable systems with go + htmx
 - [jet](https://github.com/CloudyKit/jet) - Jet template engine.
 - [liquid](https://github.com/osteele/liquid) - Go implementation of Shopify Liquid templates.
+- [liquidgo](https://github.com/Notifuse/liquidgo) - Full Go implementation of Shopify's Liquid template engine.
 - [maroto](https://github.com/johnfercher/maroto) - A maroto way to create PDFs. Maroto is inspired in Bootstrap and uses gofpdf. Fast and simple.
 - [pongo2](https://github.com/flosch/pongo2) - Django-like template-engine for Go.
 - [quicktemplate](https://github.com/valyala/quicktemplate) - Fast, powerful, yet easy to use template engine. Converts templates into Go code and then compiles it.


### PR DESCRIPTION
Forge link: https://github.com/Notifuse/liquidgo
pkg.go.dev: https://pkg.go.dev/github.com/Notifuse/liquidgo
goreportcard.com: https://goreportcard.com/report/github.com/Notifuse/liquidgo
Coverage: https://codecov.io/github/notifuse/liquidgo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new template engine to the list of supported options in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->