### PR TITLE
feat: add infergo — Go-native LLM inference without Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1719,6 +1719,7 @@ _Libraries for Machine Learning._
 - [goscore](https://github.com/asafschers/goscore) - Go Scoring API for PMML.
 - [gosseract](https://github.com/otiai10/gosseract) - Go package for OCR (Optical Character Recognition), by using Tesseract C++ library.
 - [hugot](https://github.com/knights-analytics/hugot) - Huggingface transformer pipelines for golang with onnxruntime.
+- [infergo](https://github.com/ailakshya/infergo) - Go-native LLM, embedding, and object detection inference via llama.cpp and ONNX Runtime. OpenAI-compatible HTTP API, continuous batching, Prometheus metrics, Kubernetes-ready.
 - [libsvm](https://github.com/datastream/libsvm) - libsvm golang version derived work based on LIBSVM 3.14.
 - [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native Go code with zero dependencies, written in Python with Go language support.
 - [neural-go](https://github.com/schuyler/neural-go) - Multilayer perceptron network implemented in Go, with training via backpropagation.


### PR DESCRIPTION
## Package

**[infergo](https://github.com/ailakshya/infergo)** — Go-native LLM, embedding, and object detection inference via llama.cpp and ONNX Runtime.

## Why it belongs in Awesome Go

- Zero Python dependency — `go get github.com/ailakshya/infergo/client` is the full install
- OpenAI-compatible HTTP API (`/v1/chat/completions`, `/v1/embeddings`, `/v1/detect`)
- Continuous batching scheduler: serves 32 concurrent users with 1 model copy in VRAM (vs Python's 1 process per user)
- Prometheus metrics, Kubernetes health probes, KEDA autoscaling support built-in
- 1.56 GB Docker image vs 10+ GB for Python equivalents
- 250/250 C++ gtests + Go test suite with race detector

## Checklist

- [x] Package is tested
- [x] Package has documentation  
- [x] Package is not a duplicate