### PR TITLE
Add ambatukam-go to HTTP Clients section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2193,6 +2193,7 @@ _Libraries for making HTTP requests._
 - [Grequest](https://github.com/lib4u/grequest)  - Simple and lightweight golang package for http requests. based on powerful net/http
 - [grequests](https://github.com/levigross/grequests) - A Go "clone" of the great and famous Requests library.
 - [hedge](https://github.com/bhope/hedge) - Adaptive hedged requests for Go. Cuts p99 latency with zero configuration, based on Google's "The Tail at Scale" paper.
+- [ambatukam-go](https://github.com/farhanturu/ambatukam-go) - Composable, idiomatic Go HTTP resilience — Retry, Circuit Breaker, Bulkhead, Rate Limiter, Timeout, Fallback, Singleflight, Hooks, Metrics, Health Check. Zero dependencies.
 - [heimdall](https://github.com/gojektech/heimdall) - An enhanced http client with retry and hystrix capabilities.
 - [httpretry](https://github.com/ybbus/httpretry) - Enriches the default go HTTP client with retry functionality.
 - [pester](https://github.com/sethgrid/pester) - Go HTTP client calls with retries, backoff, and concurrency.


### PR DESCRIPTION
## What is this?

Add [ambatukam-go](https://github.com/farhanturu/ambatukam-go) to the HTTP Clients section.

## Why should it be included?

Ambatukam Go is a **zero-dependency** Go HTTP resilience library that combines 10+ production-grade patterns in one composable API:

- Retry with exponential/constant/linear backoff + jitter
- Circuit breaker (closed/open/half-open state machine)
- Bulkhead (concurrency limiter with bounded queue)
- Rate limiter (token bucket)
- Per-attempt timeout
- Fallback strategy
- Singleflight (request deduplication)
- Request ID propagation
- Hooks (BeforeRequest, AfterResponse, OnRetry, OnStateChange, OnFallback)
- Generic JSON helpers (GetJSON[T], PostJSON[T])
- Health check endpoint
- Metrics interface (Prometheus-ready)

**Key differentiators:**
- Zero external dependencies (only stdlib)
- Go 1.21+ with generics
- 80+ tests with race detector
- MIT license
- Well-documented (README, COOKBOOK, FAQ, MIGRATION guides)

## Example

```go
client := ambatukam.New(
    ambatukam.WithTimeout(ambatukam.TimeoutConfig{Timeout: 2 * time.Second}),
    ambatukam.WithRetry(ambatukam.RetryConfig{MaxRetries: 3}),
    ambatukam.WithCircuitBreaker(ambatukam.CircuitConfig{FailureThreshold: 5}),
)
resp, err := client.Get(ctx, "https://api.example.com/users")
```

## Links

- **GitHub:** https://github.com/farhanturu/ambatukam-go
- **Go Reference:** https://pkg.go.dev/github.com/farhanturu/ambatukam-go
- **License:** MIT