### PR TITLE
Add ClawShield to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2287,6 +2287,7 @@ _Libraries that are used to help make your application more secure._
 - [Cameradar](https://github.com/Ullaakut/cameradar) - Tool and library to remotely hack RTSP streams from surveillance cameras.
 - [certificates](https://github.com/mvmaasakkers/certificates) - An opinionated tool for generating tls certificates.
 - [CertMagic](https://github.com/caddyserver/certmagic) - Mature, robust, and powerful ACME client integration for fully-managed TLS certificate issuance and renewal.
+- [ClawShield](https://github.com/lennystepn-hue/clawshield) - Security scanner and hardener for AI agent environments with 50+ automated checks across Linux, macOS, and Windows.
 - [Coraza](https://github.com/corazawaf/coraza) - Enterprise-ready, modsecurity and OWASP CRS compatible WAF library.
 - [dongle](https://github.com/golang-module/dongle) - A simple, semantic and developer-friendly golang package for encoding&decoding and encryption&decryption.
 - [encid](https://github.com/bobg/encid) - Encode and decode encrypted integer IDs.


### PR DESCRIPTION
## What is ClawShield?

ClawShield is an open-source security scanner and hardener for AI agent environments.

- **Single binary** (~2MB), zero config, zero dependencies
- **50+ automated checks** across Linux (50), macOS (42), and Windows (37)
- **Interactive hardener** with risk-level explanations
- **Skill/plugin scanner** detecting 40+ malicious code patterns
- Written in **Go 1.22+**, MIT licensed

GitHub: https://github.com/lennystepn-hue/clawshield

It fits the Security section as it provides automated security auditing specifically designed for server environments running AI agents.