### PR TITLE
Add PikoCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,7 @@ _Tools for help with continuous integration._
 - [goveralls](https://github.com/mattn/goveralls) - Go integration for Coveralls.io continuous code coverage tracking system.
 - [muffet](https://github.com/raviqqe/muffet) - Fast website link checker in Go, see [alternatives](https://github.com/lycheeverse/lychee#features).
 - [overalls](https://github.com/go-playground/overalls) - Multi-Package go project coverprofile for tools like goveralls.
+- [PikoCI](https://github.com/pikoci/pikoci) - Self-hosted CI/CD inspired by Concourse. Single binary, any database, any queue. HCL pipelines, pluggable resource types and runners.
 - [roveralls](https://github.com/LawrenceWoodman/roveralls) - Recursive coverage testing tool.
 - [woodpecker](https://github.com/woodpecker-ci/woodpecker) - Woodpecker is a community fork of the Drone CI system.
 


### PR DESCRIPTION
PikoCI is a self-hosted CI/CD system inspired by Concourse CI. 
Runs as a single binary with no external dependencies required. 
Pluggable database (SQLite, PostgreSQL, MySQL) and queue backends (NATS, Kafka, RabbitMQ).
HCL pipelines, pluggable resource types, runners, service types, and secret backends.
Apache 2.0 licensed.

Forge link: https://github.com/pikoci/pikoci
pkg.go.dev: https://pkg.go.dev/github.com/pikoci/pikoci
goreportcard.com: https://goreportcard.com/report/github.com/pikoci/pikoci
Coverage: https://app.codecov.io/gh/pikoci/pikoci