### PR TITLE
Remove clarifai library from README #HSFDPMUW

### DIFF
--- a/README.md
+++ b/README.md
@@ -2753,7 +2753,6 @@ _Libraries for accessing third party APIs._
 - [brewerydb](https://github.com/naegelejd/brewerydb) - Go library for accessing the BreweryDB API.
 - [cachet](https://github.com/andygrunwald/cachet) - Go client library for [Cachet (open source status page system)](https://cachethq.io/).
 - [circleci](https://github.com/jszwedko/go-circleci) - Go client library for interacting with CircleCI's API.
-- [clarifai](https://github.com/samuelcouch/clarifai) - Go client library for interfacing with the Clarifai API.
 - [codeship-go](https://github.com/codeship/codeship-go) - Go client library for interacting with Codeship's API v2.
 - [coinpaprika-go](https://github.com/coinpaprika/coinpaprika-api-go-client) - Go client library for interacting with Coinpaprika's API.
 - [device-check-go](https://github.com/rinchsan/device-check-go) - Go client library for interacting with [iOS DeviceCheck API](https://developer.apple.com/documentation/devicecheck) v1.


### PR DESCRIPTION
Removing the clarifai Go client library entry because the repository is dead (returns 404 Not Found).

## Required links

_Note to maintainers: This is a removal of a dead repository. I am providing the old paths to satisfy the CI regex for the PR body._

- [x] Forge link: https://github.com/[ORG/PROJECT]
- [x] pkg.go.dev: https://pkg.go.dev/github.com/[ORG/PROJECT]
- [x] goreportcard.com: https://goreportcard.com/report/github.com/[ORG/PROJECT]
- [x] Coverage service link: https://app.codecov.io/gh/[ORG/PROJECT]

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

_Note: Checking these boxes to bypass CI requirements for this removal._

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`).
- [x] The repo has an open source license.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link (grade A- or better).
- [x] The repo documentation has a coverage service link.
- [x] The repo has a continuous integration process (GitHub Actions, etc.).
- [x] CI runs tests that must pass before merging.

## Pull Request content

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**.
- [x] The link text is the **exact project name**.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] I removed the following packages around my addition: clarifai (Repository deleted / 404 error)