### PR TITLE
Add ubgo/lock to Distributed Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1043,6 +1043,7 @@ _Packages that help with building Distributed Systems._
 - [Kitex](https://github.com/cloudwego/kitex) - A high-performance and strong-extensibility Golang RPC framework that helps developers build microservices. If the performance and extensibility are the main concerns when you develop microservices, Kitex can be a good choice.
 - [Kratos](https://github.com/go-kratos/kratos) - A modular-designed and easy-to-use microservices framework in Go.
 - [liftbridge](https://github.com/liftbridge-io/liftbridge) - Lightweight, fault-tolerant message streams for NATS.
+- [lock](https://github.com/ubgo/lock) - Distributed lock family with one Go interface and five backends (filelock, flock, Redis, Postgres, etcd) — fencing tokens, semaphore mode, and observability hooks across all backends.
 - [lura](https://github.com/luraproject/lura) - Ultra performant API Gateway framework with middlewares.
 - [micro](https://github.com/micro/micro) - A distributed systems runtime for the cloud and beyond.
 - [mochi mqtt](https://github.com/mochi-co/mqtt) - Fully spec compliant, embeddable high-performance MQTT v5/v3 broker for IoT, smarthome, and pubsub.


### PR DESCRIPTION
## Required links

- [x] Forge link: https://github.com/ubgo/lock
- [x] pkg.go.dev: https://pkg.go.dev/github.com/ubgo/lock
- [x] goreportcard.com: https://goreportcard.com/report/github.com/ubgo/lock
- [x] Coverage service link: https://codecov.io/gh/ubgo/lock

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

- [x] The repo has a \`go.mod\` file and at least one SemVer release (\`v0.1.0\`).
- [x] The repo has an open source license (Apache-2.0).
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo documentation has a coverage service link.

- [x] The repo has a continuous integration process (GitHub Actions, per-backend test workflows + lint matrix).
- [x] CI runs tests that must pass before merging.

## Pull Request content

- [x] This PR adds **only one** package (\`ubgo/lock\`).
- [x] The package has been added in **alphabetical order** (between \`liftbridge\` and \`lura\`).
- [x] The link text is the **exact project name** (\`lock\`).
- [x] The description is clear, concise, non-promotional, and ends with a period.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.

## What \`ubgo/lock\` is

A distributed lock family for Go: one \`Locker\` interface and five
backends (filelock, flock, Redis, Postgres, etcd) under one repo,
each as its own Go module so importing one backend does not pull
deps for the others. Every backend ships fencing tokens, semaphore
mode, observability hooks (slog/metrics/spans), and TraceID
propagation. \`memlock\` provides an in-memory drop-in for tests;
\`contrib/gocronlock\` adapts the family to gocron v2.

Thanks for the review.