### PR TITLE
Add tickstem/verify to Email section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,7 @@ _Libraries and tools that implement email creation and sending._
 - [smtp](https://github.com/mailhog/smtp) - SMTP server protocol state machine.
 - [smtpmock](https://github.com/mocktools/go-smtp-mock) - Lightweight configurable multithreaded fake SMTP server. Mimic any SMTP behaviour for your test environment.
 - [truemail-go](https://github.com/truemail-rb/truemail-go) - Configurable Golang email validator/verifier. Verify email via Regex, DNS, SMTP and even more.
+- [tickstem/verify](https://github.com/tickstem/verify) - Email address verification: syntax, MX lookup, disposable domain detection, and role-based prefix checks.
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
  Adds `tickstem/verify` to the Email section.

  - **Package:** https://github.com/tickstem/verify
  - **pkg.go.dev:** https://pkg.go.dev/github.com/tickstem/verify
  - **goreportcard:** A+

  Checks syntax, MX records, disposable domains, and role-based prefixes without SMTP probing.

  ### Checklist
  - [x] Added in alphabetical order
  - [x] Has a SemVer tag (v0.1.0)
  - [x] Listed on pkg.go.dev
  - [x] goreportcard A+
  - [x] Follows the format `- [package](url) - Description.`
