### PR TITLE
Add oktsec to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2305,6 +2305,7 @@ _Libraries that are used to help make your application more secure._
 - [memguard](https://github.com/awnumar/memguard) - A pure Go library for handling sensitive values in memory.
 - [multikey](https://github.com/adrianosela/multikey) - An n-out-of-N keys encryption/decryption framework based on Shamir's Secret Sharing algorithm.
 - [nacl](https://github.com/kevinburke/nacl) - Go implementation of the NaCL set of API's.
+- [oktsec](https://github.com/oktsec/oktsec) - Security proxy for AI agent-to-agent communication with identity verification and policy enforcement.
 - [optimus-go](https://github.com/pjebs/optimus-go) - ID hashing and Obfuscation using Knuth's Algorithm.
 - [passlib](https://github.com/hlandau/passlib) - Futureproof password hashing library.
 - [passwap](https://github.com/zitadel/passwap) - Provides a unified implementation between different password hashing algorithms


### PR DESCRIPTION
## Add oktsec to Security section

Forge link: https://github.com/oktsec/oktsec
pkg.go.dev: https://pkg.go.dev/github.com/oktsec/oktsec
goreportcard.com: https://goreportcard.com/report/github.com/oktsec/oktsec
Coverage: https://app.codecov.io/gh/oktsec/oktsec

**oktsec** is a security proxy for AI agent-to-agent communication. It provides Ed25519 identity verification, YAML-based policy enforcement, content scanning via Aguara, and a SQLite audit trail. Single Go binary, no LLM required.

- [x] Entry is in alphabetical order within the Security section
- [x] Description ends with a period
- [x] Link text matches the project name
- [x] Project has an open source license
- [x] Project has a `go.mod` file
- [x] Project has SemVer releases
- [x] Documentation in English