### PR TITLE
Add bindboss - self-extracting executable packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3306,6 +3306,7 @@ _Software written in Go._
 - [aurora](https://github.com/xuri/aurora) - Cross-platform web-based Beanstalkd queue server console.
 - [awsenv](https://github.com/soniah/awsenv) - Small binary that loads Amazon (AWS) environment variables for a profile.
 - [Balerter](https://github.com/balerter/balerter) - A self-hosted script-based alerting manager.
+- [bindboss](https://github.com/grug-group420/Bindboss) - Pack any directory into a self-extracting executable with dependency checking, integrity hashing, and Ed25519 signing.
 - [Blast](https://github.com/dave/blast) - A simple tool for API load testing and batch jobs.
 - [bombardier](https://github.com/codesenberg/bombardier) - Fast cross-platform HTTP benchmarking tool.
 - [cassowary](https://github.com/rogerwelin/cassowary) - Modern cross-platform HTTP load-testing tool written in Go.


### PR DESCRIPTION
## Add bindboss to DevOps Tools

[Bindboss](https://github.com/grug-group420/Bindboss) packs any directory into a single self-extracting executable with:

- Dependency checking with auto-download
- SHA-256 integrity hashing + optional Ed25519 signing
- Pre/post hooks
- Cross-compilation (linux/amd64, darwin/arm64, windows, etc.)
- JSON-driven install wizard
- Clean Go library API (`pkg/bindboss`)

```bash
bindboss pack ./myapp myapp-bin --run="python main.py" --needs="python3,python3 --version,https://python.org"
```

- **License:** MIT
- **CI:** GitHub Actions with tests
- **Pure Go**, zero runtime dependencies