### PR TITLE
Add mydml: batch DML tool for MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,6 +850,7 @@ _Data stores with expiring records, in-memory distributed data stores, or in-mem
 - [hasql](https://golang.yandex/hasql) - Library for accessing multi-host SQL database installations.
 - [octillery](https://github.com/knocknote/octillery) - Go package for sharding databases ( Supports every ORM or raw SQL ).
 - [onedump](https://github.com/liweiyi88/onedump) - Database backup from different drivers to different destinations with one command and configuration.
+- [mydml](https://github.com/jackiesre721/mydml) - Batch DELETE/UPDATE/INSERT_SELECT for MySQL with adaptive throttling and replication lag control.
 - [pg_timetable](https://github.com/cybertec-postgresql/pg_timetable) - Advanced scheduling for PostgreSQL.
 - [pgrwl](https://github.com/pgrwl/pgrwl) - Cloud-native continuous backup for PostgreSQL.
 - [pgweb](https://github.com/sosedoff/pgweb) - Web-based PostgreSQL database browser.


### PR DESCRIPTION
## mydml

MySQL large-scale DML tool — batch DELETE / UPDATE / INSERT\_SELECT without locking.

- Splits DML into small batches by **primary key range** (not OFFSET)
- **Adaptive throttling** — replication lag, server load, custom query
- **HTTP control API** — pause / resume / stop at runtime
- **Dry-run** mode and **max-rows** limit
- Pre-flight checks: binlog format, foreign keys, triggers
- Single Go binary, no external dependencies

**Repo:** https://github.com/jackiesre721/mydml
**License:** MIT

Added under `### Database Tools` in alphabetical order between `onedump` and `pg_timetable`.