### PR TITLE
Add tmux-manager to Other Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -3492,6 +3492,7 @@ _Software written in Go._
 - [syncthing](https://syncthing.net/) - Open, decentralized file synchronization tool and protocol.
 - [tcpdog](https://github.com/mehrdadrad/tcpdog) - eBPF based TCP observability.
 - [tinycare-tui](https://github.com/DMcP89/tinycare-tui) - Small terminal app that shows git commits from the last 24 hours and week, current weather, some self care advice, a joke, and you current todo list tasks.
+- [tmux-manager](https://github.com/charlie0077/tmux-manager) - A TUI for managing tmux sessions across multiple remote servers via SSH, with live session counts and YAML config.
 - [toxiproxy](https://github.com/shopify/toxiproxy) - Proxy to simulate network and system conditions for automated tests.
 - [tsuru](https://tsuru.io/) - Extensible and open source Platform as a Service software.
 - [vaku](https://github.com/lingrino/vaku) - CLI & API for folder-based functions in Vault like copy, move, and search.


### PR DESCRIPTION
## Summary

Add [tmux-manager](https://github.com/charlie0077/tmux-manager) to the **Other Software** section.

tmux-manager is a TUI for managing tmux sessions across multiple remote servers via SSH. It is built with Go and [Bubbletea](https://github.com/charmbracelet/bubbletea), and features live session counts and YAML-based configuration.

- **Entry added:** `Other Software` section, in alphabetical order (between `tinycare-tui` and `toxiproxy`)
- **Format:** Matches existing list entry format exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)