### PR TITLE
Add GooseForum (forum platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3598,6 +3598,7 @@ _Software written in Go._
 - [Gokapi](https://github.com/Forceu/gokapi) - Lightweight server to share files, which expire after a set amount of downloads or days. Similar to Firefox Send, but without public upload.
 - [GoLand](https://jetbrains.com/go) - Full featured cross-platform Go IDE.
 - [GoNB](https://github.com/janpfeifer/gonb) - Interactive Go programming with Jupyter Notebooks (also works in VSCode, Binder and Google's Colab).
+- [GooseForum](https://github.com/leancodebox/GooseForum) - Self-hosted forum platform built with Go, Vue, and Tailwind CSS.
 - [Gor](https://github.com/buger/gor) - Http traffic replication tool, for replaying traffic from production to stage/dev environments in real-time.
 - [Guora](https://github.com/meloalright/guora) - A self-hosted Quora like web application written in Go.
 - [hoofli](https://github.com/dnnrly/hoofli) - Generate PlantUML diagrams from Chrome or Firefox network inspections.


### PR DESCRIPTION
Adds GooseForum, a self-hosted forum platform built with Go, Vue, and Tailwind CSS, to Other Software.

Forge link: https://github.com/leancodebox/GooseForum
pkg.go.dev: https://pkg.go.dev/github.com/leancodebox/GooseForum
goreportcard.com: https://goreportcard.com/report/github.com/leancodebox/GooseForum
Coverage: https://app.codecov.io/gh/leancodebox/GooseForum
CI: GitHub Actions
License: MIT
Latest release: v0.2.32

Checklist

- Added in alphabetical order within its section
- Description has correct grammar and a trailing period
- Repo has a pkg.go.dev link
- Repo has a coverage service (Codecov)
- Repo has continuous integration (GitHub Actions)
- Repo's tests are passing
- Repo has a stable tagged release (v0.2.32)