### PR TITLE
Add terraformer to DevOps Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -3492,6 +3492,7 @@ _Software written in Go._
 - [StatusOK](https://github.com/sanathp/statusok) - Monitor your Website and REST APIs.Get Notified through Slack, E-mail when your server is down or response time is more than expected.
 - [tau](https://github.com/taubyte/tau) - Easily build Cloud Computing Platforms with features like Serverless WebAssembly Functions, Frontend Hosting, CI/CD, Object Storage, K/V Database, and Pub-Sub Messaging.
 - [terraform-provider-openapi](https://github.com/dikhan/terraform-provider-openapi) - Terraform provider plugin that dynamically configures itself at runtime based on an OpenAPI document (formerly known as swagger file) containing the definitions of the APIs exposed.
+- [terraformer](https://github.com/chenrui333/terraformer) - CLI tool to generate Terraform files from existing infrastructure. Infrastructure to Code. Supports many providers.
 - [tf-profile](https://github.com/datarootsio/tf-profile) - Profiler for Terraform runs. Generate global stats, resource-level stats or visualizations.
 - [tlm](https://github.com/yusufcanb/tlm) - Local cli copilot, powered by CodeLLaMa
 - [traefik](https://github.com/containous/traefik) - Reverse proxy and load balancer with support for multiple backends.


### PR DESCRIPTION
Add [terraformer](https://github.com/chenrui333/terraformer) — a CLI tool that generates Terraform files from existing infrastructure.

The upstream [GoogleCloudPlatform/terraformer](https://github.com/GoogleCloudPlatform/terraformer) was archived in March 2026. I picked up maintenance as the [top human contributor](https://github.com/GoogleCloudPlatform/terraformer/graphs/contributors) (#4 excluding bots, 62 commits) to the original project.

The fork is actively maintained with refreshed dependencies, CI modernization, and continued feature development.

Forge link: https://github.com/chenrui333/terraformer
pkg.go.dev: https://pkg.go.dev/github.com/chenrui333/terraformer
goreportcard.com: https://goreportcard.com/report/github.com/chenrui333/terraformer