### PR TITLE
Add dakera-go to Artificial Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ _Libraries for building programs that leverage AI._
 - [agent-sdk-go](https://github.com/agenticenv/agent-sdk-go) - Go SDK for building durable AI agents on Temporal with support for tools, MCP, human approvals, and sub-agent delegation.
 - [ai](https://github.com/joakimcarlsson/ai) - A Go toolkit for building AI agents and applications across multiple providers with unified LLM, embeddings, tool calling, and MCP integration.
 - [chromem-go](https://github.com/philippgille/chromem-go) - Embeddable vector database for Go with Chroma-like interface and zero third-party dependencies. In-memory with optional persistence.
+- [dakera-go](https://github.com/dakera-ai/dakera-go) - Official Go client SDK for the Dakera self-hosted agent memory server, providing typed interfaces for memory store/recall, session management, namespace operations, and decay configuration.
 - [fun](https://gitlab.com/tozd/go/fun) - The simplest but powerful way to use large language models (LLMs) in Go.
 - [goai](https://github.com/zendev-sh/goai) - Go SDK for building AI applications. One SDK, 20+ providers. Inspired by Vercel AI SDK.
 - [hotplex](https://github.com/hrygo/hotplex) - AI Agent runtime engine with long-lived sessions for Claude Code, OpenCode, pi-mono and other CLI AI tools. Provides full-duplex streaming, multi-platform integrations, and secure sandbox.


### PR DESCRIPTION
## dakera-go

[dakera-go](https://github.com/dakera-ai/dakera-go) is the official Go client SDK for the Dakera self-hosted agent memory server — typed interfaces for store/recall, session management, namespace configuration, and decay control.

**Why it fits the Artificial Intelligence section:**
- Purpose-built for Go developers building AI agents that need persistent memory
- Typed interfaces for memory store/recall operations, session management, and namespace configuration
- Connects to a self-hosted Dakera server (Rust/RocksDB backend) that achieves 87.8% on the LoCoMo long-term memory benchmark
- Works alongside other Go AI tooling in this list (langchaingo, LocalAI, etc.) as the memory persistence layer

The Go SDK complements Go AI frameworks by providing the persistent memory layer agents need to retain context across sessions.

---

Forge link: https://github.com/dakera-ai/dakera-go
pkg.go.dev: https://pkg.go.dev/github.com/dakera-ai/dakera-go
goreportcard.com: https://goreportcard.com/report/github.com/dakera-ai/dakera-go