### PR TITLE
add confluence2md to Data Integration Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ _Frameworks for performing ELT / ETL_
 
 - [Benthos](https://github.com/benthosdev/benthos) - A message streaming bridge between a range of protocols.
 - [CloudQuery](http://github.com/cloudquery/cloudquery) - A high-performance ELT data integration framework with pluggable architecture.
+- [confluence2md](https://github.com/gkoos/confluence2md) - Confluence to Markdown crawler and converter.
 - [omniparser](https://github.com/jf-tech/omniparser) - A versatile ETL library that parses text input (CSV/txt/JSON/XML/EDI/X12/EDIFACT/etc) in streaming fashion and transforms data into JSON output using data-driven schema.
 
 **[⬆ back to top](#contents)**


### PR DESCRIPTION
## Required links

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/gkoos/confluence2md
- [x] pkg.go.dev: https://pkg.go.dev/github.com/gkoos/confluence2md
- [x] goreportcard.com: https://goreportcard.com/report/github.com/gkoos/confluence2md
- [ ] Coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): intentionally omitted

## Pre-submission checklist

- [x] I have read the Contribution Guidelines
- [x] I have read the Quality Standards

## Pull Request content

- [x] This PR adds/removes/changes only one package.
- [x] The package has been added in alphabetical order.
- [x] The link text is the exact project name.
- [x] The description is clear, concise, non-promotional, and ends with a period.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.

## Summary

Adds confluence2md under Data Integration Frameworks between CloudQuery and omniparser.