### PR TITLE
Add relay to Server Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -2477,6 +2477,8 @@ _Libraries and tools for binary serialization._
 
 **[⬆ back to top](#contents)**
 
+* [relay](https://github.com/valtors/relay) - MCP server with 40 tools for AI agents. Memory, web fetch, search, file ops, screenshots, and multi-agent coordination in one Go binary.
+
 ## Server Applications
 
 - [algernon](https://github.com/xyproto/algernon) - HTTP/2 web server with built-in support for Lua, Markdown, GCSS and Amber.


### PR DESCRIPTION
## What

Adding [relay](https://github.com/valtors/relay) to the Server Applications section.

## Why

Relay is an MCP (Model Context Protocol) server written in Go with 40 tools for AI agents. It provides memory, web fetch, search, file operations, screenshots, and multi-agent coordination in a single binary.

- Go binary, no runtime needed
- 40 tools across 7 categories
- SQLite-backed agent memory
- Cross-platform (Windows, macOS, Linux)
- MIT licensed

NPM: [userelay](https://www.npmjs.com/package/userelay)

## Links

Forge link: https://github.com/valtors/relay

pkg.go.dev: https://pkg.go.dev/github.com/valtors/relay

goreportcard.com: https://goreportcard.com/report/github.com/valtors/relay

Coverage: https://app.codecov.io/gh/valtors/relay

> Note: pkg.go.dev may take a few minutes to index the module after the v0.4.9 tag. The module path in go.mod is `github.com/valtors/relay` as of v0.4.9.
