### PR TITLE
Add mdsmith to Markup Languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2697,6 +2697,7 @@ See also [Natural Language Processing](#natural-language-processing) and [Text A
 - [htmlquery](https://github.com/antchfx/htmlquery) - An XPath query package for HTML, lets you extract data or evaluate from HTML documents by an XPath expression.
 - [htmlyaml](https://github.com/nikolaydubina/htmlyaml) - Rich rendering of YAML as HTML in Go.
 - [htree](https://github.com/bobg/htree) - Traverse, navigate, filter, and otherwise process trees of [html.Node](https://pkg.go.dev/golang.org/x/net/html#Node) objects.
+- [mdsmith](https://github.com/jeduden/mdsmith) - fast, auto-fixing Markdown linter and formatter. Checks style, readability, structure, and cross-file integrity.
 - [mxj](https://github.com/clbanning/mxj) - Encode / decode XML as JSON or map[string]interface{}; extract values with dot-notation paths and wildcards. Replaces x2j and j2x packages.
 - [toml](https://github.com/BurntSushi/toml) - TOML configuration format (encoder/decoder with reflection).
 


### PR DESCRIPTION
Add [mdsmith](https://github.com/jeduden/mdsmith) fast, auto-fixing Markdown linter and formatter. Checks style, readability, structure, and cross-file integrity.Code Analysis


Website: https://mdsmith.dev

[![Quality][grc-badge]][grc-link]
[![Coverage][cov-badge]][cov-link]

Maturity: 
- 5 Months old. [First commit 8 February 2026]( https://github.com/jeduden/mdsmith/commit/3716204e66e80d432129abfb54a93f79357f9d5f#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7 ) 
- 2600 Commits


## Required links

Forge link: https://github.com/jeduden/mdsmith
pkg.go.dev: https://pkg.go.dev/github.com/jeduden/mdsmith
goreportcard.com: https://goreportcard.com/report/github.com/jeduden/mdsmith
Coverage service link: https://codecov.io/gh/jeduden/mdsmith
License: [MIT](https://github.com/jeduden/mdsmith/blob/main/LICENSE)

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

_These are validated automatically by CI:_

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`).
- [x] The repo has an open source license.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link (grade A- or better).
- [x] The repo documentation has a coverage service link.

_These are recommended and reported as warnings:_

- [x] The repo has a continuous integration process (GitHub Actions, etc.).
- [x] CI runs tests that must pass before merging.

## Pull Request content

_These are validated automatically by CI:_

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**.
- [x] The link text is the **exact project name**.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.


---
[grc-badge]: https://goreportcard.com/badge/github.com/jeduden/mdsmith
[grc-link]: https://goreportcard.com/report/github.com/jeduden/mdsmith
[cov-badge]: https://codecov.io/gh/jeduden/mdsmith/branch/main/graph/badge.svg
[cov-link]: https://codecov.io/gh/jeduden/mdsmith/branch/main