### PR TITLE
Add datatrax to Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1681,6 +1681,7 @@ _Libraries for Machine Learning._
 - [born](https://github.com/born-ml/born) - Deep learning framework inspired by Burn (Rust), with autograd, type-safe tensors, and zero-CGO GPU acceleration.
 - [catboost-cgo](https://github.com/mirecl/catboost-cgo) - Fast, scalable, high performance Gradient Boosting on Decision Trees library. Golang using Cgo for blazing fast inference CatBoost Model.
 - [CloudForest](https://github.com/ryanbressler/CloudForest) - Fast, flexible, multi-threaded ensembles of decision trees for machine learning in pure Go.
+- [datatrax](https://github.com/rbmuller/datatrax) - Data engineering and classic ML toolkit with batch processing, type coercion, and 7 algorithms in pure Go with zero dependencies.
 - [ddt](https://github.com/sgrodriguez/ddt) - Dynamic decision tree, create trees defining customizable rules.
 - [eaopt](https://github.com/MaxHalford/eaopt) - An evolutionary optimization library.
 - [evoli](https://github.com/khezen/evoli) - Genetic Algorithm and Particle Swarm Optimization library.


### PR DESCRIPTION
## Add [datatrax](https://github.com/rbmuller/datatrax) to Machine Learning

**datatrax** — Data engineering and classic ML toolkit for Go with zero external dependencies.

Forge link: https://github.com/rbmuller/datatrax
pkg.go.dev: https://pkg.go.dev/github.com/rbmuller/datatrax
goreportcard.com: https://goreportcard.com/report/github.com/rbmuller/datatrax
Coverage: https://github.com/rbmuller/datatrax/actions

### What it includes
- 8 utility packages (batch processing, type coercion, deduplication, date utilities, string utils, map utils, error utils, math utils)
- 7 classic ML algorithms (Linear/Logistic Regression, KNN, K-Means, Decision Tree, Gaussian/Multinomial Naive Bayes)
- Preprocessing, encoding, metrics, cross-validation
- Pure Go stdlib — zero external dependencies
- Generics-first, Go 1.21+
- Test coverage 90-100% across all packages
- Go Report Card: A+

### Checklist
- [x] 5+ months of commit history (since Nov 2023)
- [x] Valid open source license (MIT)
- [x] Contains go.mod
- [x] Semantic version release (v1.1.0)
- [x] Actively maintained
- [x] English documentation
- [x] Test coverage 90%+
- [x] Go Report Card A+
- [x] Alphabetical ordering respected
- [x] Concise, non-promotional description ending with period