### PR TITLE
Add Den to DevOps Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -3364,6 +3364,7 @@ _Software written in Go._
 - [colima](https://github.com/abiosoft/colima) - Container runtimes on macOS (and Linux) with minimal setup.
 - [Ddosify](https://github.com/ddosify/ddosify) - High-performance load testing tool, written in Golang.
 - [decompose](https://github.com/s0rg/decompose) - tool to generate and process Docker containers connections graphs.
+- [Den](https://github.com/us/den) - Self-hosted sandbox runtime for AI agents with isolated Docker containers, REST API, WebSocket streaming, MCP server, and snapshot/restore.
 - [DepCharge](https://github.com/centerorbit/depcharge) - Helps orchestrating the execution of commands across the many dependencies in larger projects.
 - [dish](https://github.com/thevxn/dish) - A lightweight, remotely configurable monitoring service.
 - [Docker](https://www.docker.com/) - Open platform for distributed applications for developers and sysadmins.


### PR DESCRIPTION
Add [Den](https://github.com/us/den) — self-hosted sandbox runtime for AI agents.

- Isolated Docker containers with REST API and WebSocket streaming
- MCP server, snapshot/restore, Go+TypeScript+Python SDKs
- Written in Go, AGPL-3.0 license