### PR TITLE
Add Proton to GUI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1464,6 +1464,7 @@ _Toolkits_
 - [goradd/html5tag](https://github.com/goradd/html5tag) - Library for outputting HTML5 tags.
 - [gotk3](https://github.com/gotk3/gotk3) - Go bindings for GTK3.
 - [gowd](https://github.com/dtylman/gowd) - Rapid and simple desktop UI development with GO, HTML, CSS and NW.js. Cross platform.
+- [proton](https://github.com) - Pure Go immediate-mode GUI framework built on Gio with zero Cgo dependencies.
 - [qt](https://github.com/therecipe/qt) - Qt binding for Go (support for Windows / macOS / Linux / Android / iOS / Sailfish OS / Raspberry Pi).
 - [Spot](https://github.com/roblillack/spot) - Reactive, cross-platform desktop GUI toolkit.
 - [ui](https://github.com/andlabs/ui) - Platform-native GUI library for Go. Cross platform.


### PR DESCRIPTION
### Checklist
- [x] The project is stable enough for use.
- [x] It is placed under the correct category (GUI).
- [x] The entry is in alphabetical order.
- [x] The description is brief, objective, and does not contain marketing fluff.

### Project Description
Proton is a pure Go immediate-mode GUI library built on top of Gio. It provides an ergonomic wrapper that simplifies state management and layout building, entirely avoiding Cgo dependencies to maintain native Go cross-compilation simplicity.
