### PR TITLE
Add mcp-go to Artificial Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ _Libraries for building programs that leverage AI._
 - [langgraphgo](https://github.com/smallnest/langgraphgo) - A Go library for building stateful, multi-actor applications with LLMs, built on the concept of LangGraph，with a lot of builtin Agent architectures.
 - [LocalAI](https://github.com/mudler/LocalAI) - Open Source OpenAI alternative, self-host AI models.
 - [localaik](https://github.com/harshaneel/localaik) - LocalStack-style local emulation of OpenAI and Gemini APIs; single Docker container, llama.cpp + Gemma 3 backend.
+- [mcp-go](https://github.com/mark3labs/mcp-go) - Go implementation of the Model Context Protocol for building MCP servers and clients in Go.
 - [Ollama](https://github.com/jmorganca/ollama) - Run large language models locally.
 - [OllamaFarm](https://github.com/presbrey/ollamafarm) - Manage, load-balance, and failover packs of Ollamas.
 - [otellix](https://github.com/oluwajubelo1/otellix) - OpenTelemetry-native LLM observability and budget guardrails for cost-constrained production environments.


### PR DESCRIPTION
## Required links

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/mark3labs/mcp-go
- [x] pkg.go.dev: https://pkg.go.dev/github.com/mark3labs/mcp-go
- [x] goreportcard.com: https://goreportcard.com/report/github.com/mark3labs/mcp-go
- [x] Coverage service link: https://app.codecov.io/gh/mark3labs/mcp-go

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`) — latest is `v0.54.1`.
- [x] The repo has an open source license — MIT.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link (grade **A+**).
- [x] The repo documentation has a coverage service link (Codecov).

Recommended:

- [x] The repo has a continuous integration process (GitHub Actions).
- [x] CI runs tests that must pass before merging.

## Pull Request content

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order** (`localaik` < `mcp-go` < `Ollama`).
- [x] The link text is the **exact project name** (`mcp-go`).
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.

## Why this is a good fit

mcp-go is the de-facto Go implementation of the [Model Context Protocol](https://modelcontextprotocol.io). The MCP specification has become a standard way for LLM applications to talk to external tools and data sources, and several entries already in this section mention MCP support (e.g. `agent-sdk-go`, `ai`, `routex`, `web-researcher-mcp`). A dedicated Go implementation entry feels like a natural fit.

- ~9k stars, first commit Nov 2024, actively maintained (latest release `v0.54.1`, May 2026).
- Tracks recent MCP spec versions (currently `2025-11-25` with back-compat for `2025-06-18`, `2025-03-26`, `2024-11-05`).
- Provides both server and client libraries with stdio, SSE, and streamable-HTTP transports.
- Used in production by a number of MCP servers in the Go ecosystem.

Thanks for considering!