### PR TITLE
Add dredge to Other Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -3501,6 +3501,7 @@ _Software written in Go._
 - [CrunchyCleaner](https://github.com/Knuspii/CrunchyCleaner) - A lightweight, software cache cleanup tool for Windows & Linux.
 - [Documize](https://github.com/documize/community) - Modern wiki software that integrates data from SaaS tools.
 - [dp](https://github.com/scryinfo/dp) - Through SDK for data exchange with blockchain, developers can get easy access to DAPP development.
+- [dredge](https://github.com/DeprecatedLuar/dredge-cargo) - Encrypted terminal vault for storing and retrieving notes, configs, keys and files using fuzzy search and git sync.
 - [drive](https://github.com/odeke-em/drive) - Google Drive client for the commandline.
 - [Duplicacy](https://github.com/gilbertchen/duplicacy) - A cross-platform network and cloud backup tool based on the idea of lock-free deduplication.
 - [fjira](https://github.com/mk-5/fjira) - A fuzzy-search based terminal UI application for Attlasian Jira


### PR DESCRIPTION
## Description

Add [dredge](https://github.com/DeprecatedLuar/dredge-cargo) to the **Other Software** section under Software Packages, in alphabetical order.

**dredge** - Encrypted terminal vault for storing and retrieving notes, configs, keys and files using fuzzy search and git sync.

## Links

- **Forge:** https://github.com/DeprecatedLuar/dredge-cargo
- **pkg.go.dev:** https://pkg.go.dev/github.com/DeprecatedLuar/dredge-cargo
- **goreportcard:** https://goreportcard.com/report/github.com/DeprecatedLuar/dredge-cargo
- **Coverage:** https://app.codecov.io/gh/DeprecatedLuar/dredge-cargo