### PR TITLE
remove defunct encdec repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2715,7 +2715,6 @@ See also [Natural Language Processing](#natural-language-processing) and [Text A
 - [did](https://github.com/ockam-network/did) - DID (Decentralized Identifiers) Parser and Stringer in Go.
 - [doi](https://github.com/hscells/doi) - Document object identifier (doi) parser in Go.
 - [editorconfig-core-go](https://github.com/editorconfig/editorconfig-core-go) - Editorconfig file parser and manipulator for Go.
-- [encdec](https://github.com/mickep76/encdec) - Package provides a generic interface to encoders and decoders.
 - [go-fasttld](https://github.com/elliotwutingfeng/go-fasttld) - High performance effective top level domains (eTLD) extraction module.
 - [go-nmea](https://github.com/adrianmo/go-nmea) - NMEA parser library for the Go language.
 - [go-querystring](https://github.com/google/go-querystring) - Go library for encoding structs into URL query parameters.


### PR DESCRIPTION
Reason for Removal
The `encdec` repository has been deleted and returns a 404 error.

Notification
Notifying the author to give them an opportunity to respond: @mickep76