### PR TITLE
Add proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -2424,6 +2424,7 @@ _Libraries and tools for binary serialization._
 - [mus-go](https://github.com/mus-format/mus-go) - MUS format serializer for Go.
 - [php_session_decoder](https://github.com/yvasiyarov/php_session_decoder) - GoLang library for working with PHP session format and PHP Serialize/Unserialize functions.
 - [pletter](https://github.com/vimeda/pletter) - A standard way to wrap a proto message for message brokers.
+- [proto](https://github.com/emicklei/proto) - Parser and writer for Google ProtocolBuffers .proto files.
 - [structomap](https://github.com/tuvistavie/structomap) - Library to easily and dynamically generate maps from static structures.
 - [unitpacking](https://github.com/recolude/unitpacking) - Library to pack unit vectors into as fewest bytes as possible.
 


### PR DESCRIPTION
## Required links

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/emicklei/proto
- [x] pkg.go.dev: https://pkg.go.dev/github.com/emicklei/proto
- [x] goreportcard.com: https://goreportcard.com/report/github.com/emicklei/proto
- [x] Coverage service link: https://app.codecov.io/gh/emicklei/proto

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`). Latest tag: `v1.14.3`.
- [x] The repo has an open source license. MIT.
- [x] The repo documentation has a pkg.go.dev link (badge in README).
- [x] The repo documentation has a goreportcard link (grade **A+**, badge in README).
- [x] The repo documentation has a coverage service link (codecov badge in README).
- [x] The repo has a continuous integration process. GitHub Actions workflow `.github/workflows/go.yml` runs on every push.
- [x] CI runs tests that must pass before merging.

## Pull Request content

- [x] This PR adds **only one** package.
- [x] The package has been added in **alphabetical order** (between `pletter` and `structomap` in the Serialization section).
- [x] The link text is the **exact project name** (`proto`).
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Why it fits

`emicklei/proto` is a long-standing pure-Go parser and writer for Google Protocol Buffers `.proto` files (proto2, proto3, and the new editions syntax). It is widely used by code generators, linters, and tooling that need to introspect or transform `.proto` schemas without invoking `protoc`. It is a natural fit for the **Serialization** section, which already lists protobuf-adjacent libraries such as `goprotobuf` and `pletter`.

Quality summary:

- 615+ stars, first commit 2017, latest push 2026-02-20 (well within the 12-month activity window).
- MIT license.
- 40 source files, A+ Go Report Card grade.
- Has tests with codecov coverage tracking, GitHub Actions CI, and full pkg.go.dev documentation on every public type.
- Tagged SemVer release `v1.14.3`.

## Local validators

Ran `go test -run 'TestAlpha|TestSeparator' .` against my change. Both pass. The two unrelated `TestDuplicatedLinks` failures (`Kono#01`, `coinpaprika-go`) reproduce on plain `main` without my change, so they are pre-existing and not caused by this PR.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.