### PR TITLE
Add go-apispec to Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1304,6 +1304,7 @@ _Tools that generate Go code._
 - [generis](https://github.com/senselogic/GENERIS) - Code generation tool providing generics, free-form macros, conditional compilation and HTML templating.
 - [go-enum](https://github.com/abice/go-enum) - Code generation for enums from code comments.
 - [go-enum-encoding](https://github.com/nikolaydubina/go-enum-encoding) - Code generation for enum encoding from code comments.
+- [go-apispec](https://github.com/antst/go-apispec) - Generate OpenAPI 3.1 specs from Go source code via static analysis with automatic framework detection.
 - [go-linq](https://github.com/ahmetalpbalkan/go-linq) - .NET LINQ-like query methods for Go.
 - [goderive](https://github.com/awalterschulze/goderive) - Derives functions from input types
 - [goverter](https://github.com/jmattheis/goverter) - Generate converters by defining an interface.


### PR DESCRIPTION
Forge link: https://github.com/antst/go-apispec
pkg.go.dev: https://pkg.go.dev/github.com/antst/go-apispec
goreportcard.com: https://goreportcard.com/report/github.com/antst/go-apispec
Coverage: 84.5% (badge in README)

**go-apispec** generates OpenAPI 3.1 specs from Go source code via static analysis — zero annotations required. It auto-detects frameworks (Chi, Gin, Echo, Fiber, Gorilla Mux, net/http), follows the call graph from routes to handlers, and infers request/response types from real code. Supports generic structs, interface resolution, conditional routing via CFG analysis, and multi-framework projects.