### PR TITLE
fix: accept app.codecov.io URLs in quality check script

### DIFF
--- a/.github/scripts/check-quality.js
+++ b/.github/scripts/check-quality.js
@@ -258,7 +258,7 @@ async function main() {
   const repo = capture(body, /forge\s+link[^:]*:\s*(https?:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/\S+)/i);
   const pkg = capture(body, /pkg\.go\.dev:\s*(https?:\/\/pkg\.go\.dev\/\S+)/i);
   const gorep = capture(body, /goreportcard\.com:\s*(https?:\/\/goreportcard\.com\/\S+)/i);
-  const coverage = capture(body, /coverage[^:]*:\s*(https?:\/\/(?:coveralls\.io|codecov\.io)\/\S+)/i);
+  const coverage = capture(body, /coverage[^:]*:\s*(https?:\/\/(?:coveralls\.io|(?:app\.)?codecov\.io)\/\S+)/i);
 
   const results = [];
   let criticalFail = false;


### PR DESCRIPTION
## Summary

Codecov changed their public URL format from `codecov.io/gh/...` to `app.codecov.io/gh/...`. The regex in `check-quality.js` only matches the old format, causing submissions with the new URL to fail validation.

## Changes

- **`.github/scripts/check-quality.js`**: Updated the coverage URL regex from `codecov\.io` to `(?:app\.)?codecov\.io` to accept both old and new URL formats.

Closes #6025

🤖 Generated with [Claude Code](https://claude.ai/claude-code)