### PR TITLE
Add go-postgres-s3-backup to Database Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,7 @@ _Data stores with expiring records, in-memory distributed data stores, or in-mem
 - [dg](https://github.com/codingconcepts/dg) - A fast data generator that produces CSV files from generated relational data.
 - [gatewayd](https://github.com/gatewayd-io/gatewayd) - Cloud-native database gateway and framework for building data-driven applications. Like API gateways, for databases.
 - [go-mysql](https://github.com/siddontang/go-mysql) - Go toolset to handle MySQL protocol and replication.
+- [go-postgres-s3-backup](https://github.com/nicobistolfi/go-postgres-s3-backup) - Serverless PostgreSQL backups to S3 using AWS Lambda, with daily, monthly, and yearly rotation.
 - [gorm-multitenancy](https://github.com/bartventer/gorm-multitenancy) - Multi-tenancy support for GORM managed databases.
 - [GoSQLX](https://github.com/ajitpratap0/GoSQLX) - High-performance SQL parser, formatter, linter, and security scanner with multi-dialect support and WASM playground.
 - [hasql](https://golang.yandex/hasql) - Library for accessing multi-host SQL database installations.


### PR DESCRIPTION
Adds [go-postgres-s3-backup](https://github.com/nicobistolfi/go-postgres-s3-backup) to the **Database Tools** category. It is a serverless backup solution for PostgreSQL databases that runs on AWS Lambda and rotates daily, monthly, and yearly backups to S3.

Forge link: https://github.com/nicobistolfi/go-postgres-s3-backup
pkg.go.dev: https://pkg.go.dev/github.com/nicobistolfi/go-postgres-s3-backup
goreportcard.com: https://goreportcard.com/report/github.com/nicobistolfi/go-postgres-s3-backup
Coverage: https://app.codecov.io/gh/nicobistolfi/go-postgres-s3-backup

Checklist:
- [x] One PR adds only one item.
- [x] Correct category (Database Tools) and alphabetical order.
- [x] Link text is the exact project name.
- [x] Description is concise, non-promotional, and ends with a period.
- [x] Repo has 5+ months of history, MIT license, a go.mod, and a SemVer release (v1.0.0).