### PR TITLE
Add impersonate-http

### DIFF
--- a/README.md
+++ b/README.md
@@ -2200,6 +2200,7 @@ _Libraries for making HTTP requests._
 - [hedge](https://github.com/bhope/hedge) - Adaptive hedged requests for Go. Cuts p99 latency with zero configuration, based on Google's "The Tail at Scale" paper.
 - [heimdall](https://github.com/gojektech/heimdall) - An enhanced http client with retry and hystrix capabilities.
 - [httpretry](https://github.com/ybbus/httpretry) - Enriches the default go HTTP client with retry functionality.
+ - [impersonate-http](https://github.com/North-web-dev/impersonate-http) - Drop-in net/http.Client with a byte-exact browser TLS (JA3/JA4) and HTTP/2 (Akamai) fingerprint.
 - [pester](https://github.com/sethgrid/pester) - Go HTTP client calls with retries, backoff, and concurrency.
 - [req](https://github.com/imroc/req) - Simple Go HTTP client with Black Magic (Less code and More efficiency).
 - [request](https://github.com/monaco-io/request) - HTTP client for golang. If you have experience about axios or requests, you will love it. No 3rd dependency.


### PR DESCRIPTION
Adding [impersonate-http](https://github.com/North-web-dev/impersonate-http) to **HTTP Clients**.

A drop-in `net/http.Client` whose TLS ClientHello (JA3/JA4) **and** HTTP/2 frames (Akamai: SETTINGS order, WINDOW_UPDATE, pseudo-header order) are byte-identical to a real browser — survives fingerprint-based blocking without a headless browser or CGo. MIT, tests + CI (green), godoc. Only deps: uTLS + x/net. Entry placed alphabetically in HTTP Clients.

Forge link: https://github.com/North-web-dev/impersonate-http
pkg.go.dev: https://pkg.go.dev/github.com/North-web-dev/impersonate-http
goreportcard.com: https://goreportcard.com/report/github.com/North-web-dev/impersonate-http

Thanks for maintaining awesome-go!