### PR TITLE
Add sqlh to SQL Query Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,7 @@ _Libraries for building and using SQL._
 - [sq](https://github.com/bokwoon95/go-structured-query) - Type-safe SQL builder and struct mapper for Go.
 - [sqlc](https://github.com/kyleconroy/sqlc) - Generate type-safe code from SQL.
 - [sqlf](https://github.com/leporo/sqlf) - Fast SQL query builder.
+- [sqlh](https://github.com/kirill-scherba/sqlh) - Zero-boilerplate SQL helper with struct tags and Go generics (CRUD, UPSERT, JOIN, benchmarks).
 - [sqlingo](https://github.com/lqs/sqlingo) - A lightweight DSL to build SQL in Go.
 - [sqrl](https://github.com/elgris/sqrl) - SQL query builder, fork of Squirrel with improved performance.
 - [Squalus](https://gitlab.com/qosenergy/squalus) - Thin layer over the Go SQL package that makes it easier to perform queries.


### PR DESCRIPTION
**Please provide package links to:**

- repo: https://github.com/kirill-scherba/sqlh
- pkg.go.dev: https://pkg.go.dev/github.com/kirill-scherba/sqlh
- goreportcard.com: https://goreportcard.com/report/github.com/kirill-scherba/sqlh
- coverage: https://github.com/kirill-scherba/sqlh/actions/workflows/test.yml (CI runs on push/PR; coverage via `go test -cover`)

Forge link: https://github.com/kirill-scherba/sqlh
Coverage: https://github.com/kirill-scherba/sqlh/actions/workflows/test.yml

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order within its category.
- [x] I have an appropriate description with correct grammar and punctuation.
- [x] I know that this package was not listed before.
- [x] I have added a link to the repo, pkg.go.dev, Go Report Card, and CI coverage.

**Description:**

`sqlh` is a lightweight, zero-boilerplate SQL helper for Go that leverages Go generics (Go 1.25+) to provide type-safe CRUD functions (`Insert`, `Get`, `List`, `Update`, `Delete`, `Set`) working directly with structs. It auto-generates SQL from struct tags (`db`, `db_type`, `db_key`), supports native UPSERT for SQLite/PostgreSQL/MySQL, JOIN queries with composite structs, advanced WHERE helpers (`Eq`, `Ne`, `Gt`, `Like`, `In`, `IsNull`, etc.), and includes comparative benchmarks against raw `database/sql`, `sqlx`, and GORM.