### PR TITLE
feat: add tickstem/heartbeat and tickstem/uptime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1573,6 +1573,7 @@ _Libraries for scheduling jobs._
 - [scheduler](https://github.com/yuseferi/scheduler) - Go-native distributed job scheduler with delayed tasks, batched Redis coordination, retries, lease-based recovery, and versioned queue partitioning.
 - [tasks](https://github.com/madflojo/tasks) - An easy to use in-process scheduler for recurring tasks in Go.
 - [tickstem/cron](https://github.com/tickstem/cron) - Go client for scheduling HTTP cron jobs, with execution history, failure alerts, and tsk-local for testing handlers without live credentials.
+- [tickstem/heartbeat](https://github.com/tickstem/heartbeat) - Go client for dead-man's switch heartbeat monitoring: ping a URL after each job run and get alerted by email if pings stop arriving.
 
 **[⬆ back to top](#contents)**
 
@@ -3486,6 +3487,7 @@ _Software written in Go._
 - [sigma](https://github.com/go-sigma/sigma) - OCI-native container image registry, support OCI-native artifact, scan artifact, image build etc.
 - [skm](https://github.com/TimothyYe/skm) - SKM is a simple and powerful SSH Keys Manager, it helps you to manage your multiple SSH keys easily!
 - [StatusOK](https://github.com/sanathp/statusok) - Monitor your Website and REST APIs.Get Notified through Slack, E-mail when your server is down or response time is more than expected.
+- [tickstem/uptime](https://github.com/tickstem/uptime) - Go client for HTTP uptime monitoring with SSL expiry alerts and configurable response assertions.
 - [tau](https://github.com/taubyte/tau) - Easily build Cloud Computing Platforms with features like Serverless WebAssembly Functions, Frontend Hosting, CI/CD, Object Storage, K/V Database, and Pub-Sub Messaging.
 - [terraform-provider-openapi](https://github.com/dikhan/terraform-provider-openapi) - Terraform provider plugin that dynamically configures itself at runtime based on an OpenAPI document (formerly known as swagger file) containing the definitions of the APIs exposed.
 - [tf-profile](https://github.com/datarootsio/tf-profile) - Profiler for Terraform runs. Generate global stats, resource-level stats or visualizations.


### PR DESCRIPTION
## Description

Adds two Go SDKs from the [Tickstem](https://tickstem.dev) developer infrastructure suite. The cron SDK (`tickstem/cron`) and email verification SDK (`tickstem/verify`) are already listed.

### tickstem/heartbeat → Job Scheduler

- **Repo:** https://github.com/tickstem/heartbeat
- **pkg.go.dev:** https://pkg.go.dev/github.com/tickstem/heartbeat
- **goreportcard:** https://goreportcard.com/report/github.com/tickstem/heartbeat
- Dead-man's switch heartbeat monitoring: create a heartbeat, ping its URL after each job run, get alerted by email if pings stop arriving
- v1.0.0 tagged, MIT license, >85% test coverage

### tickstem/uptime → DevOps Tools

- **Repo:** https://github.com/tickstem/uptime
- **pkg.go.dev:** https://pkg.go.dev/github.com/tickstem/uptime
- **goreportcard:** https://goreportcard.com/report/github.com/tickstem/uptime
- HTTP uptime monitoring with SSL expiry alerts and configurable response assertions (status code, response time, body)
- v1.0.0 tagged, MIT license, >85% test coverage

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md)
- [x] Packages have been added alphabetically within their sections
- [x] Each package has a SemVer tag (v1.0.0)
- [x] Each package is listed on pkg.go.dev
- [x] Each package has tests
- [x] The description ends with a period