### PR TITLE
Add hotplex - AI Agent Runtime Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ _Libraries for building programs that leverage AI._
 
 - [chromem-go](https://github.com/philippgille/chromem-go) - Embeddable vector database for Go with Chroma-like interface and zero third-party dependencies. In-memory with optional persistence.
 - [fun](https://gitlab.com/tozd/go/fun) - The simplest but powerful way to use large language models (LLMs) in Go.
-- [hotplex](https://github.com/hrygo/hotplex) - AI Agent runtime engine providing long-lived sessions for Claude Code, OpenCode and other CLI AI tools. Provides full-duplex streaming, multi-platform integrations (Slack, Feishu, Telegram, Discord), and secure sandbox.
+- [hotplex](https://github.com/hrygo/hotplex) - AI Agent runtime engine with long-lived sessions for Claude Code, OpenCode, pi-mono and other CLI AI tools. Provides full-duplex streaming, multi-platform integrations, and secure sandbox.
 - [langchaingo](https://github.com/tmc/langchaingo) - LangChainGo is a framework for developing applications powered by language models.
 - [langgraphgo](https://github.com/smallnest/langgraphgo) - A Go library for building stateful, multi-actor applications with LLMs, built on the concept of LangGraph，with a lot of builtin Agent architectures.
 - [LocalAI](https://github.com/mudler/LocalAI) - Open Source OpenAI alternative, self-host AI models.


### PR DESCRIPTION
Forge link: https://github.com/hrygo/hotplex
pkg.go.dev: https://pkg.go.dev/github.com/hrygo/hotplex
goreportcard.com: https://goreportcard.com/report/github.com/hrygo/hotplex

hotplex is an AI Agent runtime engine with long-lived sessions for Claude Code, OpenCode, pi-mono and other CLI AI tools.