### PR TITLE
Move tldx to Other Software section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2186,7 +2186,6 @@ _Libraries for making HTTP requests._
 - [rq](https://github.com/ddo/rq) - A nicer interface for golang stdlib HTTP client.
 - [sling](https://github.com/dghubble/sling) - Sling is a Go HTTP client library for creating and sending API requests.
 - [surf](https://github.com/enetx/surf) - Advanced HTTP client with HTTP/1.1, HTTP/2, HTTP/3 (QUIC), SOCKS5 proxy support and browser-grade TLS fingerprinting.
-- [tldx](https://github.com/brandonyoungdev/tldx) - Bulk domain availability checker using RDAP, DNS, and WHOIS fallback with keyword permutation generation.
 - [tls-client](https://github.com/bogdanfinn/tls-client) - net/http.Client like HTTP Client with options to select specific client TLS Fingerprints to use for requests.
 
 **[⬆ back to top](#contents)**
@@ -3612,6 +3611,7 @@ _Software written in Go._
 - [syncthing](https://syncthing.net/) - Open, decentralized file synchronization tool and protocol.
 - [tcpdog](https://github.com/mehrdadrad/tcpdog) - eBPF based TCP observability.
 - [tinycare-tui](https://github.com/DMcP89/tinycare-tui) - Small terminal app that shows git commits from the last 24 hours and week, current weather, some self care advice, a joke, and you current todo list tasks.
+- [tldx](https://github.com/brandonyoungdev/tldx) - Bulk domain availability checker using RDAP, DNS, and WHOIS fallback with keyword permutation generation.
 - [toxiproxy](https://github.com/shopify/toxiproxy) - Proxy to simulate network and system conditions for automated tests.
 - [tsuru](https://tsuru.io/) - Extensible and open source Platform as a Service software.
 - [vaku](https://github.com/lingrino/vaku) - CLI & API for folder-based functions in Vault like copy, move, and search.


### PR DESCRIPTION
tldx was incorrectly placed in the HTTP Clients subsection. This moves it to the correct location: ### Other Software, alphabetically between tinycare-tui and toxiproxy.

tldx is a domain availability CLI tool, not an HTTP client library.

Forge link: https://github.com/brandonyoungdev/tldx
pkg.go.dev: https://pkg.go.dev/github.com/brandonyoungdev/tldx
goreportcard.com: https://goreportcard.com/report/github.com/brandonyoungdev/tldx
Coverage: https://app.codecov.io/gh/brandonyoungdev/tldx