### PR TITLE
Add scigolib/matlab to Science and Data Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -2250,6 +2250,7 @@ _Libraries for scientific computing and data analyzing._
 - [hdf5](https://github.com/scigolib/hdf5) - Pure Go implementation of the HDF5 file format for scientific data storage and exchange.
 - [insyra](https://github.com/HazelnutParadise/insyra) - Data analysis library with statistics, visualization, Parquet support, and Python integration.
 - [jsonl-graph](https://github.com/nikolaydubina/jsonl-graph) - Tool to manipulate JSONL graphs with graphviz support.
+- [matlab](https://github.com/scigolib/matlab) - Pure Go library for reading and writing MATLAB .mat files (v5-v7.3) without CGO.
 - [MatProInterface.go](https://github.com/MatProGo-dev/MatProInterface.go) - MatProInterface.go is an open source package for defining mathematical programs (e.g., convex optimization problems) in Go.
 - [ode](https://github.com/ChristopherRabotin/ode) - Ordinary differential equation (ODE) solver which supports extended states and channel-based iteration stop conditions.
 - [orb](https://github.com/paulmach/orb) - 2D geometry types with clipping, GeoJSON and Mapbox Vector Tile support.


### PR DESCRIPTION
**Project Name:** matlab
**Project URL:** https://github.com/scigolib/matlab
**Project Desc:** Pure Go library for reading and writing MATLAB .mat files (v5-v7.3) without CGO.

**Check links:**
- Forge link: https://github.com/scigolib/matlab
- pkg.go.dev: https://pkg.go.dev/github.com/scigolib/matlab
- goreportcard.com: https://goreportcard.com/report/github.com/scigolib/matlab
- Coverage service (Codecov): https://app.codecov.io/gh/scigolib/matlab

**Checklist:**
- [x] Has go.mod file
- [x] Has at least one tagged release (v0.3.5)
- [x] English README with full documentation
- [x] Available on pkg.go.dev
- [x] Go Report Card grade A+
- [x] Coverage service badge (Codecov)
- [x] CI with GitHub Actions
- [x] Open-source license (MIT)

**Additional Info:**
- Read and write MATLAB v5-v7.2 (traditional format) and v7.3+ (HDF5 format)
- Full support for numeric types, complex numbers, and multi-dimensional arrays
- Zero external C dependencies, cross-platform (Windows/Linux/macOS)
- Part of the SciGoLib scientific computing ecosystem
- 228 tests, 91.2% code coverage
