### PR TITLE
feat: add drift terminal screensaver

### DIFF
--- a/README.md
+++ b/README.md
@@ -3575,6 +3575,7 @@ _Software written in Go._
 - [CrunchyCleaner](https://github.com/Knuspii/CrunchyCleaner) - A lightweight, software cache cleanup tool for Windows & Linux.
 - [Documize](https://github.com/documize/community) - Modern wiki software that integrates data from SaaS tools.
 - [dp](https://github.com/scryinfo/dp) - Through SDK for data exchange with blockchain, developers can get easy access to DAPP development.
+- [drift](https://github.com/phlx0/drift) - Terminal screensaver with 13 animated scenes and 9 color themes.
 - [drive](https://github.com/odeke-em/drive) - Google Drive client for the commandline.
 - [Duplicacy](https://github.com/gilbertchen/duplicacy) - A cross-platform network and cloud backup tool based on the idea of lock-free deduplication.
 - [fjira](https://github.com/mk-5/fjira) - A fuzzy-search based terminal UI application for Attlasian Jira


### PR DESCRIPTION
**drift** is a terminal screensaver written in Go with 13 animated scenes and 9 color themes. Single binary, no CGO. Uses tcell/v2 for rendering with true color, 256-color, and 8-color degradation.

- Repository: https://github.com/phlx0/drift
- pkg.go.dev: https://pkg.go.dev/github.com/phlx0/drift
- Go Report Card: https://goreportcard.com/report/github.com/phlx0/drift
- Coverage: not tracked via Codecov or Coveralls; project is a TUI application

**Checklist:**

- [x] Single item per PR
- [x] Alphabetical order in Other Software section (between `dp` and `drive`)
- [x] Description ends with a period
- [x] open source license (MIT)
- [x] go.mod present
- [x] SemVer releases present (v0.1.0 through v0.11.0)
- [x] README present