### PR TITLE
Add ofelia to Job Scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1593,6 +1593,7 @@ _Libraries for scheduling jobs._
 - [gronx](https://github.com/adhocore/gronx) - Cron expression parser, task runner and daemon consuming crontab like task list.
 - [JobRunner](https://github.com/bamzi/jobrunner) - Smart and featureful cron job scheduler with job queuing and live monitoring built in.
 - [leprechaun](https://github.com/kilgaloon/leprechaun) - Job scheduler that supports webhooks, crons and classic scheduling.
+- [ofelia](https://github.com/netresearch/ofelia) - Docker job scheduler (crontab for Docker); fork of mcuadros/ofelia that adds a web UI, job dependencies, retries, and job persistence.
 - [pending](https://github.com/kahoon/pending) - ID-based debounced task scheduler for deferred tasks with cancellation, graceful shutdown, and optional concurrency limits.
 - [sched](https://github.com/romshark/sched) - A job scheduler with the ability to fast-forward time.
 - [scheduler](https://github.com/carlescere/scheduler) - Cronjobs scheduling made easy.


### PR DESCRIPTION
## Required links

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/netresearch/ofelia
- [x] pkg.go.dev: https://pkg.go.dev/github.com/netresearch/ofelia
- [x] goreportcard.com: https://goreportcard.com/report/github.com/netresearch/ofelia
- [x] Coverage service link (codecov, coveralls, etc.): https://app.codecov.io/gh/netresearch/ofelia

## Pre-submission checklist

- [x] I have read the Contribution Guidelines
- [x] I have read the Quality Standards

## Repository requirements

- [x] `go.mod` file and SemVer release (v0.25.1)
- [x] Open source license (MIT)
- [x] pkg.go.dev link in docs
- [x] goreportcard link (grade A+)
- [x] Coverage service link
- [x] Continuous integration (GitHub Actions)

## Pull Request content

- [x] Adds only one package.
- [x] Added in alphabetical order.
- [x] Link text is the exact project name.
- [x] Description is clear, concise, non-promotional, and ends with a period.
- [x] The link in README.md matches the forge link above.

## Note on the fork relationship

The entry openly states this is a fork of `mcuadros/ofelia` (mirroring the existing `gocron` entry's "actively maintained fork of jasonlvhit/gocron" convention). It is independently and actively developed: it adds a web UI, job dependencies, retries, job persistence, graceful shutdown, and multi-service webhook notifications, with 40+ SemVer releases. Upstream is currently in dependency-update maintenance, so the listed features do not exist there.
