### PR TITLE
Add pending to Job Scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1531,6 +1531,7 @@ _Libraries for scheduling jobs._
 - [gronx](https://github.com/adhocore/gronx) - Cron expression parser, task runner and daemon consuming crontab like task list.
 - [JobRunner](https://github.com/bamzi/jobrunner) - Smart and featureful cron job scheduler with job queuing and live monitoring built in.
 - [leprechaun](https://github.com/kilgaloon/leprechaun) - Job scheduler that supports webhooks, crons and classic scheduling.
+- [pending](https://github.com/kahoon/pending) - ID-based debounced task scheduler for deferred tasks with cancellation, graceful shutdown, and optional concurrency limits.
 - [sched](https://github.com/romshark/sched) - A job scheduler with the ability to fast-forward time.
 - [scheduler](https://github.com/carlescere/scheduler) - Cronjobs scheduling made easy.
 - [tasks](https://github.com/madflojo/tasks) - An easy to use in-process scheduler for recurring tasks in Go.


### PR DESCRIPTION
Adds one item under Job Scheduler (alphabetical order):

- [pending](https://github.com/kahoon/pending) - ID-based debounced task scheduler for deferred tasks with cancellation, graceful shutdown, and optional concurrency limits.

Forge link: https://github.com/kahoon/pending
pkg.go.dev: https://pkg.go.dev/github.com/kahoon/pending
goreportcard.com: https://goreportcard.com/report/github.com/kahoon/pending
Coverage: https://app.codecov.io/gh/kahoon/pending