### PR TITLE
Add gh-image to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2934,6 +2934,7 @@ _General utilities and tools to make your life easier._
 - [filter](https://github.com/gookit/filter) - provide filtering, sanitizing, and conversion of Go data.
 - [fzf](https://github.com/junegunn/fzf) - Command-line fuzzy finder written in Go.
 - [generate](https://github.com/go-playground/generate) - runs go generate recursively on a specified path or environment variable and can filter by regex.
+- [gh-image](https://github.com/drogers0/gh-image) - A gh CLI extension that uploads images to GitHub issues, PRs, and READMEs from the command line, producing user-attachments URLs that respect repository visibility.
 - [ghokin](https://github.com/antham/ghokin) - Parallelized formatter with no external dependencies for gherkin (cucumber, behat...).
 - [git-time-metric](https://github.com/git-time-metric/gtm) - Simple, seamless, lightweight time tracking for Git.
 - [git-tools](https://github.com/kazhuravlev/git-tools) - Tool to help manage git tags.


### PR DESCRIPTION
Adds [gh-image](https://github.com/drogers0/gh-image) to the **Utilities** section (alphabetically between `generate` and `ghokin`).

gh-image is a `gh` CLI extension that uploads local images to GitHub from the terminal and returns ready-to-embed `user-attachments` URLs for issues, PRs, and READMEs. GitHub has no public image-upload API; it replicates the web UI's internal flow, and URLs respect repository visibility.

Forge link: https://github.com/drogers0/gh-image
pkg.go.dev: https://pkg.go.dev/github.com/drogers0/gh-image
goreportcard.com: https://goreportcard.com/report/github.com/drogers0/gh-image
Coverage: https://app.codecov.io/gh/drogers0/gh-image

- MIT license, go.mod at root, SemVer release (v1.0.4 via GoReleaser).
- Test coverage >= 80% across packages (root 87.8%, upload 90.9%, repo 92.6%, session 88.9%, cookies 92.4%).

Note: the repository is ~3 months old, so the automated **maturity** check (>=5 months of history) emits its non-blocking warning. Opening for maintainer consideration; happy to resubmit after the repo crosses the 5-month mark (late Aug 2026) if preferred.