### PR TITLE
Add metricsd to DevOps Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -3449,6 +3449,7 @@ _Software written in Go._
 - [lwc](https://github.com/timdp/lwc) - A live-updating version of the UNIX wc command.
 - [manssh](https://github.com/xwjdsh/manssh) - manssh is a command line tool for managing your ssh alias config easily.
 - [Mantil](https://github.com/mantil-io/mantil) - Go specific framework for building serverless applications on AWS that enables you to focus on pure Go code while Mantil takes care of the infrastructure.
+- [metricsd](https://github.com/0x524A/metricsd) - Lightweight metrics collector with plugin system, shipping to Prometheus, Splunk HEC, and HTTP JSON endpoints.
 - [minikube](https://github.com/kubernetes/minikube) - Run Kubernetes locally.
 - [Moby](https://github.com/moby/moby) - Collaborative project for the container ecosystem to assemble container-based systems.
 - [Mora](https://github.com/emicklei/mora) - REST server for accessing MongoDB documents and meta data.


### PR DESCRIPTION
## Add metricsd

- **Repository:** https://github.com/0x524A/metricsd
- **pkg.go.dev:** https://pkg.go.dev/github.com/0x524A/metricsd
- **Go Report Card:** https://goreportcard.com/report/github.com/0x524A/metricsd (Grade: A+)
- **Coverage:** 80%

### What is metricsd?

A lightweight, production-ready metrics collector written in Go with a shell-script plugin system. Collects system metrics (CPU, memory, disk, network, GPU), scrapes Prometheus endpoints, and ships to multiple backends.

### Why it belongs here

- **Plugin system** with circuit breaker, parallel collection, and security sandboxing
- Ships to **Prometheus Remote Write, Splunk HEC, HTTP JSON, and local files**
- **Debian packaging** with systemd service and security hardening
- Compile-time Go plugin extension point
- 80% test coverage, A+ Go Report Card