### PR TITLE
fix(markdown): initialize IDGenerator.used map to prevent nil-map panic

### DIFF
--- a/pkg/markdown/convert.go
+++ b/pkg/markdown/convert.go
@@ -26,7 +26,7 @@ func ToHTML(markdown []byte) ([]byte, error) {
 	)
 
 	ctx := parser.NewContext(
-		parser.WithIDs(&IDGenerator{}), // register custom ID generator
+		parser.WithIDs(NewIDGenerator()), // register custom ID generator
 	)
 
 	var buf bytes.Buffer
@@ -40,6 +40,12 @@ func ToHTML(markdown []byte) ([]byte, error) {
 // IDGenerator for goldmark to provide IDs more similar to GitHub's IDs on markdown parsing
 type IDGenerator struct {
 	used map[string]bool
+}
+
+// NewIDGenerator returns an IDGenerator with its internal state initialized,
+// ready to track used IDs without panicking on the first Put call.
+func NewIDGenerator() *IDGenerator {
+	return &IDGenerator{used: map[string]bool{}}
 }
 
 // Generate an ID

--- a/pkg/markdown/convert_test.go
+++ b/pkg/markdown/convert_test.go
@@ -5,6 +5,12 @@ import (
 	"testing"
 )
 
+func TestIDGeneratorPutDoesNotPanic(t *testing.T) {
+	g := NewIDGenerator()
+	g.Put([]byte("some-headline"))
+	g.Put([]byte("another-headline"))
+}
+
 func TestToHTML(t *testing.T) {
 	input := []byte(
 		`## some headline


### PR DESCRIPTION

**Repo:** avelino/awesome-go (⭐ 170526)
**Type:** bugfix
**Files changed:** 2
**Lines:** +13/-1

## What
`pkg/markdown.IDGenerator` declared a `used map[string]bool` field but was
constructed via `&IDGenerator{}` in `ToHTML`, leaving the map nil. Any call
to `IDGenerator.Put` would panic with `assignment to entry in nil map`. This
PR adds a `NewIDGenerator()` constructor that initializes the map, switches
`ToHTML` to use it, and adds a regression test exercising `Put`.

## Why
The current implementation is a latent panic: goldmark's parser invokes
`IDs.Put` whenever it records an already-used heading ID. `TestToHTML`
happens to use only unique headings, so the bug never trips in the test
suite, but any markdown input with two headings that slugify to the same
value (e.g. duplicate section titles in `README.md`) would crash the site
generator. Initializing the map is a one-line correctness fix.

## Testing
- `go test ./pkg/markdown/ -v` → both `TestToHTML` and the new
  `TestIDGeneratorPutDoesNotPanic` pass locally.
- The new test calls `Put` directly, which would have panicked against the
  previous code.

## Risk
Low — adds a constructor and initializes a map; no behavior change for the
non-panicking path.
