### PR TITLE
Add httper to Testing Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2604,6 +2604,7 @@ _Libraries for testing codebases and generating test data._
 - [got](https://github.com/ysmood/got) - An enjoyable golang test framework.
 - [gotest.tools](https://github.com/gotestyourself/gotest.tools) - A collection of packages to augment the go testing package and support common patterns.
 - [Hamcrest](https://github.com/rdrdr/hamcrest) - fluent framework for declarative Matcher objects that, when applied to input values, produce self-describing results.
+- [httper](https://github.com/gustofarbi/httper) - CLI runner for JetBrains .http files with scripting, assertions, gRPC, and load testing.
 - [httpexpect](https://github.com/gavv/httpexpect) - Concise, declarative, and easy to use end-to-end HTTP and REST API testing.
 - [is](https://github.com/matryer/is) - Professional lightweight testing mini-framework for Go.
 - [jsonassert](https://github.com/kinbiko/jsonassert) - Package for verifying that your JSON payloads are serialized correctly.


### PR DESCRIPTION
Adding [httper](https://github.com/gustofarbi/httper), a CLI runner for JetBrains `.http` files: variable/env resolution, JS pre/post-request scripts with `client.test` assertions, gRPC via server reflection, and `@vegeta` load testing. CI-friendly exit codes plus JUnit/JSON reports.

Forge link: https://github.com/gustofarbi/httper
pkg.go.dev: https://pkg.go.dev/github.com/gustofarbi/httper
goreportcard.com: https://goreportcard.com/report/github.com/gustofarbi/httper
Coverage (Codecov): https://app.codecov.io/gh/gustofarbi/httper

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] The package has tests and CI.

License: MIT. First commit 2024-05-11 (> 5 months of history).
