### PR TITLE
feat: add radar - terminal API explorer for OpenAPI/Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -3591,6 +3591,7 @@ _Software written in Go._
 - [peg](https://github.com/pointlander/peg) - Peg, Parsing Expression Grammar, is an implementation of a Packrat parser generator.
 - [Plik](https://github.com/root-gg/plik) - Plik is a temporary file upload system (Wetransfer like) in Go.
 - [portal](https://github.com/SpatiumPortae/portal) - Portal is a quick and easy command-line file transfer utility from any computer to another.
+- [radar](https://github.com/shayan-shojaei/radar) - Terminal-based API explorer for OpenAPI and Swagger specifications with request editing, encrypted session persistence, and cookie management.
 - [restic](https://github.com/restic/restic) - De-duplicating backup program.
 - [sake](https://github.com/alajmo/sake) - sake is a command runner for local and remote hosts.
 - [scc](https://github.com/boyter/scc) - Sloc Cloc and Code, a very fast accurate code counter with complexity calculations and COCOMO estimates.


### PR DESCRIPTION
## Description

Adds [radar](https://github.com/shayan-shojaei/radar) to the **Other Software** section, in alphabetical order between `portal` and `restic`.

radar is a terminal-based API explorer for OpenAPI 3.x and Swagger 2.0 specifications. It lets developers browse endpoints, fill in parameters, fire HTTP requests, and inspect responses — all without leaving the terminal. Sessions are auto-saved as age-encrypted files.

## Links

Forge link: https://github.com/shayan-shojaei/radar
pkg.go.dev: https://pkg.go.dev/github.com/shayan-shojaei/radar
goreportcard.com: https://goreportcard.com/report/github.com/shayan-shojaei/radar
Coverage: https://github.com/shayan-shojaei/radar/actions