### PR TITLE
Add xberg to Text Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ additional ordered map implementations.
 - [ptrie](https://github.com/viant/ptrie) - An implementation of prefix tree.
 - [radixtree](https://github.com/gammazero/radixtree) - Adaptive radix tree (prefix-tree or compact-trie).
 - [trie](https://github.com/derekparker/trie) - Trie implementation in Go.
+- [xberg](https://github.com/xberg-io/xberg) - Document intelligence library that extracts text, tables, and metadata from PDFs, Office documents, and 97+ formats with optional OCR (Go binding over a Rust core).
 
 ### Trees
 


### PR DESCRIPTION
Adds **xberg** to Text Analysis — a document intelligence library (Rust core, MIT, 8.5k★) with a native Go binding that extracts text, tables, and metadata from PDFs, Office documents, and 97+ formats with optional OCR.

Forge link: https://github.com/xberg-io/xberg
pkg.go.dev: https://pkg.go.dev/github.com/xberg-io/xberg
goreportcard.com: https://goreportcard.com/report/github.com/xberg-io/xberg
