### PR TITLE
Add coregx/fursy to Routers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3117,6 +3117,7 @@ _Full stack web frameworks._
 - [Bxog](https://github.com/claygod/Bxog) - Simple and fast HTTP router for Go. It works with routes of varying difficulty, length and nesting. And he knows how to create a URL from the received parameters.
 - [chi](https://github.com/go-chi/chi) - Small, fast and expressive HTTP router built on net/context.
 - [fasthttprouter](https://github.com/buaazp/fasthttprouter) - High performance router forked from `httprouter`. The first router fit for `fasthttp`.
+- [fursy](https://github.com/coregx/fursy) - HTTP router with type-safe generic handlers, automatic OpenAPI 3.1 generation from code, and RFC 9457 error responses.
 - [FastRouter](https://github.com/razonyang/fastrouter) - a fast, flexible HTTP router written in Go.
 - [goblin](https://github.com/bmf-san/goblin) - A golang http router based on trie tree.
 - [gocraft/web](https://github.com/gocraft/web) - Mux and middleware package in Go.


### PR DESCRIPTION
**Project Name:** fursy
**Project URL:** https://github.com/coregx/fursy
**Project Desc:** HTTP router with type-safe generic handlers, automatic OpenAPI 3.1 generation from code, and RFC 9457 error responses.

**Check links:**
- Forge link: https://github.com/coregx/fursy
- pkg.go.dev: https://pkg.go.dev/github.com/coregx/fursy
- goreportcard.com: https://goreportcard.com/report/github.com/coregx/fursy
- Coverage service (Codecov): https://app.codecov.io/gh/coregx/fursy

**Checklist:**
- [x] Has go.mod file
- [x] Has at least one tagged release (v0.3.4)
- [x] English README with full documentation
- [x] Available on pkg.go.dev
- [x] Go Report Card grade A+
- [x] Coverage service badge (Codecov, 91%)
- [x] CI with GitHub Actions
- [x] Open-source license (MIT)

**Additional Info:**
- First Go router with generics-based `Box[Req, Res]` type-safe handlers — compile-time request/response type safety without code generation
- Automatic OpenAPI 3.1 spec generation directly from Go types — no annotations, no separate spec files
- Native RFC 9457 Problem Details for standardized HTTP error responses
- 8 production-ready middleware (Logger, CORS, JWT, RateLimit, Security, Recovery, CircuitBreaker, RequestID)
- Core routing: zero external dependencies (stdlib only)
- Part of the [coregx](https://github.com/coregx) ecosystem (coregex, signals, relica, stream)
