### PR TITLE
Add fort to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -2384,6 +2384,7 @@ _Libraries that are used to help make your application more secure._
 - [encid](https://github.com/bobg/encid) - Encode and decode encrypted integer IDs.
 - [entpassgen](https://github.com/andreimerlescu/entpassgen) - Entropy Password Generator with extensive command line arguments to generate random strings securely including digits, passwords, and passwords built using obscure dictionary words mixed with symbols and digits.
 - [firewalld-rest](https://github.com/prashantgupta24/firewalld-rest) - A rest application to dynamically update firewalld rules on a linux server.
+- [fort](https://github.com/djadmin/fort) - Audits macOS security settings across 16 checks, reports a score, and fixes issues where it safely can. Single binary, installable via Homebrew.
 - [go-generate-password](https://github.com/m1/go-generate-password) - Password generator that can be used on the cli or as a library.
 - [go-htpasswd](https://github.com/tg123/go-htpasswd) - Apache htpasswd Parser for Go.
 - [go-password-validator](https://github.com/lane-c-wagner/go-password-validator) - Password validator based on raw cryptographic entropy values.


### PR DESCRIPTION
fort is a macOS security auditing CLI. It runs 16 checks covering FileVault, SIP, firewall, Gatekeeper, SSH hardening, and more, reports a pass/fail score, and can auto-fix issues where safe to do so.

- Single static binary, installable via Homebrew
- MIT licensed
- Written in Go

Forge link: https://github.com/djadmin/fort
pkg.go.dev: https://pkg.go.dev/github.com/djadmin/fort
goreportcard.com: https://goreportcard.com/report/github.com/djadmin/fort