### PR TITLE
Add nullsec-go to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2278,6 +2278,7 @@ _Libraries that are used to help make your application more secure._
 
 - [acmetool](https://github.com/hlandau/acme) - ACME (Let's Encrypt) client tool with automatic renewal.
 - [acopw-go](https://sr.ht/~jamesponddotco/acopw-go/) - Small cryptographically secure password generator package for Go.
+- [nullsec-go](https://github.com/bad-antics/nullsec-go) - Comprehensive Go security toolkit featuring hash cracking, network analysis, steganography, and cryptographic utilities for security professionals.
 - [acra](https://github.com/cossacklabs/acra) - Network encryption proxy to protect database-based applications from data leaks: strong selective encryption, SQL injections prevention, intrusion detection system.
 - [age](https://github.com/FiloSottile/age) - A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability.
 - [argon2-hashing](https://github.com/andskur/argon2-hashing) - light wrapper around Go's argon2 package that closely mirrors with Go's standard library Bcrypt and simple-scrypt package.


### PR DESCRIPTION
## Description
Adding nullsec-go to the Security section.

**nullsec-go** is a comprehensive Go security toolkit featuring:
- Hash cracking utilities
- Network analysis tools
- Steganography implementations
- Cryptographic utilities
- Security testing helpers

Repository: https://github.com/bad-antics/nullsec-go

This library provides well-documented Go implementations for common security operations.