### PR TITLE
Add gedb to databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,7 @@ _Data stores with expiring records, in-memory distributed data stores, or in-mem
 - [diskv](https://github.com/peterbourgon/diskv) - Home-grown disk-backed key-value store.
 - [dolt](https://github.com/dolthub/dolt) - Dolt – It's Git for Data.
 - [eliasdb](https://github.com/krotik/eliasdb) - Dependency-free, transactional graph database with REST API, phrase search and SQL-like query language.
+- [gedb](https://github.com/vinicius-lino-figueiredo/gedb) - MongoDB-like embedded database, written in pure-go. Supports indexing and complex queries.
 - [go-sqlite](https://github.com/glebarez/go-sqlite) – A Pure Golang implemented SQLite driver without CGO.
 - [godis](https://github.com/hdt3213/godis) - A Golang implemented high-performance Redis server and cluster.
 - [goleveldb](https://github.com/syndtr/goleveldb) - Implementation of the [LevelDB](https://github.com/google/leveldb) key/value database in Go.


### PR DESCRIPTION
Adds [gedb](https://github.com/vinicius-lino-figueiredo/gedb), an embedded database written in pure-go, and a MongoDB-like API.

- Forge link: https://github.com/vinicius-lino-figueiredo/gedb
- pkg.go.dev: https://pkg.go.dev/github.com/vinicius-lino-figueiredo/gedb
- goreportcard.com: https://goreportcard.com/report/github.com/vinicius-lino-figueiredo/gedb