### PR TITLE
update go-mutesting to active maintained fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -2556,7 +2556,7 @@ _Libraries for testing codebases and generating test data._
 - [go-cmp](https://github.com/google/go-cmp) - Package for comparing Go values in tests.
 - [go-hit](https://github.com/Eun/go-hit) - Hit is an http integration test framework written in golang.
 - [go-httpbin](https://github.com/mccutchen/go-httpbin) - HTTP testing and debugging tool with various endpoints for client testing.
-- [go-mutesting](https://github.com/zimmski/go-mutesting) - Mutation testing for Go source code.
+- [go-mutesting](https://github.com/jonbaldie/go-mutesting) - Mutation testing for Go with CI quality gates, coverage-aware MSI, baseline tracking, and git-diff filtering.
 - [go-mysql-test-container](https://github.com/arikama/go-mysql-test-container) - Golang MySQL testcontainer to help with MySQL integration testing.
 - [go-snaps](http://github.com/gkampitakis/go-snaps) - Jest-like snapshot testing in Golang.
 - [go-test-coverage](https://github.com/vladopajic/go-test-coverage) - Tool that reports coverage of files below set threshold.


### PR DESCRIPTION
The current entry points to [zimmski/go-mutesting](https://github.com/zimmski/go-mutesting), the original project. It has not had a meaningful commit in several years, does not support Go modules natively, and has open PRs that have not been reviewed.

[jonbaldie/go-mutesting](https://github.com/jonbaldie/go-mutesting) is the actively maintained continuation (forked via avito-tech) with a substantially extended feature set:

- MSI quality gates (`--min-msi`, `--min-covered-msi`) for CI enforcement
- Coverage-aware MSI — scores only covered-code mutations separately
- Baseline file — tracks known-surviving mutants so CI fails only on *new* regressions
- Git-diff filtering (`--git-diff-lines`) — only mutates lines changed in a PR
- Parallel execution with `--workers`
- Per-test coverage map (`--per-test`) — runs only tests that cover each mutant
- Structured JSON, HTML, and LLM-ready agentic reports
- GitHub Actions annotation output
- Active release cadence with semver tags and a changelog
- Documentation site: https://jonbaldie.github.io/go-mutesting/

The description is updated to reflect the richer feature set. The link text stays `go-mutesting` since that is the repo name.

This is an update to the existing entry (URL changed from zimmski to jonbaldie).

Forge link: https://github.com/jonbaldie/go-mutesting
pkg.go.dev: https://pkg.go.dev/github.com/jonbaldie/go-mutesting/v2
goreportcard.com: https://goreportcard.com/report/github.com/jonbaldie/go-mutesting