### PR TITLE
Add gspy to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -2360,6 +2360,7 @@ _Libraries that are used to help make your application more secure._
 - [goArgonPass](https://github.com/dwin/goArgonPass) - Argon2 password hash and verification designed to be compatible with existing Python and PHP implementations.
 - [goSecretBoxPassword](https://github.com/dwin/goSecretBoxPassword) - A probably paranoid package for securely hashing and encrypting passwords.
 - [gost-crypto](https://github.com/rekurt/gost-crypto) - Go library for Russian GOST cryptographic standards (digital signatures, Streebog hash, Kuznechik cipher, MGM AEAD) backed by OpenSSL gost-engine.
+- [gspy](https://github.com/Mutasem-mk4/gspy) - Forensic goroutine-to-syscall inspector for live Go processes.
 - [Interpol](https://github.com/avahidi/interpol) - Rule-based data generator for fuzzing and penetration testing.
 - [leakhound](https://github.com/nilpoona/leakhound) - Static analysis tool to detect accidental logging of sensitive struct fields, preventing data leaks in logs.
 - [lego](https://github.com/go-acme/lego) - Pure Go ACME client library and CLI tool (for use with Let's Encrypt).


### PR DESCRIPTION
## Description

I am submitting my tool to awesome-go.

- [gspy](https://github.com/Mutasem-mk4/gspy) - Forensic goroutine-to-syscall inspector for live Go processes.

It uses eBPF (uprobes and tracepoints) coupled with `process_vm_readv` to map live Goroutine IDs to kernel syscalls and userspace stack frames, specifically for security incidence response and forensics without impacting binary footprint.

The repository is actively maintained and fulfills the standard guidelines (**except age limit**, as I am requesting a manual review exception given its uniqueness as the only zero-ptrace eBPF Go process forensic tool in the ecosystem).

Forge link: https://github.com/Mutasem-mk4/gspy
pkg.go.dev: https://pkg.go.dev/github.com/Mutasem-mk4/gspy
goreportcard.com: https://goreportcard.com/report/github.com/Mutasem-mk4/gspy
Coverage: https://github.com/Mutasem-mk4/gspy/actions/workflows/build.yml

Thank you for your review.
