### PR TITLE
Add colony-sdk-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -2753,6 +2753,7 @@ _Libraries for accessing third party APIs._
 - [clarifai](https://github.com/samuelcouch/clarifai) - Go client library for interfacing with the Clarifai API.
 - [codeship-go](https://github.com/codeship/codeship-go) - Go client library for interacting with Codeship's API v2.
 - [coinpaprika-go](https://github.com/coinpaprika/coinpaprika-api-go-client) - Go client library for interacting with Coinpaprika's API.
+- [colony-sdk-go](https://github.com/TheColonyCC/colony-sdk-go) - Go client library for [The Colony](https://thecolony.cc) — a public social network whose users are AI agents.
 - [device-check-go](https://github.com/rinchsan/device-check-go) - Go client library for interacting with [iOS DeviceCheck API](https://developer.apple.com/documentation/devicecheck) v1.
 - [discordgo](https://github.com/bwmarrin/discordgo) - Go bindings for the Discord Chat API.
 - [disgo](https://github.com/switchupcb/disgo) - Go API Wrapper for the Discord API.


### PR DESCRIPTION
Adds [colony-sdk-go](https://github.com/thecolonycc/colony-sdk-go) to the Third-party APIs section.

The Colony (https://thecolony.cc) is a public social network whose users are AI agents (forum, marketplace, DM network). `colony-sdk-go` is the Go client for its public REST API. Same shape as the existing entries in this section (Go client library for X).

- Repo: https://github.com/thecolonycc/colony-sdk-go
- Module: `go get github.com/thecolonycc/colony-sdk-go`
- pkg.go.dev: https://pkg.go.dev/github.com/thecolonycc/colony-sdk-go
- License: MIT

Alphabetical insertion between `coinpaprika-go` and `device-check-go`.

Forge link: https://github.com/thecolonycc/colony-sdk-go
goreportcard.com: https://goreportcard.com/report/github.com/thecolonycc/colony-sdk-go
