### PR TITLE
Add onWatch to Other Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -3478,6 +3478,7 @@ _Software written in Go._
 - [naclpipe](https://github.com/unix4fun/naclpipe) - Simple NaCL EC25519 based crypto pipe tool written in Go.
 - [Neo-cowsay](https://github.com/Code-Hex/Neo-cowsay) - 🐮 cowsay is reborn. for a New Era.
 - [nes](https://github.com/fogleman/nes) - Nintendo Entertainment System (NES) emulator written in Go.
+- [onWatch](https://github.com/onllm-dev/onWatch) - Monitor AI API quotas across providers locally with historical tracking, alerts, and a web dashboard to avoid surprise throttling and budget overruns.
 - [Orbit](https://github.com/gulien/orbit) - A simple tool for running commands and generating files from templates.
 - [peg](https://github.com/pointlander/peg) - Peg, Parsing Expression Grammar, is an implementation of a Packrat parser generator.
 - [Plik](https://github.com/root-gg/plik) - Plik is a temporary file upload system (Wetransfer like) in Go.


### PR DESCRIPTION
## Required links

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/onllm-dev/onWatch
- [x] pkg.go.dev: https://pkg.go.dev/github.com/onllm-dev/onwatch/v2
- [x] goreportcard.com: https://goreportcard.com/report/github.com/onllm-dev/onwatch/v2
- [x] Coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://app.codecov.io/gh/onllm-dev/onwatch

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

_These are validated automatically by CI:_

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`).
- [x] The repo has an open source license.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link (grade A- or better).
- [x] The repo documentation has a coverage service link.

_These are recommended and reported as warnings:_

- [x] The repo has a continuous integration process (GitHub Actions, etc.).
- [x] CI runs tests that must pass before merging.

## Pull Request content

_These are validated automatically by CI:_

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**.
- [x] The link text is the **exact project name**.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

_Note: new categories require a minimum of 3 packages._

Please delete one of the following lines:

- [ ] The packages around my addition still meet the Quality Standards.
- [ ] I removed the following packages around my addition: (please give a short reason for each removal)

## Notes

- Proposed category: `Software Packages > Other Software`
- Proposed entry:

```md
- [onWatch](https://github.com/onllm-dev/onWatch) - Monitor AI API quotas across multiple providers locally with historical tracking, alerts, and a web dashboard to avoid surprise throttling and budget overruns.
```

- Current module path: `github.com/onllm-dev/onwatch/v2`
- Latest release: `v2.11.17`
- Go Report Card: `A+`
- Local overall coverage from `go test ./... -coverprofile=coverage.out`: `90.0%`
