### PR TITLE
Add FCaptcha to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -2287,6 +2287,7 @@ _Libraries that are used to help make your application more secure._
 - [dongle](https://github.com/golang-module/dongle) - A simple, semantic and developer-friendly golang package for encoding&decoding and encryption&decryption.
 - [encid](https://github.com/bobg/encid) - Encode and decode encrypted integer IDs.
 - [entpassgen](https://github.com/andreimerlescu/entpassgen) - Entropy Password Generator with extensive command line arguments to generate random strings securely including digits, passwords, and passwords built using obscure dictionary words mixed with symbols and digits.
+- [FCaptcha](https://github.com/WebDecoy/FCaptcha) - Self-hosted CAPTCHA that detects bots, vision AI agents, and headless browsers through behavioral analysis and SHA-256 proof of work.
 - [firewalld-rest](https://github.com/prashantgupta24/firewalld-rest) - A rest application to dynamically update firewalld rules on a linux server.
 - [go-generate-password](https://github.com/m1/go-generate-password) - Password generator that can be used on the cli or as a library.
 - [go-htpasswd](https://github.com/tg123/go-htpasswd) - Apache htpasswd Parser for Go.


### PR DESCRIPTION
Adds FCaptcha to the Security section.

FCaptcha is a self-hosted CAPTCHA system with a Go server that detects bots, vision AI agents, and headless browsers through behavioral analysis and SHA-256 proof of work.

Forge link: https://github.com/WebDecoy/FCaptcha
Go server: https://github.com/WebDecoy/FCaptcha/tree/main/server-go
Demo: https://webdecoy.com/product/fcaptcha-demo/