### PR TITLE
Add go-finder (terminal file/folder picker library)

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ _Libraries for building Console Applications and Console User Interfaces._
 - [go-ataman](https://github.com/workanator/go-ataman) - Go library for rendering ANSI colored text templates in terminals.
 - [go-colorable](https://github.com/mattn/go-colorable) - Colorable writer for windows.
 - [go-colortext](https://github.com/daviddengcn/go-colortext) - Go library for color output in terminals.
+- [go-finder](https://github.com/SREsAreHumanToo/go-finder) - Cross-platform terminal file/folder picker with fuzzy search, multi-select, and a preview pane.
 - [go-isatty](https://github.com/mattn/go-isatty) - isatty for golang.
 - [go-palette](https://github.com/abusomani/go-palette) - Go library that provides elegant and convenient style definitions using ANSI colors. Fully compatible & wraps the [fmt library](https://pkg.go.dev/fmt) for nice terminal layouts.
 - [go-prompt](https://github.com/c-bata/go-prompt) - Library for building a powerful interactive prompt, inspired by [python-prompt-toolkit](https://github.com/jonathanslenders/python-prompt-toolkit).


### PR DESCRIPTION
Adds **go-finder**, a cross-platform terminal file/folder picker library built on Bubble Tea, to *Advanced Console UIs* (inserted in alphabetical order between `go-colortext` and `go-isatty`).

- Repository: https://github.com/SREsAreHumanToo/go-finder
- Documentation (pkg.go.dev): https://pkg.go.dev/github.com/SREsAreHumanToo/go-finder
- Go Report Card: https://goreportcard.com/report/github.com/SREsAreHumanToo/go-finder
- Coverage: Codecov · CI: GitHub Actions (passing) · License: MIT · Latest release: v0.2.0

### Checklist
- [x] Added in alphabetical order within its section
- [x] Description has correct grammar and a trailing period
- [x] Repo has a pkg.go.dev link
- [x] Repo has a coverage service (Codecov)
- [x] Repo has continuous integration (GitHub Actions)
- [x] Repo's tests are passing
- [x] Repo has a stable tagged release (v0.2.0)