### PR TITLE
Add wick to Project Layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1887,6 +1887,7 @@ _**Unofficial** set of patterns for structuring projects._
 - [pagoda](https://github.com/mikestefanello/pagoda) - Rapid, easy full-stack web development starter kit built in Go.
 - [scaffold](https://github.com/catchplay/scaffold) - Scaffold generates a starter Go project layout. Lets you focus on business logic implemented.
 - [wangyoucao577/go-project-layout](https://github.com/wangyoucao577/go-project-layout) - Set of practices and discussions on how to structure Go project layout.
+- [wick](https://github.com/yogasw/wick) - AI-first Go framework for building internal tools and background jobs — just prompt, AI does the rest.
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
### What's changed

Add [wick](https://github.com/yogasw/wick) under **Miscellaneous → Project Layout**.

> AI-first Go framework for building internal tools and background jobs — just prompt, AI does the rest.

### Why

Wick is a Go framework for building internal tools, admin panels, and background jobs. Modules self-register, config is runtime-editable from an admin UI, and it ships a typed `wick:"..."` tag grammar so boilerplate stays out of the tool code. Fills a gap in the Project Layout section — closest neighbors are `modern-go-application`, `goapp`, `go-starter` — but focused on the internal-tools/admin-panel use case rather than generic REST scaffolding.

### Links

- Repo: https://github.com/yogasw/wick
- pkg.go.dev: https://pkg.go.dev/github.com/yogasw/wick
- Go Report Card: https://goreportcard.com/report/github.com/yogasw/wick
- Docs: https://yogasw.github.io/wick/
- License: MIT
- Latest release: v0.2.0

### Checklist

- [x] One item added.
- [x] Alphabetical order inside category.
- [x] Description concise, non-promotional, ends with period.
- [x] Link to repository source.
- [x] MIT license.
- [x] `go.mod` present (`module github.com/yogasw/wick`).
- [x] SemVer release tagged.
- [x] English README + docs site.
- [ ] >= 5 months repo history - *not yet met; happy to wait and resubmit if required.*
- [ ] >= 80% test coverage - *in progress.*
