### PR TITLE
feat: add tickstem/cron to Job Scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1572,6 +1572,7 @@ _Libraries for scheduling jobs._
 - [scheduler](https://github.com/carlescere/scheduler) - Cronjobs scheduling made easy.
 - [scheduler](https://github.com/yuseferi/scheduler) - Go-native distributed job scheduler with delayed tasks, batched Redis coordination, retries, lease-based recovery, and versioned queue partitioning.
 - [tasks](https://github.com/madflojo/tasks) - An easy to use in-process scheduler for recurring tasks in Go.
+- [tickstem/cron](https://github.com/tickstem/cron) - Go client for scheduling HTTP cron jobs, with execution history, failure alerts, and tsk-local for testing handlers without live credentials.
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
  Required links

  - Forge link: https://github.com/tickstem/cron
  - pkg.go.dev: https://pkg.go.dev/github.com/tickstem/cron
  - goreportcard.com: https://goreportcard.com/report/github.com/tickstem/cron
  - Coverage service link: https://codecov.io/gh/tickstem/cron

  Pre-submission checklist

  - I have read the https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines
  - I have read the https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards

  Repository requirements

  - The repo has a go.mod file and at least one SemVer release (v0.1.2).
  - The repo has an open source license.
  - The repo documentation has a pkg.go.dev link.
  - The repo documentation has a goreportcard link (grade A- or better).
  - The repo documentation has a coverage service link.
  - The repo has a continuous integration process (GitHub Actions, etc.).
  - CI runs tests that must pass before merging.

  Pull Request content

  - This PR adds/removes/changes only one package.
  - The package has been added in alphabetical order.
  - The link text is the exact project name.
  - The description is clear, concise, non-promotional, and ends with a period.
  - The link in README.md matches the forge link above.

  Category quality

  - The packages around my addition still meet the Quality Standards.
