### PR TITLE
Add infracanvas to DevOps Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -3489,6 +3489,7 @@ _Software written in Go._
 - [GVM](https://github.com/moovweb/gvm) - GVM provides an interface to manage Go versions.
 - [Hey](https://github.com/rakyll/hey) - Hey is a tiny program that sends some load to a web application.
 - [httpref](https://github.com/dnnrly/httpref) - httpref is a handy CLI reference for HTTP methods, status codes, headers, and TCP and UDP ports.
+- [infracanvas](https://github.com/bytestrix/InfraCanvas) - Live visual map of containers, pods, volumes, and deployments on any Linux server.
 - [jcli](https://github.com/jenkins-zh/jenkins-cli) - Jenkins CLI allows you manage your Jenkins as an easy way.
 - [k0s](https://github.com/k0sproject/k0s) - Zero Friction Kubernetes distribution.
 - [k3d](https://github.com/k3d-io/k3d) - Little helper to run CNCF's k3s in Docker.


### PR DESCRIPTION
**InfraCanvas** is a single Go binary that discovers and live-visualizes every container, pod, volume, network, and deployment on a Linux host.

- Written in Go with embedded Next.js UI (static export)
- WebSocket-powered live dashboard
- Supports Docker + Kubernetes (pods/deployments/statefulsets/daemonsets)
- AGPL-3.0 license, actively maintained

Forge link: https://github.com/bytestrix/InfraCanvas
pkg.go.dev: https://pkg.go.dev/github.com/bytestrix/InfraCanvas
goreportcard.com: https://goreportcard.com/report/github.com/bytestrix/InfraCanvas
