### PR TITLE
Add GopherCon Africa to conferences list

### DIFF
--- a/README.md
+++ b/README.md
@@ -3528,6 +3528,7 @@ _Where to discover new Go libraries._
 - [GoDays](https://www.godays.io/) - Berlin, Germany.
 - [GoLab](https://golab.io/) - Florence, Italy.
 - [GopherCon](https://www.gophercon.com/) - Varied Locations Each Year, USA.
+- [GopherCon Africa](https://gophercon.africa/) - Nairobi, Kenya.
 - [GopherCon Australia](https://gophercon.com.au/) - Sydney, Australia.
 - [GopherCon Brazil](https://gopherconbr.org) - Florianópolis, Brazil.
 - [GopherCon China](https://gophercon.com.cn) - Shanghai, China.


### PR DESCRIPTION
This PR adds a conference entry (non-package).

The automated quality checks appear to require a GitHub repository with a SemVer release, which does not apply to conference entries.

All changes are limited to a single alphabetical entry in the Conferences section.

Could a maintainer please review and merge if appropriate? Thank you!