### PR TITLE
Fix libopenapi alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -2843,8 +2843,8 @@ _Libraries for accessing third party APIs._
 - [jokeapi-go](https://github.com/icelain/jokeapi) - Go client for [JokeAPI](https://sv443.net/jokeapi/v2/).
 - [lark](https://github.com/chyroc/lark) - [Feishu](https://open.feishu.cn/)/[Lark](https://open.larksuite.com/) Open API Go SDK, Support ALL Open API and Event Callback.
 - [lastpass-go](https://github.com/ansd/lastpass-go) - Go client library for the [LastPass](https://www.lastpass.com/) API.
-- [libopenapi](https://github.com/pb33f/libopenapi) - Parse, validate, and work with OpenAPI, Swagger, Overlays, and Arazzo specifications.
 - [libgoffi](https://github.com/clevabit/libgoffi) - Library adapter toolbox for native [libffi](https://sourceware.org/libffi/) integration
+- [libopenapi](https://github.com/pb33f/libopenapi) - Parse, validate, and work with OpenAPI, Swagger, Overlays, and Arazzo specifications.
 - [Medium](https://github.com/Medium/medium-sdk-go) - Golang SDK for Medium's OAuth2 API.
 - [megos](https://github.com/andygrunwald/megos) - Client library for accessing an [Apache Mesos](https://mesos.apache.org/) cluster.
 - [minio-go](https://github.com/minio/minio-go) - Minio Go Library for Amazon S3 compatible cloud storage.


### PR DESCRIPTION
This follow-up fixes the alphabetical placement of `libopenapi` after #6379 was auto-merged before the branch update landed. The repo test expected `libgoffi` before `libopenapi` in Third-party APIs.

Forge link: https://github.com/pb33f/libopenapi
pkg.go.dev: https://pkg.go.dev/github.com/pb33f/libopenapi
goreportcard.com: https://goreportcard.com/report/github.com/pb33f/libopenapi
Coverage: https://codecov.io/gh/pb33f/libopenapi

Validation:

- `git diff --check`
- verified a single `libopenapi` README entry remains

Local Go is not installed in this environment, so the upstream test workflow is the authoritative Go check for this reorder.