### PR TITLE
Add GoX to templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2473,6 +2473,7 @@ _Libraries and tools for templating and lexing._
 - [gomponents](https://www.gomponents.com) - HTML 5 components in pure Go, that look something like this: `func(name string) g.Node { return Div(Class("headline"), g.Textf("Hi %v!", name)) }`.
 - [got](https://github.com/goradd/got) - A Go code generator inspired by Hero and Fasttemplate. Has include files, custom tag definitions, injected Go code, language translation, and more.
 - [goview](https://github.com/foolin/goview) - Goview is a lightweight, minimalist and idiomatic template library based on golang html/template for building Go web application.
+- [gox](https://github.com/doors-dev/gox) - HTML templates as first-class Go expressions, with seamless editor support.
 - [htmgo](https://htmgo.dev) - build simple and scalable systems with go + htmx
 - [jet](https://github.com/CloudyKit/jet) - Jet template engine.
 - [liquid](https://github.com/osteele/liquid) - Go implementation of Shopify Liquid templates.


### PR DESCRIPTION
Forge link: https://github.com/doors-dev/gox
pkg.go.dev:  https://pkg.go.dev/github.com/doors-dev/gox
goreportcard.com: https://goreportcard.com/report/github.com/doors-dev/gox
Coverage: https://app.codecov.io/gh/doors-dev/gox

Notes:
- The github repo is 4 month old, but i started in october 2025 on gitlab in a private repo and can provide proof.
- I don't see much sense to push test coverage above the current level (77%), language server part contains many error branches related to LSP protocol violation by editor or gopls. 
- I used cross-package coverage metrics, because LSP part is covered by e2e test suite, it's the best way to test it.
- I use AI tools only to assist with tests and docs.
- I build a [server-driven web framework](https://github.com/doors-dev/doors) on top of it, that utilizes every feature and and every layer of runtime part to the max, so I am sure of it's stability.