### PR TITLE
Add kreuzberg

### DIFF
--- a/README.md
+++ b/README.md
@@ -2592,6 +2592,7 @@ See also [Natural Language Processing](#natural-language-processing) and [Text A
 - [gofeed](https://github.com/mmcdole/gofeed) - Parse RSS and Atom feeds in Go.
 - [gographviz](https://github.com/awalterschulze/gographviz) - Parses the Graphviz DOT language.
 - [gonameparts](https://github.com/polera/gonameparts) - Parses human names into individual name parts.
+- [kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) - Document intelligence library that extracts text, tables, and metadata from 62+ formats including PDF, Office, images with OCR, HTML, email, and archives.
 - [ltsv](https://github.com/Wing924/ltsv) - High performance [LTSV (Labeled Tab Separated Value)](http://ltsv.org/) reader for Go.
 - [normalize](https://github.com/avito-tech/normalize) - Sanitize, normalize and compare fuzzy text.
 - [parseargs-go](https://github.com/nproc/parseargs-go) - string argument parser that understands quotes and backslashes.


### PR DESCRIPTION
Add [kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) to the Text Processing > Parsers/Encoders/Decoders section.

Kreuzberg is a document intelligence library with Go bindings (via cgo) that extracts text, tables, and metadata from 62+ file formats including PDF, Office documents, images with OCR, HTML, email, and archives.

Forge link: https://github.com/kreuzberg-dev/kreuzberg
pkg.go.dev: https://pkg.go.dev/github.com/kreuzberg-dev/kreuzberg
goreportcard.com: https://goreportcard.com/report/github.com/kreuzberg-dev/kreuzberg