### PR TITLE
Add gitl to DevOps Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -3504,6 +3504,7 @@ _Software written in Go._
 - [ghorg](https://github.com/gabrie30/ghorg) - Quickly clone an entire org/users repositories into one directory - Supports GitHub, GitLab, Gitea, and Bitbucket.
 - [Gitea](https://github.com/go-gitea/gitea) - Fork of Gogs, entirely community driven.
 - [gitea-github-migrator](https://git.jonasfranz.software/JonasFranzDEV/gitea-github-migrator) - Migrate all your GitHub repositories, issues, milestones and labels to your Gitea instance.
+- [gitl](https://github.com/akomyagin/gitl) - AI review of git commit ranges with risk scoring (low/medium/high), changelog generation, and multi-repo activity digest. GitHub Action included.
 - [go-furnace](https://github.com/go-furnace/go-furnace) - Hosting solution written in Go. Deploy your Application with ease on AWS, GCP or DigitalOcean.
 - [go-rocket-update](https://github.com/mouuff/go-rocket-update) - A simple way to make self updating Go applications - Supports Github and Gitlab.
 - [go-selfupdate](https://github.com/sanbornm/go-selfupdate) - Enable your Go applications to self update.


### PR DESCRIPTION
Adds [gitl](https://github.com/akomyagin/gitl) (git-log-lens) — a Go CLI tool + GitHub Action for AI-powered code review of git commit ranges with structured risk scoring.

**Commands:**
- `gitl review <range>` — AI review with low/medium/high risk score, CI gating via `--fail-on`
- `gitl changelog` — Keep a Changelog-style output from conventional commits
- `gitl digest` — activity summary across multiple repos in parallel

**Features:**
- BYOK: OpenAI-compatible API, Ollama (local), Azure OpenAI
- Works offline without an API key (deterministic heuristic fallback)
- GitHub Action posts sticky PR comment with risk score
- Binaries signed with cosign keyless (Sigstore)

Forge link: https://github.com/akomyagin/gitl
pkg.go.dev: https://pkg.go.dev/github.com/akomyagin/gitl
goreportcard.com: https://goreportcard.com/report/github.com/akomyagin/gitl