### PR TITLE
Add GoLogX to Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1670,6 +1670,7 @@ _Libraries for generating and working with log files._
 - [go-log](https://github.com/siddontang/go-log) - Log lib supports level and multi handlers.
 - [go-log](https://github.com/ian-kent/go-log) - Log4j implementation in Go.
 - [go-logger](https://github.com/apsdehal/go-logger) - Simple logger of Go Programs, with level handlers.
+- [GoLogX](https://github.com/AyoubTadlaoui/GoLogX) - Append-only, hash-chained, optionally Ed25519-signed slog handler with offline verification of tampering.
 - [gone/log](https://github.com/One-com/gone/tree/master/log) - Fast, extendable, full-featured, std-lib source compatible log library.
 - [httpretty](https://github.com/henvic/httpretty) - Pretty-prints your regular HTTP requests on your terminal for debugging (similar to http.DumpRequest).
 - [journald](https://github.com/ssgreg/journald) - Go implementation of systemd Journal's native API for logging.


### PR DESCRIPTION
Adds **GoLogX** to the Logging section.

GoLogX is a tamper-evident `log/slog` handler: it writes an append-only, hash-chained, optionally Ed25519-signed log, and the `logx verify` command checks a log offline and reports the first entry that was edited, deleted, reordered, or forged. Standard library only, no external dependencies, Go 1.22+.

Make sure that you've checked the boxes below before submitting:

- [x] I have read the Contribution Guidelines, the Maintainers Note, and the Quality Standards.
- [x] I searched for duplicates; GoLogX is not already listed.
- [x] Only one package is added in this PR.
- [x] The package is added in alphabetical order (between `go-logger` and `gone/log` in Logging).
- [x] The link text is the exact project name and uses HTTPS.
- [x] The description is clear, concise, non-promotional, and ends with a period.
- [x] The repo has been around well over a month (created April 2024).
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo documentation has a coverage service link.
- [x] CI is green (build, go vet, gofmt, race tests, and golangci-lint on Go 1.22 and 1.23).

Required links:

- Forge link: https://github.com/AyoubTadlaoui/GoLogX
- pkg.go.dev: https://pkg.go.dev/github.com/AyoubTadlaoui/GoLogX/logx
- goreportcard.com: https://goreportcard.com/report/github.com/AyoubTadlaoui/GoLogX
- Coverage (Codecov): https://app.codecov.io/gh/AyoubTadlaoui/GoLogX
