### PR TITLE
Add aguara to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2279,6 +2279,7 @@ _Libraries that are used to help make your application more secure._
 - [acopw-go](https://sr.ht/~jamesponddotco/acopw-go/) - Small cryptographically secure password generator package for Go.
 - [acra](https://github.com/cossacklabs/acra) - Network encryption proxy to protect database-based applications from data leaks: strong selective encryption, SQL injections prevention, intrusion detection system.
 - [age](https://github.com/FiloSottile/age) - A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability.
+- [aguara](https://github.com/garagon/aguara) - Static security scanner for AI agent skills and MCP server configurations.
 - [argon2-hashing](https://github.com/andskur/argon2-hashing) - light wrapper around Go's argon2 package that closely mirrors with Go's standard library Bcrypt and simple-scrypt package.
 - [autocert](https://pkg.go.dev/golang.org/x/crypto/acme/autocert) - Auto provision Let's Encrypt certificates and start a TLS server.
 - [BadActor](https://github.com/jaredfolkins/badactor) - In-memory, application-driven jailer built in the spirit of fail2ban.


### PR DESCRIPTION
## Add aguara to Security section

Forge link: https://github.com/garagon/aguara
pkg.go.dev: https://pkg.go.dev/github.com/garagon/aguara
goreportcard.com: https://goreportcard.com/report/github.com/garagon/aguara
Coverage: https://app.codecov.io/gh/garagon/aguara

**aguara** is a static security scanner for AI agent skills and MCP server configurations. It is a single Go binary with no external dependencies, offline, deterministic analysis with 148 built-in rules across 15 categories.

- [x] Entry is in alphabetical order within the Security section
- [x] Description ends with a period
- [x] Link text matches the project name
- [x] Project has an open source license
- [x] Project has a `go.mod` file
- [x] Project has SemVer releases
- [x] Documentation in English