### PR TITLE
Add mdv — browser-based Markdown viewer with live reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -3586,6 +3586,7 @@ _Software written in Go._
 - [limetext](https://limetext.github.io) - Lime Text is a powerful and elegant text editor primarily developed in Go that aims to be a Free and open-source software successor to Sublime Text.
 - [LiteIDE](https://github.com/visualfc/liteide) - LiteIDE is a simple, open source, cross-platform Go IDE.
 - [mac-cleanup-go](https://github.com/2ykwang/mac-cleanup-go) - Preview-first TUI for cleaning macOS caches, logs, and temporary files.
+- [mdv](https://github.com/Allra-Fintech/mdv) - CLI tool that renders Markdown files in the browser with live reload, GFM, syntax highlighting, Mermaid diagrams, and PDF export.
 - [mockingjay](https://github.com/quii/mockingjay-server) - Fake HTTP servers and consumer driven contracts from one configuration file. You can also make the server randomly misbehave to help do more realistic performance tests.
 - [myLG](https://github.com/mehrdadrad/mylg) - Command Line Network Diagnostic tool written in Go.
 - [naclpipe](https://github.com/unix4fun/naclpipe) - Simple NaCL EC25519 based crypto pipe tool written in Go.


### PR DESCRIPTION
## What is mdv?

[mdv](https://github.com/Allra-Fintech/mdv) is a Go CLI tool that instantly renders a Markdown file in your browser and keeps it live-synced as you edit.

## Key features

- **Live reload via SSE** — no polling; the browser content updates in place without a full page refresh, preserving scroll position.
- **GitHub-flavoured Markdown** — powered by [goldmark](https://github.com/yuin/goldmark) with GFM extensions (tables, strikethrough, task lists, autolinks).
- **Syntax highlighting** — fenced code blocks are highlighted server-side.
- **Mermaid diagrams** — ```` ```mermaid ```` blocks are rendered client-side; the JS is loaded lazily from CDN only when needed.
- **PDF export** — headless Chrome renders the styled page to PDF on demand.
- Single static binary, zero runtime dependencies beyond a browser.

## Why it belongs here

The **Other Software** section already lists browser-based developer tools (e.g. `ide`, `GoDocTooltip`, `Wave Terminal`). `mdv` fits that pattern: it's a self-contained Go binary that serves a useful local development workflow — specifically, distraction-free Markdown previewing with the exact styling developers expect from GitHub.

## Links

Forge link: https://github.com/Allra-Fintech/mdv
pkg.go.dev: https://pkg.go.dev/github.com/Allra-Fintech/mdv
goreportcard.com: https://goreportcard.com/report/github.com/Allra-Fintech/mdv

## Checklist

- [x] Added in alphabetical order under **Other Software**
- [x] Entry follows the existing format: `- [name](url) - Description.`
- [x] Description is concise and ends with a period
- [x] Link points to a public GitHub repository
- [x] The repository contains Go source code with a valid `go.mod`