### PR TITLE
feat: add skillreaper to Artificial Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ _Libraries for building programs that leverage AI._
 - [OllamaFarm](https://github.com/presbrey/ollamafarm) - Manage, load-balance, and failover packs of Ollamas.
 - [otellix](https://github.com/oluwajubelo1/otellix) - OpenTelemetry-native LLM observability and budget guardrails for cost-constrained production environments.
 - [routex](https://github.com/Ad3bay0c/routex) - YAML-driven multi-agent AI runtime for Go with Erlang-style supervision, MCP tool server support, and a CLI.
+- [skillreaper](https://github.com/thousandflowers/skillreaper) - CLI that scans AI agent session transcripts to identify and safely quarantine unused skills, MCP servers, and agents across Claude Code, Codex CLI, Hermes, OpenCode, Cursor, and OpenClaw.
 - [trpc-agent-go](https://github.com/trpc-group/trpc-agent-go) - Framework for building LLM-based multi-agent systems.
 - [web-researcher-mcp](https://github.com/zoharbabin/web-researcher-mcp) - MCP server providing AI assistants with web search, content extraction, and multi-source research capabilities. Single binary, 5 search providers with circuit-breaker failover, 4-tier scraping pipeline.
 - [zenflow](https://github.com/zendev-sh/zenflow) - Multi-agent orchestration & workflow engine. Declarative YAML workflows, LLM coordinator with hub-and-spoke mailboxes, race-safe delivery. One YAML file, one Go binary. Runs on any goai-supported provider.


### PR DESCRIPTION
Forge link: https://github.com/thousandflowers/skillreaper
pkg.go.dev: https://pkg.go.dev/github.com/thousandflowers/skillreaper/cmd/reap
goreportcard.com: https://goreportcard.com/report/github.com/thousandflowers/skillreaper

CLI that scans AI agent session transcripts to identify and safely quarantine unused skills, MCP servers, and agents. Supports Claude Code, Codex CLI, Hermes, OpenCode, Cursor, and OpenClaw. Zero telemetry, single static binary, ships on Homebrew and npm.

- [x] I have read the Contribution Guidelines
- [x] I know that this package was not listed before
- [x] The packages around my addition still meet the Quality Standards