### PR TITLE
Fix Pwn Request vulnerability in pr-quality-check workflow

### DIFF
--- a/.github/workflows/pr-quality-check.yaml
+++ b/.github/workflows/pr-quality-check.yaml
@@ -1,7 +1,7 @@
 name: PR Quality Checks
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
Fixes #6077. The workflow used pull_request_target which grants fork PRs access to secrets and write permissions, enabling the classic Pwn Request attack. This was exploited by the hackerbot-claw bot which achieved remote code execution and exfiltrated the GITHUB_TOKEN.

Changed from pull_request_target to pull_request. With pull_request, fork PRs no longer have access to secrets or write permissions, preventing the Pwn Request attack. The quality checks will still function correctly as the scripts are checked out from the base branch via pull_request.base.sha.