### PR TITLE
feat: add KubeStellar Console to DevOps Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3460,6 +3460,7 @@ _Software written in Go._
 - [kubefwd](https://github.com/txn2/kubefwd) - Bulk Kubernetes port forwarding with unique IPs per service for local development.
 - [kubernetes](https://github.com/kubernetes/kubernetes) - Container Cluster Manager from Google.
 - [kubeshark](https://github.com/kubeshark/kubeshark) - API traffic analyzer for Kubernetes, inspired by Wireshark, purposely built for Kubernetes.
+- [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes management dashboard for monitoring workloads, bindings, and cluster health across KubeStellar deployments.
 - [KubeVela](https://github.com/kubevela/kubevela) - Cloud native application delivery.
 - [KubeVPN](https://github.com/kubenetworks/kubevpn) - KubeVPN offers a Cloud-Native Dev Environment that seamlessly connects to your Kubernetes cluster network.
 - [KusionStack](https://github.com/KusionStack/kusion) - A unified programmable configuration techstack to deliver modern app in 'platform as code' and 'infra as code' approach.


### PR DESCRIPTION
## Description

Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **DevOps Tools** section.

**KubeStellar Console** is an AI-powered multi-cluster Kubernetes management dashboard written in Go (backend) + React. It provides:
- Real-time monitoring of workloads, bindings, and cluster health across multiple KubeStellar clusters
- AI-assisted operations (Claude, OpenAI, Gemini integration)
- 150+ dashboard cards for Kubernetes ecosystem tools (ArgoCD, Istio, Prometheus, etc.)
- KubeStellar-native support for WorkloadStatusBinding and BindingPolicy resources

The backend is written in Go using the Fiber framework, serving both REST/WebSocket APIs and the frontend assets.

Repository: https://github.com/kubestellar/console
License: Apache-2.0

Positioned alphabetically between `kubeshark` and `KubeVela` in the DevOps Tools section.

**Checklist**
- [x] I have read the [How to Contribute](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md) and [Style Guide](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#style-guide) documents.
- [x] This project has been around for at least 6 months.
- [x] It has at least 100 stars.
- [x] The README is formatted correctly.
- [x] The project actively responds to issues.
- [x] The project has a `go.mod` file.
