### PR TITLE
Add minisql to Databases Implemented in Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,7 +794,8 @@ _Data stores with expiring records, in-memory distributed data stores, or in-mem
 - [unitdb](https://github.com/unit-io/unitdb) - Fast timeseries database for IoT, realtime messaging applications. Access unitdb with pubsub over tcp or websocket using github.com/unit-io/unitd application.
 - [Vasto](https://github.com/chrislusf/vasto) - A distributed high-performance key-value store. On Disk. Eventual consistent. HA. Able to grow or shrink without service interruption.
 - [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics) - fast, resource-effective and scalable open source time series database. May be used as long-term remote storage for Prometheus. Supports PromQL.
-
+- [minisql](https://github.com/RichardKnop/minisql) - Embedded single file SQL database.
+- 
 ### Database Schema Migration
 
 - [atlas](https://github.com/ariga/atlas) - A Database Toolkit. A CLI designed to help companies better work with their data.


### PR DESCRIPTION
## What is minisql?

[MiniSQL](https://github.com/RichardKnop/minisql) is an embedded single file database written in Golang, inspired by SQLite (however borrowing some features from other databases as well, mainly PostgreSQL).

## Links

Forge link: https://github.com/RichardKnop/minisql
pkg.go.dev: https://pkg.go.dev/github.com/RichardKnop/minisql
goreportcard.com: https://goreportcard.com/report/github.com/RichardKnop/minisql

## Quality

- **Go Report Card**: A+
- **Test coverage**: 72%
- **License**: Apache
- **First commit**: September 2024
- **Latest release**: v0.1.0
- **CI**: golangci-lint + tests on every push/PR