### PR TITLE
remove defunct connexions repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2630,7 +2630,6 @@ _Libraries for testing codebases and generating test data._
 
 ### Mock
 
-- [connexions](https://github.com/cubahno/connexions) - Combine multiple APIs with meaningful responses, configurable latency and error codes based on OpenAPI 3.0 specifications and files.
 - [counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) - Tool for generating self-contained mock objects.
 - [genmock](https://gitlab.com/so_literate/genmock) - Go mocking system with code generator for building calls of the interface methods.
 - [go-localstack](https://github.com/elgohr/go-localstack) - Tool for using localstack in AWS testing.


### PR DESCRIPTION
Reason for Removal
The `connexions` repository has been deleted and returns a 404 error.

Notification
Notifying the author to give them an opportunity to respond: @cubahno