### PR TITLE
Add deheap to Queues; fix Routers alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ additional ordered map implementations.
 
 ### Queues
 
+- [deheap](https://github.com/aalpar/deheap) - Doubly-ended heap (min-max heap) with O(log n) access to both minimum and maximum elements.
 - [deque](https://github.com/edwingeng/deque) - A highly optimized double-ended queue.
 - [deque](https://github.com/gammazero/deque) - Fast ring-buffer deque (double-ended queue).
 - [dqueue](https://github.com/vodolaz095/dqueue) - Simple, in memory, zero dependency and battle tested, thread-safe deferred queue.


### PR DESCRIPTION
Forge link: https://github.com/aalpar/deheap
pkg.go.dev: https://pkg.go.dev/github.com/aalpar/deheap
goreportcard.com: https://goreportcard.com/report/github.com/aalpar/deheap
Coverage: https://app.codecov.io/gh/aalpar/deheap

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/QUALITY_STANDARD.md)

---

**Commit 1 — Add deheap to Queues**

Adds [deheap](https://github.com/aalpar/deheap), a doubly-ended heap (min-max heap) for Go, to the **Queues** section under Data Structures and Algorithms.

deheap provides O(log n) Push, Pop, PopMax, and Remove using a single flat slice — no pointers, no auxiliary arrays. It ships two API surfaces: a generic `Deheap[T]` for `cmp.Ordered` types (Go 1.21+) and the original `heap.Interface`-based API. Zero external dependencies.

- **Go Report Card:** A+
- **Test coverage:** 97.2% (54 test functions including fuzz targets)
- **First commit:** April 2019, actively maintained
- **Releases:** v1.0.0 – v1.1.2
- **CI:** GitHub Actions across Go 1.21, 1.22, 1.23

**Commit 2 — Fix Routers alphabetical order**

Swaps `FastRouter` and `fursy` in the **Routers** section to restore alphabetical order. This fixes the pre-existing `TestAlpha/Routers` failure on `main`.