### PR TITLE
Add ribbonGo to Bloom and Cuckoo Filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ _Frameworks for performing ELT / ETL_
 - [boomfilters](https://github.com/tylertreat/BoomFilters) - Probabilistic data structures for processing continuous, unbounded streams.
 - [cuckoo-filter](https://github.com/linvon/cuckoo-filter) - Cuckoo filter: a comprehensive cuckoo filter, which is configurable and space optimized compared with other implements, and all features mentioned in original paper are available.
 - [cuckoofilter](https://github.com/seiflotfy/cuckoofilter) - Cuckoo filter: a good alternative to a counting bloom filter implemented in Go.
+- [ribbonGo](https://github.com/RibbonGo/ribbonGo) - First pure Go implementation of Ribbon filters (practically smaller than Bloom and Xor) for space-efficient approximate set membership queries.
 - [ring](https://github.com/TheTannerRyan/ring) - Go implementation of a high performance, thread safe bloom filter.
 
 ### Data Structure and Algorithm Collections


### PR DESCRIPTION
Add ribbonGo (https://github.com/RibbonGo/ribbonGo) - first pure Go implementation of Ribbon filters for space-efficient approximate set membership queries.

## Required links

_Provide the links below. Our CI will automatically validate them._

- [X] Forge link (github.com, gitlab.com, etc): https://github.com/RibbonGo/ribbonGo
- [x] pkg.go.dev: https://pkg.go.dev/github.com/RibbonGo/ribbonGo
- [x] goreportcard.com: https://goreportcard.com/report/github.com/RibbonGo/ribbonGo
- [x] Coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://coveralls.io/github/DhruvilK7/ribbonGo?branch=main

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

_These are validated automatically by CI:_

- [ ] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`).
- [ ] The repo has an open source license.
- [ ] The repo documentation has a pkg.go.dev link.
- [ ] The repo documentation has a goreportcard link (grade A- or better).
- [ ] The repo documentation has a coverage service link.

_These are recommended and reported as warnings:_

- [x] The repo has a continuous integration process (GitHub Actions, etc.).
- [x] CI runs tests that must pass before merging.

## Pull Request content

_These are validated automatically by CI:_

- [ ] This PR adds/removes/changes **only one** package.
- [ ] The package has been added in **alphabetical order**.
- [ ] The link text is the **exact project name**.
- [ ] The description is clear, concise, non-promotional, and **ends with a period**.
- [ ] The link in README.md matches the forge link above.

## Category quality

_Note: new categories require a minimum of 3 packages._

Packages added a long time ago might not meet the current guidelines anymore. It would be very helpful if you could check 3-5 packages above and below your submission to ensure they still meet the Quality Standards.

Please delete one of the following lines:

- [x] The packages around my addition still meet the Quality Standards.

Thanks for your PR, you're awesome! :sunglasses:
