### PR TITLE
Remove GopherChina from the events list

### DIFF
--- a/README.md
+++ b/README.md
@@ -3507,7 +3507,6 @@ _Where to discover new Go libraries._
 - [GoCon](https://gocon.connpass.com/) - Tokyo, Japan.
 - [GoDays](https://www.godays.io/) - Berlin, Germany.
 - [GoLab](https://golab.io/) - Florence, Italy.
-- [GopherChina](https://gopherchina.org) - Shanghai, China.
 - [GopherCon](https://www.gophercon.com/) - Varied Locations Each Year, USA.
 - [GopherCon Australia](https://gophercon.com.au/) - Sydney, Australia.
 - [GopherCon Brazil](https://gopherconbr.org) - Florianópolis, Brazil.


### PR DESCRIPTION
GopherChina domain is down, and @gopherchina group seems no longer active in the past 2 years.