### PR TITLE
Add boa to Standard CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ _Libraries for building standard or basic Command Line applications._
 - [acmd](https://github.com/cristalhq/acmd) - Simple, useful, and opinionated CLI package in Go.
 - [argparse](https://github.com/akamensky/argparse) - Command line argument parser inspired by Python's argparse module.
 - [argv](https://github.com/cosiner/argv) - Go library to split command line string as arguments array using the bash syntax.
+- [boa](https://github.com/GiGurra/boa) - Declarative flags, env vars, validation, and config files from struct tags. Built on cobra.
 - [carapace](https://github.com/rsteube/carapace) - Command argument completion generator for spf13/cobra.
 - [carapace-bin](https://github.com/rsteube/carapace-bin) - Multi-shell multi-command argument completer.
 - [carapace-spec](https://github.com/rsteube/carapace-spec) - Define simple completions using a spec file.


### PR DESCRIPTION
This PR was created together by [@GiGurra](https://github.com/GiGurra) and [Claude Code](https://claude.com/claude-code) (Anthropic's AI coding assistant). We built boa together and are submitting it here as co-authors.

## What is boa?

Like if [alecthomas/kong](https://github.com/alecthomas/kong) and [urfave/cli](https://github.com/urfave/cli) had a baby and made it [cobra](https://github.com/spf13/cobra) compatible.

[boa](https://github.com/GiGurra/boa) lets you declaratively define CLI flags, env vars, validation, and config file loading using Go struct tags — all built on top of cobra with full interop.

```go
type Params struct {
    Name string `descr:"your name"`
    Port int    `descr:"port number" default:"8080" optional:"true"`
}
```

This generates flags, short flags, defaults, required/optional markers, descriptions, and help text automatically.

## Links

Forge link: https://github.com/GiGurra/boa
pkg.go.dev: https://pkg.go.dev/github.com/GiGurra/boa
goreportcard.com: https://goreportcard.com/report/github.com/GiGurra/boa

## Quality

- **Go Report Card**: A+
- **Test coverage**: 90.7%
- **License**: MIT
- **First commit**: October 2023
- **Latest release**: v1.0.9+
- **CI**: golangci-lint + tests on every push/PR