### PR TITLE
Add indicator to Financial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1213,6 +1213,7 @@ _Packages for accounting and finance._
 - [coinpaprika-api-go-client](https://github.com/coinpaprika/coinpaprika-api-go-client) - Go client for the CoinPaprika cryptocurrency market data API.
 - [go-nowpayments](https://github.com/matm/go-nowpayments) - Library for the crypto NOWPayments API.
 - [gobl](https://github.com/invopop/gobl) - Invoice and billing document framework. JSON Schema based. Automates tax calculations and validation, with tooling to convert into global formats.
+- [indicator](https://github.com/cinar/indicator) - Technical analysis library providing financial indicators, strategies, and backtesting framework.
 - [ledger](https://github.com/formancehq/ledger) - A programmable financial ledger that provides a foundation for money-moving applications.
 - [money](https://github.com/govalues/money) - Immutable monetary amounts and exchange rates with panic-free arithmetic.
 - [ofxgo](https://github.com/aclindsa/ofxgo) - Query OFX servers and/or parse the responses (with example command-line client).


### PR DESCRIPTION
## Summary
- Add [indicator](https://github.com/cinar/indicator) to the Financial category in README.md

## Quality Links
Forge link: https://github.com/cinar/indicator
pkg.go.dev: https://pkg.go.dev/github.com/cinar/indicator/v2
goreportcard.com: https://goreportcard.com/report/github.com/cinar/indicator/v2
Coverage: https://codecov.io/gh/cinar/indicator