### PR TITLE
Fix link for "beep" in Audio and Music section

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ _Libraries for building programs that leverage AI._
 
 _Libraries for manipulating audio._
 
-- [beep](https://github.com/faiface/beep) - A simple library for playback and audio manipulation.
+- [beep](https://github.com/gopxl/beep) - A simple library for playback and audio manipulation.
 - [flac](https://github.com/mewkiz/flac) - Native Go FLAC encoder/decoder with support for FLAC streams.
 - [gaad](https://github.com/Comcast/gaad) - Native Go AAC bitstream parser.
 - [go-mpris](https://github.com/leberKleber/go-mpris) - Client for mpris dbus interfaces.


### PR DESCRIPTION
Hello maintainers and contributors,

The repository by faiface has moved their development to gopxl. I changed the link for "beep" in the category of "Audio and Music".

Repo link: https://github.com/gopxl/beep
pkg.go.dev: https://pkg.go.dev/github.com/gopxl/beep/v2
goreportcard: https://goreportcard.com/report/github.com/gopxl/beep/v2
coverage: https://coveralls.io/github/gopxl/beep?branch=main

Kind Regards,
adeel26in