### PR TITLE
Add togo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3203,6 +3203,7 @@ _Full stack web frameworks._
 - [Ronykit](https://github.com/clubpay/ronykit) - Web framework with pluggable architecture and very performant.
 - [rux](https://github.com/gookit/rux) - Simple and fast web framework for build golang HTTP applications.
 - [templui](https://github.com/axzilla/templui) - Modern UI Components for Go & Templ.
+- [togo](https://github.com/togo-framework/togo) - Full-stack framework that ships your Go backend and React frontend as a single binary; a Laravel-artisan-grade CLI.
 - [uAdmin](https://github.com/uadmin/uadmin) - Fully featured web framework for Golang, inspired by Django.
 - [WebGo](https://github.com/naughtygopher/webgo) - A micro-framework to build web apps with handler chaining, middleware, and context injection. With standard library-compliant HTTP handlers (i.e., `http.HandlerFunc`)..
 - [Xun](https://github.com/yaitoo/xun) - Web framework built on Go's built-in html/template and net/http package’s router. It is designed to be lightweight, fast, and easy to use while providing a simple and intuitive API for building web applications with advanced features such as middleware, routing, and template rendering.


### PR DESCRIPTION
**Adding:** [togo](https://github.com/togo-framework/togo) — an open-source, API-first full-stack framework: a Laravel-artisan-grade CLI for the Go + sqlc + Atlas + React stack (one binary, one repo). Website: https://to-go.dev

Forge link: https://github.com/togo-framework/togo
pkg.go.dev: https://pkg.go.dev/github.com/togo-framework/togo
goreportcard.com: https://goreportcard.com/report/github.com/togo-framework/togo

- [x] Added to the **Web Frameworks** section, alphabetically (between `templui` and `uAdmin`).
- [x] Description is concise and ends with a period.
- [x] Project is open-source (MIT) with documentation.