### PR TITLE
Add vedika-go: Vedika Astrology API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -2738,6 +2738,7 @@ _Libraries for accessing third party APIs._
 - [TripAdvisor](https://github.com/mrbenosborne/tripadvisor-golang) - Go wrapper for the TripAdvisor API.
 - [tumblr](https://github.com/mattcunningham/gumblr) - Go wrapper for the Tumblr v2 API.
 - [uptimerobot](https://github.com/bitfield/uptimerobot) - Go wrapper and command-line client for the Uptime Robot v2 API.
+- [vedika-go](https://github.com/vedika-ai/vedika-go) - Go client for the Vedika Astrology API, providing Vedic astrology calculations, horoscope, kundali, panchang, and AI-powered astrology chatbot.
 - [vl-go](https://github.com/verifid/vl-go) - Go client library around the VerifID identity verification layer API.
 - [webhooks](https://github.com/go-playground/webhooks) - Webhook receiver for GitHub and Bitbucket.
 - [wit-go](https://github.com/wit-ai/wit-go) - Go client for wit.ai HTTP API.


### PR DESCRIPTION
## Summary
Add vedika-go to the Third-party APIs section.

## Description
Vedika API provides:
- Vedic astrology calculations (108+ endpoints)
- Horoscope, kundali, panchang, numerology
- AI-powered astrology chatbot
- REST API compatible with any programming language

## Entry
```markdown
- [vedika-go](https://github.com/vedika-ai/vedika-go) - Go client for the Vedika Astrology API, providing Vedic astrology calculations, horoscope, kundali, panchang, and AI-powered astrology chatbot.
```

## Links
- Website: https://vedika.io
- API Docs: https://vedika.io/docs
- Repository: https://github.com/vedika-ai/vedika-go

Note: SDK is currently under development. REST API is fully functional at https://vedika.io