### PR TITLE
feat: add TWZRD Agent Intel MCP server to Artificial Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ _Libraries for building programs that leverage AI._
 - [OllamaFarm](https://github.com/presbrey/ollamafarm) - Manage, load-balance, and failover packs of Ollamas.
 - [otellix](https://github.com/oluwajubelo1/otellix) - OpenTelemetry-native LLM observability and budget guardrails for cost-constrained production environments.
 - [routex](https://github.com/Ad3bay0c/routex) - YAML-driven multi-agent AI runtime for Go with Erlang-style supervision, MCP tool server support, and a CLI.
+- [twzrd-agent-intel](https://intel.twzrd.xyz) - Solana-native x402 MCP server for AI agent trust scoring. Score any Solana wallet with 4 free preflight tools; pay-per-call `get_trust_receipt` delivers a signed receipt via HTTP 402 + on-chain USDC. Remote streamable HTTP — no install: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 - [web-researcher-mcp](https://github.com/zoharbabin/web-researcher-mcp) - MCP server providing AI assistants with web search, content extraction, and multi-source research capabilities. Single binary, 5 search providers with circuit-breaker failover, 4-tier scraping pipeline.
 - [zenflow](https://github.com/zendev-sh/zenflow) - Multi-agent orchestration & workflow engine. Declarative YAML workflows, LLM coordinator with hub-and-spoke mailboxes, race-safe delivery. One YAML file, one Go binary. Runs on any goai-supported provider.
 


### PR DESCRIPTION
## What

Adds [twzrd-agent-intel](https://intel.twzrd.xyz) to the **Artificial Intelligence** section, in alphabetical order before `web-researcher-mcp`.

## Why

TWZRD Agent Intel is a remote MCP server for AI agent trust scoring. It is relevant to the Go AI section because:

1. Go agents (using `langchaingo`, `agent-sdk-go`, etc.) can plug it in via standard MCP config with no SDK changes
2. Implements the HTTP 402 / x402 pay-per-call pattern that Go AI agent developers are starting to adopt

**Tools provided:**
- `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt` — free, no auth
- `get_trust_receipt` — returns signed `twzrd.receipt.v5` via HTTP 402 + USDC on Solana

**Config (works in any MCP client):**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

Remote streamable HTTP — zero install.