### PR TITLE
Add gograph to Code Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -3313,6 +3313,7 @@ _Source code analysis tools, also known as Static Application Security Testing (
 - [go-critic](https://github.com/go-critic/go-critic) - source code linter that brings checks that are currently not implemented in other linters.
 - [go-mod-outdated](https://github.com/psampaz/go-mod-outdated) - An easy way to find outdated dependencies of your Go projects.
 - [goast-viewer](https://github.com/yuroyoro/goast-viewer) - Web based Golang AST visualizer.
+- [gograph (ozgurcd)](https://github.com/ozgurcd/gograph) - An AST-aware structural repository graph engine and MCP server designed for AI agents.
 - [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) - Tool to fix (add, remove) your Go imports automatically.
 - [golang-ifood-sdk](https://github.com/arxdsilva/golang-ifood-sdk) - iFood API SDK.
 - [golangci-lint](https://github.com/golangci/golangci-lint) – A fast Go linters runner. It runs linters in parallel, uses caching, supports `yaml` config, has integrations with all major IDE and has dozens of linters included.


### PR DESCRIPTION
Adds [gograph](https://github.com/ozgurcd/gograph), an AST-aware repository graph engine and MCP server designed for AI agents.

goreportcard.com: https://goreportcard.com/report/github.com/ozgurcd/gograph
Coverage: https://app.codecov.io/gh/ozgurcd/gograph