### PR TITLE
feat: add lazyredis - lazygit-inspired TUI for Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ _Libraries for building Console Applications and Console User Interfaces._
 - [gookit/color](https://github.com/gookit/color) - Terminal color rendering tool library, support 16 colors, 256 colors, RGB color rendering output, compatible with Windows.
 - [goscaf](https://github.com/iyashjayesh/goscaf) - goscaf generates opinionated, production-quality Go project boilerplate via an interactive CLI. Stop copy-pasting skeleton code between projects.
 - [lazyenv](https://github.com/lazynop/lazyenv) - TUI for browsing, comparing, and editing .env files.
+- [lazyredis](https://github.com/sm010422/lazyredis) - lazygit-inspired terminal UI for Redis with hierarchical key tree, multi-type viewer, and multi-profile support.
 - [lipgloss](https://github.com/charmbracelet/lipgloss) - Declaratively define styles for color, format and layout in the terminal.
 - [loom](https://github.com/loom-go/loom) - Signal-based reactive components framework for building TUIs.
 - [marker](https://github.com/cyucelen/marker) - Easiest way to match and mark strings for colorful terminal outputs.


### PR DESCRIPTION
## Description

Adding [lazyredis](https://github.com/sm010422/lazyredis) to the **Command Line** section.

## What is lazyredis?

A lazygit-inspired terminal UI for Redis built with [bubbletea](https://github.com/charmbracelet/bubbletea) and [lipgloss](https://github.com/charmbracelet/lipgloss).

**Features:**
- Hierarchical key tree — groups keys by `:` delimiter into navigable folders
- All Redis types: String (with JSON pretty-print + hex dump), List, Hash, Set, Sorted Set, Stream, RedisJSON, Vector Set, Time Series
- Full CRUD via modal dialogs (create, rename, TTL, edit sub-items)
- Multi-select + batch delete with range selection
- Multi-profile config (`~/.config/lazyredis/config.json`) with `p` to switch connections
- Search with fuzzy match and glob pattern support
- Auto-refresh, TLS support, copy to clipboard

**Installation:**
```sh
brew tap sm010422/lazyredis
brew install lazyredis
```

## Links

Forge link: https://github.com/sm010422/lazyredis
pkg.go.dev: https://pkg.go.dev/github.com/sm010422/lazyredis
goreportcard.com: https://goreportcard.com/report/github.com/sm010422/lazyredis

## Checklist

- [x] The repository is valid Go
- [x] Only ONE package is added in this PR
- [x] The package has a clear description (not marketing copy)
- [x] Link is alphabetically ordered within its section
- [x] The package has been around for at least 30 days with real commits
- [x] The package has tests or is a tool (CLI tools are accepted without unit tests)