### PR TITLE
Add Dota AI Coach to Artificial Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ _Libraries for building programs that leverage AI._
 - [ai](https://github.com/joakimcarlsson/ai) - A Go toolkit for building AI agents and applications across multiple providers with unified LLM, embeddings, tool calling, and MCP integration.
 - [chromem-go](https://github.com/philippgille/chromem-go) - Embeddable vector database for Go with Chroma-like interface and zero third-party dependencies. In-memory with optional persistence.
 - [dakera-go](https://github.com/dakera-ai/dakera-go) - Official Go client SDK for the Dakera self-hosted agent memory server, providing typed interfaces for memory store/recall, session management, namespace operations, and decay configuration.
+- [Dota AI Coach](https://github.com/BrightGir/dota-ai-coach) - AI assistant for Dota 2 with real-time game analysis via GSI and advice from LLM.
 - [fun](https://gitlab.com/tozd/go/fun) - The simplest but powerful way to use large language models (LLMs) in Go.
 - [goai](https://github.com/zendev-sh/goai) - Go SDK for building AI applications. One SDK, 20+ providers. Inspired by Vercel AI SDK.
 - [hotplex](https://github.com/hrygo/hotplex) - AI Agent runtime engine with long-lived sessions for Claude Code, OpenCode, pi-mono and other CLI AI tools. Provides full-duplex streaming, multi-platform integrations, and secure sandbox.


### PR DESCRIPTION
Hello! I would like to add Dota AI Coach to the Artificial Intelligence section. It is a real-time AI assistant for Dota 2 that leverages Game State Integration (GSI) and Large Language Models (LLMs) to provide tactical advice. 

Key features:
- Real-time game state parsing in Go.
- RAG-based advice engine using ChromaDB and BERT.
- Tactical overlay UI using Raylib.
- Fully written in Go with comprehensive tests.

Forge link: https://github.com/BrightGir/dota-ai-coach
pkg.go.dev: https://pkg.go.dev/github.com/BrightGir/dota-ai-coach
goreportcard.com: https://goreportcard.com/report/github.com/BrightGir/dota-ai-coach