### PR TITLE
Add llm-box to Artificial Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ _Libraries for building programs that leverage AI._
 - [hotplex](https://github.com/hrygo/hotplex) - AI Agent runtime engine with long-lived sessions for Claude Code, OpenCode, pi-mono and other CLI AI tools. Provides full-duplex streaming, multi-platform integrations, and secure sandbox.
 - [langchaingo](https://github.com/tmc/langchaingo) - LangChainGo is a framework for developing applications powered by language models.
 - [langgraphgo](https://github.com/smallnest/langgraphgo) - A Go library for building stateful, multi-actor applications with LLMs, built on the concept of LangGraph，with a lot of builtin Agent architectures.
+- [llm-box](https://github.com/alib8b8/llm-box) - Terminal-based AI workflow engine with YAML-driven pipelines, 20+ LLM providers (DeepSeek, Qwen, GLM, Mistral, etc.), and a TUI for workflow management.
 - [LocalAI](https://github.com/mudler/LocalAI) - Open Source OpenAI alternative, self-host AI models.
 - [localaik](https://github.com/harshaneel/localaik) - LocalStack-style local emulation of OpenAI and Gemini APIs; single Docker container, llama.cpp + Gemma 3 backend.
 - [mcp-go](https://github.com/mark3labs/mcp-go) - Go implementation of the Model Context Protocol for building MCP servers and clients in Go.


### PR DESCRIPTION
## Description

Adding [llm-box](https://github.com/alib8b8/llm-box) - a terminal-based AI workflow engine with YAML-driven pipelines, supporting 20+ LLM providers (DeepSeek, Qwen, GLM, Mistral, etc.), and featuring a TUI for workflow management.

## Summary of Changes

- Added llm-box entry to the Artificial Intelligence section
- Positioned alphabetically between langgraphgo and LocalAI

## Why it belongs in awesome-go

- Written in pure Go with no external dependencies
- Provides a complete workflow engine with YAML pipeline definitions
- Supports 20+ LLM providers via unified provider interface
- Features a TUI for interactive workflow management
- Local-first execution with deterministic workflow results
- Single binary deployment, cross-platform support

Forge link: https://github.com/alib8b8/llm-box
pkg.go.dev: https://pkg.go.dev/github.com/alib8b8/llm-box
goreportcard.com: https://goreportcard.com/report/github.com/alib8b8/llm-box
