### PR TITLE
Add localaik - local Gemini and OpenAI API compatibility proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ _Libraries for building programs that leverage AI._
 - [langchaingo](https://github.com/tmc/langchaingo) - LangChainGo is a framework for developing applications powered by language models.
 - [langgraphgo](https://github.com/smallnest/langgraphgo) - A Go library for building stateful, multi-actor applications with LLMs, built on the concept of LangGraph，with a lot of builtin Agent architectures.
 - [LocalAI](https://github.com/mudler/LocalAI) - Open Source OpenAI alternative, self-host AI models.
+- [localaik](https://github.com/harshaneel/localaik) - Local compatibility proxy for the Gemini and OpenAI APIs. Run one container locally and test both SDK protocol shapes on the same port without API keys or network access.
 - [Ollama](https://github.com/jmorganca/ollama) - Run large language models locally.
 - [OllamaFarm](https://github.com/presbrey/ollamafarm) - Manage, load-balance, and failover packs of Ollamas.
 - [otellix](https://github.com/oluwajubelo1/otellix) - OpenTelemetry-native LLM observability and budget guardrails for cost-constrained production environments.


### PR DESCRIPTION
**Please provide package links to:**
- Forge link: https://github.com/harshaneel/localaik
- pkg.go.dev: https://pkg.go.dev/github.com/harshaneel/localaik
- goreportcard.com: https://goreportcard.com/report/github.com/harshaneel/localaik
- Coverage: https://github.com/harshaneel/localaik/actions/workflows/release.yml
- Docker Hub: https://hub.docker.com/r/gokhalh/localaik

**Description:**

localaik is a local compatibility proxy for the Gemini and OpenAI APIs. Run one container locally and test both SDK protocol shapes on the same port without API keys or network access.

Running integration tests for AI SDK code requires API keys set up in every environment, including CI workflows. localaik solves this with a single `docker run` — it translates both Gemini (`/v1beta/models/{model}:generateContent`) and OpenAI (`/v1/chat/completions`) protocols to the same upstream llama.cpp server running Gemma 3.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added pkg.go.dev link to the repo and to my pull request.
- [x] I have read Contribution guidelines, maintainers note and Quality standard.