### PR TITLE
Add Marten to Web Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3040,6 +3040,7 @@ _Full stack web frameworks._
 - [Huma](https://github.com/danielgtaylor/huma/) - Framework for modern REST/GraphQL APIs with built-in OpenAPI 3, generated documentation, and a CLI.
 - [iWF](https://github.com/indeedeng/iwf) - iWF is an all-in-one platform for developing long-running business processes. It offers a convenient abstraction for utilizing databases, ElasticSearch, message queues, durable timers, and more, with a clean, simple, and user-friendly interface.
 - [Lit](https://github.com/jvcoutinho/lit) - Highly performant declarative web framework for Golang, aiming for simplicity and quality of life.
+- [Marten](https://github.com/gomarten/marten) - Zero-dependency Go web framework focused on simplicity: nothing in the way, stdlib context preserved, production middleware included.
 - [Microservice](https://github.com/claygod/microservice) - The framework for the creation of microservices, written in Golang.
 - [patron](https://github.com/beatlabs/patron) - Patron is a microservice framework following best cloud practices with a focus on productivity.
 - [Pnutmux](https://gitlab.com/fruitygo/pnutmux) - Pnutmux is a powerful Go web framework that uses regex for matching and handling HTTP requests. It offers features such as CORS handling, structured logging, URL parameters extraction, middlewares, and concurrency limiting.


### PR DESCRIPTION
Adding Marten to Web Frameworks section.

- Repository link: https://github.com/gomarten/marten
- pkg.go.dev: https://pkg.go.dev/github.com/gomarten/marten
- Go Report Card: https://goreportcard.com/report/github.com/gomarten/marten
- Coverage: Unit tests present 

Marten is an elegant, zero-external-dependency Go web framework with:
- Clean handler helpers (c.JSON, c.Bind, c.Param, etc.)
- Untouched stdlib context.Context
- Built-in production middleware (gzip, CORS, secure headers, rate limiting, etc.)

Philosophy: "The framework you reach for when you want nothing in the way."

Thank you for considering!