### PR TITLE
fix: remove duplicate 'a' in Chapar entry description

### DIFF
--- a/README.md
+++ b/README.md
@@ -3580,7 +3580,7 @@ _Software written in Go._
 - [bluetuith](https://github.com/bluetuith-org/bluetuith) - TUI Bluetooth manager for Linux.
 - [borg](https://github.com/crufter/borg) - Terminal based search engine for bash snippets.
 - [boxed](https://github.com/tejo/boxed) - Dropbox based blog engine.
-- [Chapar](https://github.com/chapar-rest/chapar) - Chapar is a a cross-platform Postman alternative built with go, aims to help developers to test their api endpoints. it support http and grpc protocols.
+- [Chapar](https://github.com/chapar-rest/chapar) - Chapar is a cross-platform Postman alternative built with go, aims to help developers to test their api endpoints. it support http and grpc protocols.
 - [Cherry](https://github.com/rafael-santiago/cherry) - Tiny webchat server in Go.
 - [Circuit](https://github.com/gocircuit/circuit) - Circuit is a programmable platform-as-a-service (PaaS) and/or Infrastructure-as-a-Service (IaaS), for management, discovery, synchronization and orchestration of services and hosts comprising cloud applications.
 - [Comcast](https://github.com/tylertreat/Comcast) - Simulate bad network connections.


### PR DESCRIPTION
## Summary

Fixes a small duplicate-word typo in the existing Chapar entry description in README.md: `Chapar is a a cross-platform` → `Chapar is a cross-platform`.

## Entry Links

Forge link: https://github.com/chapar-rest/chapar
pkg.go.dev: https://pkg.go.dev/github.com/chapar-rest/chapar
goreportcard.com: https://goreportcard.com/report/github.com/chapar-rest/chapar
Coverage: https://app.codecov.io/gh/chapar-rest/chapar

## Change

- File: `README.md`
- One duplicate word removed (`a a` → `a`).
- No entry added, removed, reordered, or relinked. Only an existing description typo is corrected.

## Verification

- Verified the entry links above are reachable.
- `git diff --check` — clean (no whitespace errors).
- Diff is a single 1-line change.

## Notes

- Intentionally tiny change: correcting a typo in an existing entry's description.
- The entry's link text, URL, and alphabetical position are unchanged.
- Per CONTRIBUTING.md: one PR changes only one item — this PR touches only the Chapar entry.
