### PR TITLE
Add gopdfrab (File Handling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1216,6 +1216,7 @@ _Libraries for handling files and file systems._
 - [go-gtfs](https://github.com/artonge/go-gtfs) - Load gtfs files in go.
 - [go-wkhtmltopdf](https://github.com/SebastiaanKlippert/go-wkhtmltopdf) - A package to convert an HTML template to a PDF file.
 - [gofs](https://github.com/no-src/gofs) - A cross-platform real-time file synchronization tool out of the box.
+- [gopdfrab](https://github.com/voidrab/gopdfrab) - PDF/A processing for Go.
 - [gulter](https://github.com/adelowo/gulter) - A simple HTTP middleware to automatically handle all your file upload needs
 - [gut/yos](https://github.com/1set/gut) - Simple and reliable package for file operations like copy/move/diff/list on files, directories and symbolic links.
 - [gxpdf](https://github.com/coregx/gxpdf) - Modern full-lifecycle PDF library for Go — parse, extract tables, generate, and sign documents with zero CGO dependencies.


### PR DESCRIPTION
Adding [gopdfrab](https://github.com/voidrab/gopdfrab) to **File Handling**.

A PDF/A verification and conversion library fully written in Go, and compliant with the industry supported veraPDF test suite. AGPLv3, tests green, > 90 percent code coverage. Entry placed alphabetically in File Handling.

Forge link: https://github.com/voidrab/gopdfrab
pkg.go.dev: https://pkg.go.dev/github.com/voidrab/gopdfrab
goreportcard.com: https://goreportcard.com/report/github.com/voidrab/gopdfrab
codecov: https://app.codecov.io/gh/voidrab/gopdfrab