### PR TITLE
Add macwifi

### DIFF
--- a/README.md
+++ b/README.md
@@ -2105,6 +2105,7 @@ _Libraries for working with various layers of the network._
 - [lhttp](https://github.com/fanux/lhttp) - Powerful websocket framework, build your IM server more easily.
 - [linkio](https://github.com/ian-kent/linkio) - Network link speed simulation for Reader/Writer interfaces.
 - [llb](https://github.com/kirillDanshin/llb) - It's a very simple but quick backend for proxy servers. Can be useful for fast redirection to predefined domain with zero memory allocation and fast response.
+- [macwifi](https://github.com/jaisonerick/macwifi) - Wi-Fi scanning and Keychain password retrieval for macOS 13+.
 - [mdns](https://github.com/hashicorp/mdns) - Simple mDNS (Multicast DNS) client/server library in Golang.
 - [mqttPaho](https://eclipse.org/paho/clients/golang/) - The Paho Go Client provides an MQTT client library for connection to MQTT brokers via TCP, TLS or WebSockets.
 - [natiu-mqtt](https://github.com/soypat/natiu-mqtt) - A dead-simple, non-allocating, low level implementation of MQTT well suited for embedded systems.


### PR DESCRIPTION
**Add the package or project**

Forge link: https://github.com/jaisonerick/macwifi
pkg.go.dev: https://pkg.go.dev/github.com/jaisonerick/macwifi
goreportcard.com: https://goreportcard.com/report/github.com/jaisonerick/macwifi

macwifi is a Go library for scanning Wi-Fi networks and reading saved Keychain passwords on macOS 13+. It exists because macOS 14.4 removed the airport CLI and CoreWLAN's scanForNetworks now only returns real BSSIDs to apps signed with a stable Developer ID that have Location Services permission. The package embeds a Developer-ID-signed and notarized helper bundle to satisfy that requirement, so consumers do not need to set up code signing themselves.

Stable v1.0.0 tagged 2026-04-22, MIT licensed. Added under Networking in alphabetical order between llb and mdns.

Note: the existing test failures on the `tests` workflow (TestAlpha for "Libraries for manipulating video" and "Full stack web frameworks", and TestDuplicatedLinks for `kono` and `coinpaprika-go`) are pre-existing on main and unrelated to this change. Our addition passes alphabetical placement and is the only line added.