### PR TITLE
feat: add Arco to Other Software section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3401,7 +3401,7 @@ _Software written in Go._
 
 ### Other Software
 
-- [Arco](https://github.com/loomi-labs/arco) - Modern GUI-based backup tool built on Borg with encryption, compression, and deduplication.
+- [Arco](https://github.com/loomi-labs/arco) - Modern GUI-based backup tool based on Borg with encryption, compression, and deduplication.
 - [Better Go Playground](https://goplay.tools) - Go playground with syntax highlight, code completion and other features.
 - [blocky](https://github.com/0xERR0R/blocky) - Fast and lightweight DNS proxy as ad-blocker for local network with many features.
 - [bluetuith](https://github.com/bluetuith-org/bluetuith) - TUI Bluetooth manager for Linux.


### PR DESCRIPTION
## Summary
- Add [Arco](https://github.com/loomi-labs/arco) to the Other Software section
- Arco is a modern GUI-based backup tool based on Borg with encryption, compression, and deduplication

## Links
- Forge link: https://github.com/loomi-labs/arco
- pkg.go.dev: https://pkg.go.dev/github.com/loomi-labs/arco
- goreportcard.com: https://goreportcard.com/report/github.com/loomi-labs/arco
- Coverage: N/A (desktop application with GUI, not a library)

## Notes
Arco is a desktop application (not a library), similar to other entries in "Other Software" like restic, Duplicacy, hugo, etc.