### PR TITLE
Add fort to DevOps Tools - macOS endpoint security CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3466,6 +3466,7 @@ _Software written in Go._
 - [easyssh-proxy](https://github.com/appleboy/easyssh-proxy) - Golang package for easy remote execution through SSH and SCP downloading via `ProxyCommand`.
 - [fac](https://github.com/mkchoi212/fac) - Command-line user interface to fix git merge conflicts.
 - [Flannel](https://github.com/flannel-io/flannel) - Flannel is a network fabric for containers, designed for Kubernetes.
+- [fort](https://github.com/djadmin/fort) - Audit, fix, and prove macOS endpoint security from one command. 15 checks, auto-remediation, JSON output, and HTML compliance reports.
 - [Fleet device management](https://github.com/fleetdm/fleet) - Lightweight, programmable telemetry for servers and workstations.
 - [gaia](https://github.com/gaia-pipeline/gaia) - Build powerful pipelines in any programming language.
 - [ghorg](https://github.com/gabrie30/ghorg) - Quickly clone an entire org/users repositories into one directory - Supports GitHub, GitLab, Gitea, and Bitbucket.


### PR DESCRIPTION
## fort

**URL:** https://github.com/djadmin/fort

A macOS endpoint security CLI that audits 15 security controls (disk encryption, firewall, screen lock, Gatekeeper, SIP, SSH, local admin rights, AirDrop, sharing services, OS updates, EDR presence), auto-remediates fixable issues, and outputs structured JSON + a self-contained HTML compliance report.

**Section:** DevOps Tools — fits alongside fleet/endpoint management tools like Fleet device management.

- Single static binary, no dependencies
- MIT licensed, open source
- macOS 12+, v0.2.0 released May 2026
- Added alphabetically before Fleet device management