### PR TITLE
Add ReleaseRun Go module health checker to DevOps Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -3355,6 +3355,7 @@ _Software written in Go._
 ### DevOps Tools
 
 - [abbreviate](https://github.com/dnnrly/abbreviate) - abbreviate is a tool turning long strings in to shorter ones with configurable separators, for example to embed branch names in to deployment stack IDs.
+- [ReleaseRun Go Module Health](https://releaserun.com/tools/gomod-health/) - Browser-based go.mod health checker. Scan Go module dependencies for EOL versions and known CVEs — no install or CLI required.
 - [alaz](https://github.com/ddosify/alaz) - Effortless, Low-Overhead, eBPF-based Kubernetes Monitoring.
 - [aptly](https://github.com/aptly-dev/aptly) - aptly is a Debian repository management tool.
 - [aurora](https://github.com/xuri/aurora) - Cross-platform web-based Beanstalkd queue server console.


### PR DESCRIPTION
ReleaseRun's Go module health checker lets developers scan their `go.mod` dependencies for end-of-life versions and known CVEs via browser — no install needed.

https://releaserun.com/tools/gomod-health/