### PR TITLE
Add stto to Code Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2506,7 +2506,6 @@ _Libraries for testing codebases and generating test data._
 - [testfixtures](https://github.com/go-testfixtures/testfixtures) - A helper for Rails' like test fixtures to test database applications.
 - [Testify](https://github.com/stretchr/testify) - Sacred extension to the standard go testing package.
 - [testsql](https://github.com/zhulongcheng/testsql) - Generate test data from SQL files before testing and clear it after finished.
-- [tparse](https://github.com/mfridman/tparse) - CLI tool for summarizing go test output. Pipe friendly. Compatible with go test flags.
 - [testza](https://github.com/MarvinJWendt/testza) - Full-featured test framework with nice colorized output.
 - [trial](https://github.com/jgroeneveld/trial) - Quick and easy extendable assertions without introducing much boilerplate.
 - [Tt](https://github.com/vcaesar/tt) - Simple and colorful test tools.


### PR DESCRIPTION
Added `stto` to the Code Analysis section. 

`stto` is a light-weight and fast line of code counter written in pure Go. This project was suggested for inclusion in issue #5563.

Forge link: https://github.com/mainak55512/stto
pkg.go.dev: https://pkg.go.dev/github.com/mainak55512/stto
goreportcard.com: https://goreportcard.com/report/github.com/mainak55512/stto