### PR TITLE
Add gitch to Version Control section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2993,6 +2993,7 @@ _Libraries for version control._
 - [froggit-go](https://github.com/jfrog/froggit-go) - Froggit-Go is a Go library, allowing to perform actions on VCS providers.
 - [git2go](https://github.com/libgit2/git2go) - Go bindings for libgit2.
 - [githooks](https://github.com/gabyx/githooks) - Per-repo and shared Git hooks with version control and auto update.
+- [gitch](https://github.com/orzazade/gitch) - Git identity manager with SSH/GPG key management, auto-switching rules, and pre-commit protection.
 - [go-git](https://github.com/go-git/go-git) - highly extensible Git implementation in pure Go.
 - [go-vcs](https://github.com/sourcegraph/go-vcs) - manipulate and inspect VCS repositories in Go.
 - [hercules](https://github.com/src-d/hercules) - gaining advanced insights from Git repository history.


### PR DESCRIPTION
## What is gitch?

[gitch](https://github.com/orzazade/gitch) is a CLI tool for managing multiple git identities with:

- SSH and GPG key management (generation and linking)
- Auto-switching based on directory or remote URL patterns
- Pre-commit hooks to prevent wrong-identity commits
- Shell prompt integration (Bash, Zsh, Fish)
- VS Code extension

## Why add it?

Developers who work across multiple projects (work, personal, open source) often commit with the wrong email/identity. gitch solves this by automating identity management.

## Checklist

- [x] Has a proper README with installation instructions
- [x] Has CI/CD (GitHub Actions)
- [x] Has proper Go module structure
- [x] MIT licensed
- [x] Actively maintained
- [x] Not a duplicate of existing entries
- [x] Sorted alphabetically in the list