### PR TITLE
Add go-cron (netresearch) - cron job scheduler, successor to robfig/cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -1583,6 +1583,7 @@ _Libraries for scheduling jobs._
 - [clockwerk](https://github.com/onatm/clockwerk) - Go package to schedule periodic jobs using a simple, fluent syntax.
 - [cronticker](https://github.com/krayzpipes/cronticker) - A ticker implementation to support cron schedules.
 - [go-cron](https://github.com/rk/go-cron) - Simple Cron library for go that can execute closures or functions at varying intervals, from once a second to once a year on a specific date and time. Primarily for web applications and long running daemons.
+- [go-cron](https://github.com/netresearch/go-cron) - Cron job scheduler with runtime schedule updates, per-entry context, resilience middleware (retry, circuit breaker, rate limiting), and observability hooks; successor to robfig/cron.
 - [go-job](https://github.com/cybergarage/go-job) - A flexible and extensible job scheduling and execution library for Go.
 - [go-quartz](https://github.com/reugn/go-quartz) - Simple, zero-dependency scheduling library for Go.
 - [go-scheduler](https://github.com/pardnchiu/go-scheduler) - Job scheduler supporting standard cron expressions, custom descriptors, intervals, and task dependencies.


### PR DESCRIPTION
## Required links

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/netresearch/go-cron
- [x] pkg.go.dev: https://pkg.go.dev/github.com/netresearch/go-cron
- [x] goreportcard.com: https://goreportcard.com/report/github.com/netresearch/go-cron
- [x] Coverage service link (codecov, coveralls, etc.): https://app.codecov.io/gh/netresearch/go-cron

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

- [x] `go.mod` file and SemVer release (v0.15.0)
- [x] Open source license (MIT)
- [x] pkg.go.dev link in docs
- [x] goreportcard link (grade A+)
- [x] Coverage service link (Codecov)
- [x] Continuous integration (GitHub Actions)
- [x] CI runs tests required to pass before merge

## Pull Request content

- [x] Adds only one package.
- [x] Added in alphabetical order.
- [x] Link text is the exact project name.
- [x] Description is clear, concise, non-promotional, and ends with a period.
- [x] The link in README.md matches the forge link above.

## Category quality

I reviewed the neighboring Job Scheduler entries and placed my addition in correct alphabetical order. This PR intentionally changes only one entry (the addition).
