### PR TITLE
Add fibersse — Production SSE for Fiber v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2068,6 +2068,7 @@ _Libraries for working with various layers of the network._
 - [go-pcaplite](https://github.com/alexcfv/go-pcaplite) - Lightweight live packet capture library with HTTPS SNI extraction.
 - [go-powerdns](https://github.com/joeig/go-powerdns) - PowerDNS API bindings for Golang.
 - [go-sse](https://github.com/lampctl/go-sse) - Go client and server implementation of HTML server-sent events.
+- [fibersse](https://github.com/vinod-morya/fibersse) - Production-grade Server-Sent Events (SSE) for Fiber v3 with event coalescing, priority lanes, topic wildcards, adaptive throttling, and built-in auth.
 - [go-stun](https://github.com/ccding/go-stun) - Go implementation of the STUN client (RFC 3489 and RFC 5389).
 - [gobgp](https://github.com/osrg/gobgp) - BGP implemented in the Go Programming Language.
 - [gopacket](https://github.com/google/gopacket) - Go library for packet processing with libpcap bindings.


### PR DESCRIPTION
## What is fibersse?

[fibersse](https://github.com/vinod-morya/fibersse) is a production-grade Server-Sent Events library built natively for [Fiber v3](https://github.com/gofiber/fiber) (fasthttp).

Forge link: https://github.com/vinod-morya/fibersse
pkg.go.dev: https://pkg.go.dev/github.com/vinod-morya/fibersse
goreportcard.com: https://goreportcard.com/report/github.com/vinod-morya/fibersse

## Features

- Hub pattern with event coalescing (last-writer-wins)
- 3 priority lanes (Instant/Batched/Coalesced)
- NATS-style topic wildcards
- Adaptive per-connection throttling
- Built-in JWT + ticket auth helpers
- Prometheus metrics endpoint
- Graceful Kubernetes-style drain
- Last-Event-ID replay, Event TTL, backpressure handling
- Cache invalidation signals (Invalidate, DomainEvent, BatchDomainEvents)
- Zero external dependencies beyond Fiber v3
- MIT License, 39 tests, 42 benchmarks

## Links

- **GitHub**: https://github.com/vinod-morya/fibersse
- **Go Docs**: https://pkg.go.dev/github.com/vinod-morya/fibersse
- **Go Report**: https://goreportcard.com/report/github.com/vinod-morya/fibersse
- **npm (React SDK)**: https://www.npmjs.com/package/fibersse-react