### PR TITLE
Add tcglookup-go to Third-party APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2807,6 +2807,7 @@ _Libraries for accessing third party APIs._
 - [steam](https://github.com/sostronk/go-steam) - Go Library to interact with Steam game servers.
 - [stripe](https://github.com/stripe/stripe-go) - Go client for the Stripe API.
 - [swag](https://github.com/zc2638/swag) - No comments, simple go wrapper to create swagger 2.0 compatible APIs. Support most routing frameworks, such as built-in, gin, chi, mux, echo, httprouter, fasthttp and more.
+- [tcglookup-go](https://github.com/TCG-Price-Lookup/tcglookup-go) - Go client library for the [TCG Price Lookup API](https://tcgpricelookup.com/tcg-api). Live trading card prices across Pokemon, MTG, Yu-Gi-Oh, Lorcana, One Piece, Star Wars Unlimited, and Flesh and Blood.
 - [textbelt](https://github.com/dietsche/textbelt) - Go client for the textbelt.com txt messaging API.
 - [threads-go](https://github.com/tirthpatell/threads-go) - Go client library for the Meta Threads API with OAuth 2.0, rate limiting, and type-safe error handling.
 - [Trello](https://github.com/adlio/trello) - Go wrapper for the Trello API.


### PR DESCRIPTION
Adds **[tcglookup-go](https://github.com/TCG-Price-Lookup/tcglookup-go)** — Go client library for the [TCG Price Lookup API](https://tcgpricelookup.com/tcg-api).

Live trading card prices across 8 major TCGs (Pokemon, MTG, Yu-Gi-Oh, Lorcana, One Piece, Star Wars Unlimited, Flesh and Blood) with TCGPlayer market data, eBay sold averages, and PSA/BGS/CGC graded prices.

- Zero third-party dependencies (stdlib `net/http` only)
- Typed error wrappers
- Auto-chunked batch lookups
- Published on [pkg.go.dev](https://pkg.go.dev/github.com/TCG-Price-Lookup/tcglookup-go)