### PR TITLE
fix(ci): add safe.directory config to fix git fetch in container

### DIFF
--- a/.github/workflows/pr-quality-check.yaml
+++ b/.github/workflows/pr-quality-check.yaml
@@ -43,7 +43,9 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch base branch
-        run: git fetch origin ${{ github.base_ref }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch origin ${{ github.base_ref }}
 
       - name: Run quality checks
         id: quality


### PR DESCRIPTION
The "Fetch base branch" step fails with exit code 128 when running
inside the golang:latest container because Git does not recognize the
workspace as a safe directory. This is a Git security feature (CVE-2022-24765)
that blocks operations in directories owned by a different user, which
happens when actions/checkout runs inside a container.

https://claude.ai/code/session_01NBtQtSPnsSvAwqUMBMLGFh