### PR TITLE
Replace broken Cloud Immunity link in Tutorials with Wayback snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -3720,7 +3720,7 @@ _Add the group of your city/country here (send **PR**)_
 
 ### Tutorials
 
-- [50 Shades of Go](https://web.archive.org/web/20230524231956/https://devs.cloudimmunity.com/gotchas-and-common-mistakes-in-go-golang/) - Traps, Gotchas, and Common Mistakes for New Golang Devs.
+- [50 Shades of Go](https://golang50shades.github.io/) - Traps, Gotchas, and Common Mistakes for New Golang Devs.
 - [A Comprehensive Guide to Structured Logging in Go](https://betterstack.com/community/guides/logging/logging-in-go/) - Delve deep into the world of structured logging in Go with a specific focus on recently accepted slog proposal which aims to bring high performance structured logging with levels to the standard library.
 - [A Guide to Golang E-Commerce](https://snipcart.com/blog/golang-ecommerce-ponzu-cms-demo?utm_term=golang-ecommerce-ponzu-cms-demo) - Building a Golang site for e-commerce (demo included).
 - [A Tour of Go](https://tour.golang.org/) - Interactive tour of Go.


### PR DESCRIPTION
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Maintainers Note](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#maintainers)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Pull Request Description

**Fixes #5946**

The original CloudImmunity “50 Shades of Go” link in the Tutorials section is now compromised and redirects to a malicious/parked domain.

This PR replaces the broken link with the last known safe Wayback Machine snapshot:

[https://web.archive.org/web/20230524231956/https://devs.cloudimmunity.com/gotchas-and-common-mistakes-in-go-golang/](https://web.archive.org/web/20230524231956/https://devs.cloudimmunity.com/gotchas-and-common-mistakes-in-go-golang/)

Newer snapshots contain JavaScript redirects, so this is the most recent clean version.
This update ensures users are **not taken to an unsafe domain** while browsing Awesome Go resources.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the "50 Shades of Go" tutorial link in the documentation to point to the new archived site.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->