### PR TITLE
Add web-researcher-mcp to Artificial Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ _Libraries for building programs that leverage AI._
 - [OllamaFarm](https://github.com/presbrey/ollamafarm) - Manage, load-balance, and failover packs of Ollamas.
 - [otellix](https://github.com/oluwajubelo1/otellix) - OpenTelemetry-native LLM observability and budget guardrails for cost-constrained production environments.
 - [routex](https://github.com/Ad3bay0c/routex) - YAML-driven multi-agent AI runtime for Go with Erlang-style supervision, MCP tool server support, and a CLI.
+- [web-researcher-mcp](https://github.com/zoharbabin/web-researcher-mcp) - MCP server providing AI assistants with web search, content extraction, and multi-source research capabilities. Single binary, 5 search providers with circuit-breaker failover, 4-tier scraping pipeline.
 - [zenflow](https://github.com/zendev-sh/zenflow) - Multi-agent orchestration & workflow engine. Declarative YAML workflows, LLM coordinator with hub-and-spoke mailboxes, race-safe delivery. One YAML file, one Go binary. Runs on any goai-supported provider.
 
 **[⬆ back to top](#contents)**


### PR DESCRIPTION
## What is it?

[web-researcher-mcp](https://github.com/zoharbabin/web-researcher-mcp) is an MCP (Model Context Protocol) server written in Go that provides AI assistants with web search, content extraction, and multi-source research capabilities. Single static binary, 5 search providers with circuit-breaker failover, 4-tier scraping pipeline.

## Required Links

Forge link: https://github.com/zoharbabin/web-researcher-mcp
pkg.go.dev: https://pkg.go.dev/github.com/zoharbabin/web-researcher-mcp
goreportcard.com: https://goreportcard.com/report/github.com/zoharbabin/web-researcher-mcp
Coverage: https://app.codecov.io/gh/zoharbabin/web-researcher-mcp

## Checklist

- [x] One item added, in correct category (Artificial Intelligence), alphabetical order
- [x] Link text is exact project name
- [x] Description is concise, non-promotional, ends with period
- [x] Repository has 5+ months of history
- [x] Open source license (MIT)
- [x] Has `go.mod` and SemVer releases (v1.2.0)
- [x] Documentation in English (README + pkg.go.dev)
- [x] Tests with ≥80% coverage
- [x] Actively maintained