### PR TITLE
Add racellm to Artificial Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ _Libraries for building programs that leverage AI._
 - [Ollama](https://github.com/jmorganca/ollama) - Run large language models locally.
 - [OllamaFarm](https://github.com/presbrey/ollamafarm) - Manage, load-balance, and failover packs of Ollamas.
 - [otellix](https://github.com/oluwajubelo1/otellix) - OpenTelemetry-native LLM observability and budget guardrails for cost-constrained production environments.
+- [racellm](https://github.com/khuynh22/racellm) - Race multiple LLM providers simultaneously and stream results in parallel through a live BubbleTea TUI dashboard with timing stats.
 - [routex](https://github.com/Ad3bay0c/routex) - YAML-driven multi-agent AI runtime for Go with Erlang-style supervision, MCP tool server support, and a CLI.
 
 **[⬆ back to top](#contents)**


### PR DESCRIPTION
**Forge link:** https://github.com/khuynh22/racellm
**pkg.go.dev:** https://pkg.go.dev/github.com/khuynh22/racellm
**goreportcard.com:** https://goreportcard.com/report/github.com/khuynh22/racellm

---

RaceLLM is a Go CLI that fans out a single prompt to multiple LLM providers (OpenAI, Anthropic, Gemini, Ollama) simultaneously, streams all responses in parallel, and surfaces timing results through a BubbleTea TUI dashboard. It supports two race modes: `all` (wait for every provider) and `fastest` (cancel the rest once the first completes).

- Has a `go.mod` file
- MIT licensed
- Written in Go 1.25