### PR TITLE
Add born-ml/born to Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1645,6 +1645,7 @@ _Libraries for generating and working with log files._
 _Libraries for Machine Learning._
 
 - [bayesian](https://github.com/jbrukh/bayesian) - Naive Bayesian Classification for Golang.
+- [born](https://github.com/born-ml/born) - Deep learning framework inspired by Burn (Rust), with autograd, type-safe tensors, and zero-CGO GPU acceleration.
 - [catboost-cgo](https://github.com/mirecl/catboost-cgo) - Fast, scalable, high performance Gradient Boosting on Decision Trees library. Golang using Cgo for blazing fast inference CatBoost Model.
 - [CloudForest](https://github.com/ryanbressler/CloudForest) - Fast, flexible, multi-threaded ensembles of decision trees for machine learning in pure Go.
 - [ddt](https://github.com/sgrodriguez/ddt) - Dynamic decision tree, create trees defining customizable rules.


### PR DESCRIPTION
**Project Name:** born
**Project URL:** https://github.com/born-ml/born
**Project Desc:** Deep learning framework inspired by Burn (Rust), with autograd, type-safe tensors, and zero-CGO GPU acceleration.

**Check links:**
- Forge link: https://github.com/born-ml/born
- pkg.go.dev: https://pkg.go.dev/github.com/born-ml/born
- goreportcard.com: https://goreportcard.com/report/github.com/born-ml/born
- Coverage service (Codecov): https://app.codecov.io/gh/born-ml/born

**Checklist:**
- [x] Has go.mod file
- [x] Has at least one tagged release (v0.7.11)
- [x] English README with full documentation
- [x] Available on pkg.go.dev
- [x] Go Report Card grade A+
- [x] Coverage service badge (Codecov)
- [x] CI with GitHub Actions
- [x] Open-source license (Apache 2.0)

**Additional Info:**
- Inspired by [Burn](https://github.com/tracel-ai/burn) (Rust) deep learning framework — Burn-like API for Go
- Automatic differentiation engine (autograd)
- Type-safe tensor operations with generics
- GPU acceleration via WebGPU — zero CGO required
- Train and deploy neural networks as single Go binaries
- Active development with 44 stars
