### PR TITLE
Add ReleaseRun Go Module Health checker to Package Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -2181,6 +2181,7 @@ _Unofficial libraries for package and dependency management._
 
 - [gup](https://github.com/nao1215/gup) - Update binaries installed by "go install".
 - [modup](https://github.com/chaindead/modup) - Terminal UI for Go dependency updates with outdated module detection and selective upgrading.
+- [ReleaseRun Go Module Health](https://releaserun.com/tools/gomod-health/) - A web-based tool to analyze go.mod files for outdated dependencies, archived modules, and unmaintained packages.
 - [syft](https://github.com/anchore/syft) - A CLI tool and Go library for generating a Software Bill of Materials (SBOM) from container images and filesystems.
 
 **[⬆ back to top](#contents)**


### PR DESCRIPTION
## What does this add?

Adds [ReleaseRun Go Module Health](https://releaserun.com/tools/gomod-health/) — a free web-based tool for analyzing `go.mod` files.

Paste your go.mod and instantly see:
- Outdated dependencies (with current vs latest version)
- Archived/abandoned modules
- Unmaintained packages (no activity in 2+ years)
- Dependency count and health score

## Why it fits the list

Fits in the _Unofficial libraries for package and dependency management_ section alongside similar tools like `modup`. It is a free, no-signup tool specifically built for Go developers to audit their module dependencies without running `go list -m -u`.

**Link:** https://releaserun.com/tools/gomod-health/

### Checklist
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md)
- [x] I have an appropriate description of what the entry is and what it does
- [x] I have added the entry to the correct section
- [x] The link is working