### PR TITLE
Add nylas to Email

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,7 @@ _Libraries and tools that implement email creation and sending._
 - [Mailpit](https://github.com/axllent/mailpit) - Email and SMTP testing tool for developers.
 - [mailx](https://github.com/valord577/mailx) - Mailx is a library that makes it easier to send email via SMTP. It is an enhancement of the golang standard library `net/smtp`.
 - [mox](https://github.com/mjl-/mox) - Modern full-featured secure mail server for low-maintenance, self-hosted email.
+- [nylas](https://github.com/nylas/cli) - CLI for sending and reading email, calendar events, and contacts across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP through one auth flow.
 - [SendGrid](https://github.com/sendgrid/sendgrid-go) - SendGrid's Go library for sending email.
 - [smtp](https://github.com/mailhog/smtp) - SMTP server protocol state machine.
 - [smtpmock](https://github.com/mocktools/go-smtp-mock) - Lightweight configurable multithreaded fake SMTP server. Mimic any SMTP behaviour for your test environment.


### PR DESCRIPTION
[`nylas`](https://github.com/nylas/cli) is added to the **Email** category, alphabetically between `mox` and `SendGrid`.

A CLI for sending and reading email, calendar events, and contacts across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP through one auth flow. Built in Go, MIT licensed.

**Quality checklist:**
- License: [MIT](https://github.com/nylas/cli/blob/main/LICENSE) ✓
- Repository age: 9 months (created Aug 2025) ✓
- `go.mod` at root ✓
- SemVer release: [v3.1.5](https://github.com/nylas/cli/releases/tag/v3.1.5) ✓
- [pkg.go.dev](https://pkg.go.dev/github.com/nylas/cli) ✓
- [Go Report Card: A+](https://goreportcard.com/report/github.com/nylas/cli) ✓
- Actively maintained: latest release 4 days ago ✓
- README in English, public APIs documented ✓

**Source:** https://github.com/nylas/cli
**Docs:** https://cli.nylas.com