### PR TITLE
Update Ollama link to canonical repository (jmorganca → ollama)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ _Libraries for building programs that leverage AI._
 - [langgraphgo](https://github.com/smallnest/langgraphgo) - A Go library for building stateful, multi-actor applications with LLMs, built on the concept of LangGraph，with a lot of builtin Agent architectures.
 - [LocalAI](https://github.com/mudler/LocalAI) - Open Source OpenAI alternative, self-host AI models.
 - [localaik](https://github.com/harshaneel/localaik) - LocalStack-style local emulation of OpenAI and Gemini APIs; single Docker container, llama.cpp + Gemma 3 backend.
-- [Ollama](https://github.com/jmorganca/ollama) - Run large language models locally.
+- [Ollama](https://github.com/ollama/ollama) - Run large language models locally.
 - [OllamaFarm](https://github.com/presbrey/ollamafarm) - Manage, load-balance, and failover packs of Ollamas.
 - [otellix](https://github.com/oluwajubelo1/otellix) - OpenTelemetry-native LLM observability and budget guardrails for cost-constrained production environments.
 - [routex](https://github.com/Ad3bay0c/routex) - YAML-driven multi-agent AI runtime for Go with Erlang-style supervision, MCP tool server support, and a CLI.


### PR DESCRIPTION
## What

The Ollama entry currently points to the old repository at `github.com/jmorganca/ollama`. The project was renamed/moved to the `ollama` org and the old URL only works via GitHub's redirect.

This PR updates the link to the canonical location: <https://github.com/ollama/ollama>.

## Why

- The repository moved from `jmorganca/ollama` to `ollama/ollama` some time ago.
- `https://github.com/jmorganca/ollama` still resolves (HTTP 200 → `ollama/ollama`) but only because GitHub keeps a transparent redirect. Listing the canonical URL is more accurate and avoids depending on the redirect being preserved.
- No description or other content changes — just the URL.

## Verification

```
$ curl -s -o /dev/null -w "%{http_code} %{url_effective}\n" -L https://github.com/jmorganca/ollama
200 https://github.com/ollama/ollama

$ gh api repos/ollama/ollama --jq '{full_name, archived, stars: .stargazers_count}'
{"archived": false, "full_name": "ollama/ollama", "stars": 173470}
```

## Checklist

- [x] Only one item is changed.
- [x] Alphabetical order is preserved (entry stays in the same position).
- [x] Link text (`Ollama`) is unchanged.
- [x] Description is unchanged and still ends with a period.
- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines) and the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).

This is a link-only correction, so the package's quality standards (license, go.mod, releases, pkg.go.dev, Go Report Card, coverage) are unchanged from when the entry was originally accepted.