### PR TITLE
add hookun to [Webhooks Server]

### DIFF
--- a/README.md
+++ b/README.md
@@ -3292,6 +3292,7 @@ _Full stack web frameworks._
 ## Webhooks Server
 
 - [webhook](https://github.com/adnanh/webhook) - Tool which allows user to create HTTP endpoints (hooks) that execute commands on the server.
+- [HookRun](https://github.com/bluvenr/hookrun) - Lightweight webhook action engine (~3MB single binary, zero deps) that executes commands and scripts from YAML rules with token/HMAC/IP auth and hot reload.
 - [webhooked](https://github.com/42Atomys/webhooked) - A webhook receiver on steroids: handle, secure, format and store a Webhook payload has never been easier.
 - [WebhookX](https://github.com/webhookx-io/webhookx) - A webhooks gateway for message receiving, processing, and reliable delivering.
 


### PR DESCRIPTION
Hi, I'd like to propose adding **HookRun** to the **Webhooks Server** category.

HookRun is a lightweight webhook action engine written in Go. It receives webhook requests and executes custom commands or scripts based on YAML-defined rules. Key highlights:

- **~3MB single binary** with zero runtime dependencies — no Docker, no database required
- **Multi-layer authentication** — Token, HMAC signature, and IP whitelist (AND-combined)
- **Execution policies** — `block` (prevent concurrency), `always` (always trigger), `cooldown` (rate limiting)
- **File-based routing** — `/webhook/{filename}` maps directly to a YAML config file
- **Hot reload** — watches config directory for changes, zero-config, zero-downtime
- **Built-in daemon management** — `start`, `stop`, `status` CLI commands out of the box

It's designed for developers who need a simple, reliable bridge between webhook events (Git push, CI triggers, monitoring alerts) and server-side actions — without the overhead of container orchestration or workflow engines.

- [x] Forge link: https://github.com/bluvenr/hookrun
- [x] pkg.go.dev: https://pkg.go.dev/github.com/bluvenr/hookrun
- [x] goreportcard.com: https://goreportcard.com/report/github.com/bluvenr/hookrun
- [x] Coverage service link: https://app.codecov.io/gh/bluvenr/hookrun
