### PR TITLE
Add BurnRate - AI coding cost analytics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -2783,6 +2783,7 @@ _General utilities and tools to make your life easier._
 - [bleep](https://github.com/sinhashubham95/bleep) - Perform any number of actions on any set of OS signals in Go.
 - [boilr](https://github.com/tmrts/boilr) - Blazingly fast CLI tool for creating projects from boilerplate templates.
 - [boring](https://github.com/alebeck/boring) - Simple command-line SSH tunnel manager.
+- [burnrate](https://github.com/burnrate-dev/burnrate) - Multi-provider AI coding cost analytics CLI tracking usage across Claude Code, Cursor, Copilot, Windsurf, Aider, Cline, and Codex.
 - [changie](https://github.com/miniscruff/changie) - Automated changelog tool for preparing releases with lots of customization options.
 - [chyle](https://github.com/antham/chyle) - Changelog generator using a git repository with multiple configuration possibilities.
 - [circuit](https://github.com/cep21/circuit) - An efficient and feature complete Hystrix like Go implementation of the circuit breaker pattern.


### PR DESCRIPTION
## What is BurnRate?

[BurnRate](https://getburnrate.io) is a local-first CLI tool that tracks AI coding tool usage and costs across 7 providers: Claude Code, Cursor, GitHub Copilot, Windsurf, Aider, Cline, and OpenAI Codex.

**Key features:**
- Real-time cost analytics dashboard
- 46 optimization rules to reduce spending
- Rate limit monitoring
- Team budgets and alerts
- PDF report generation
- Written in Go, single binary, no dependencies

Forge link: https://github.com/burnrate-dev/burnrate
pkg.go.dev: https://pkg.go.dev/github.com/burnrate-dev/burnrate
goreportcard.com: https://goreportcard.com/report/github.com/burnrate-dev/burnrate