### PR TITLE
remove defunct go-styleguide repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3838,7 +3838,6 @@ _Add the group of your city/country here (send **PR**)_
 
 ## Style Guides
 
-- [bahlo/go-styleguide](https://github.com/bahlo/go-styleguide)
 - [CockroachDB](https://github.com/cockroachdb/cockroach/blob/master/docs/style.md)
 - [GitLab](https://docs.gitlab.com/ee/development/go_guide/)
 - [Google](https://google.github.io/styleguide/go/)

--- a/README.md
+++ b/README.md
@@ -3839,6 +3839,7 @@ _Add the group of your city/country here (send **PR**)_
 ## Style Guides
 
 - [CockroachDB](https://github.com/cockroachdb/cockroach/blob/master/docs/style.md)
+- [enra/go-styleguide](https://codeberg.org/enra/go-styleguide)
 - [GitLab](https://docs.gitlab.com/ee/development/go_guide/)
 - [Google](https://google.github.io/styleguide/go/)
 - [Hyperledger](https://github.com/hyperledger/fabric/blob/release-1.4/docs/source/style-guides/go-style.rst)


### PR DESCRIPTION
Reason for Removal
The `go-styleguide` repository has been deleted and returns a 404 error.

Notification
Notifying the author to give them an opportunity to respond: @bahlo