### PR TITLE
Add coinpaprika-api-go-client to Financial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1195,7 +1195,7 @@ _Packages for accounting and finance._
 - [go-finance](https://github.com/alpeb/go-finance) - Library of financial functions for time value of money (annuities), cash flow, interest rate conversions, bonds and depreciation calculations.
 - [go-finance](https://github.com/pieterclaerhout/go-finance) - Module to fetch exchange rates, check VAT numbers via VIES and check IBAN bank account numbers.
 - [go-money](https://github.com/rhymond/go-money) - Implementation of Fowler's Money pattern.
-- [go-coinpaprika](https://github.com/coinpaprika/coinpaprika-api-go-client) - Go client for the CoinPaprika cryptocurrency market data API.
+- [coinpaprika-api-go-client](https://github.com/coinpaprika/coinpaprika-api-go-client) - Go client for the CoinPaprika cryptocurrency market data API.
 - [go-nowpayments](https://github.com/matm/go-nowpayments) - Library for the crypto NOWPayments API.
 - [gobl](https://github.com/invopop/gobl) - Invoice and billing document framework. JSON Schema based. Automates tax calculations and validation, with tooling to convert into global formats.
 - [ledger](https://github.com/formancehq/ledger) - A programmable financial ledger that provides a foundation for money-moving applications.


### PR DESCRIPTION
Forge link: https://github.com/coinpaprika/coinpaprika-api-go-client
pkg.go.dev: https://pkg.go.dev/github.com/coinpaprika/coinpaprika-api-go-client/v2
goreportcard.com: https://goreportcard.com/report/github.com/coinpaprika/coinpaprika-api-go-client

Adds [coinpaprika-api-go-client](https://github.com/coinpaprika/coinpaprika-api-go-client) — a Go client for the CoinPaprika cryptocurrency market data API.

- Access prices, tickers, exchanges, OHLCV, contracts, and market data for 12,000+ coins
- No API key required for free tier
- Go Report Card: A+
- MIT licensed
- Latest release: v2.5.0