### PR TITLE
Add go-utils to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2972,6 +2972,7 @@ _General utilities and tools to make your life easier._
 - [go-trigger](https://github.com/sadlil/go-trigger) - Go-lang global event triggerer, Register Events with an id and trigger the event from anywhere from your project.
 - [go-tripper](https://github.com/rajnandan1/go-tripper) - Tripper is a circuit breaker package for Go that allows you to circuit and control the status of circuits.
 - [go-type](https://github.com/mikekonan/go-types) - Library providing Go types for store/validation and transfer of ISO-4217, ISO-3166, and other types.
+- [go-utils](https://github.com/Goldziher/go-utils) - Simple, performant generic utilities for Go inspired by JavaScript and Python (map, filter, reduce, and more).
 - [goback](https://github.com/carlescere/goback) - Go simple exponential backoff package.
 - [goctx](https://github.com/zerosnake0/goctx) - Get your context value with high performance.
 - [godaemon](https://github.com/VividCortex/godaemon) - Utility to write daemons.


### PR DESCRIPTION
Adds **go-utils** to Utilities — simple, performant generic utilities for Go inspired by JavaScript and Python (MIT, 57★).

Forge link: https://github.com/Goldziher/go-utils
pkg.go.dev: https://pkg.go.dev/github.com/Goldziher/go-utils
goreportcard.com: https://goreportcard.com/report/github.com/Goldziher/go-utils
