### PR TITLE
Add powerlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1445,6 +1445,7 @@ _Tools for managing and working with Goroutines._
 - [parallel-fn](https://github.com/rafaeljesus/parallel-fn) - Run functions in parallel.
 - [pond](https://github.com/alitto/pond) - Minimalistic and High-performance goroutine worker pool written in Go.
 - [pool](https://github.com/go-playground/pool) - Limited consumer goroutine or unlimited goroutine pool for easier goroutine handling and cancellation.
+- [powerlock](https://github.com/donomii/powerlock) - Named FIFO mutexes with context cancellation, bounded wait queues, watchdog diagnostics, pprof profiles, and Prometheus metrics.
 - [rill](https://github.com/destel/rill) - Go toolkit for clean, composable, channel-based concurrency.
 - [routine](https://github.com/timandy/routine) - `routine` is a `ThreadLocal` for go library. It encapsulates and provides some easy-to-use, non-competitive, high-performance `goroutine` context access interfaces, which can help you access coroutine context information more gracefully.
 - [routine](https://github.com/x-mod/routine) - go routine control with context, support: Main, Go, Pool and some useful Executors.


### PR DESCRIPTION
Adds powerlock to the Goroutines section.

Forge link: https://github.com/donomii/powerlock
pkg.go.dev: https://pkg.go.dev/github.com/donomii/powerlock
goreportcard.com: https://goreportcard.com/report/github.com/donomii/powerlock
Coverage: https://coveralls.io/github/donomii/powerlock
Release: https://github.com/donomii/powerlock/releases/tag/v0.1.0