### PR TITLE
Add Den to DevOps Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -3364,6 +3364,7 @@ _Software written in Go._
 - [colima](https://github.com/abiosoft/colima) - Container runtimes on macOS (and Linux) with minimal setup.
 - [Ddosify](https://github.com/ddosify/ddosify) - High-performance load testing tool, written in Golang.
 - [decompose](https://github.com/s0rg/decompose) - tool to generate and process Docker containers connections graphs.
+- [Den](https://github.com/us/den) - Self-hosted sandbox runtime for AI agents. Open-source E2B alternative.
 - [DepCharge](https://github.com/centerorbit/depcharge) - Helps orchestrating the execution of commands across the many dependencies in larger projects.
 - [dish](https://github.com/thevxn/dish) - A lightweight, remotely configurable monitoring service.
 - [Docker](https://www.docker.com/) - Open platform for distributed applications for developers and sysadmins.


### PR DESCRIPTION
Forge link: https://github.com/us/den
pkg.go.dev: https://pkg.go.dev/github.com/us/den
goreportcard.com: https://goreportcard.com/report/github.com/us/den

[Den](https://github.com/us/den) — Self-hosted sandbox runtime for AI agents. Open-source E2B alternative. Isolated Docker containers, REST API, MCP server, snapshot/restore. Written in Go, licensed under AGPL-3.0.