### PR TITLE
Add jargo to Artificial Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ _Libraries for building programs that leverage AI._
 - [fun](https://gitlab.com/tozd/go/fun) - The simplest but powerful way to use large language models (LLMs) in Go.
 - [goai](https://github.com/zendev-sh/goai) - Go SDK for building AI applications. One SDK, 20+ providers. Inspired by Vercel AI SDK.
 - [hotplex](https://github.com/hrygo/hotplex) - AI Agent runtime engine with long-lived sessions for Claude Code, OpenCode, pi-mono and other CLI AI tools. Provides full-duplex streaming, multi-platform integrations, and secure sandbox.
+- [jargo](https://github.com/gojargo/jargo) - Framework for building real-time voice AI agents over WebRTC, wiring speech-to-text, LLMs, and text-to-speech into a streaming pipeline.
 - [langchaingo](https://github.com/tmc/langchaingo) - LangChainGo is a framework for developing applications powered by language models.
 - [langgraphgo](https://github.com/smallnest/langgraphgo) - A Go library for building stateful, multi-actor applications with LLMs, built on the concept of LangGraph，with a lot of builtin Agent architectures.
 - [llm-box](https://github.com/alib8b8/llm-box) - Terminal-based AI workflow engine with YAML-driven pipelines, 20+ LLM providers (DeepSeek, Qwen, GLM, Mistral, etc.), and a TUI for workflow management.


### PR DESCRIPTION
## Description

Adding [jargo](https://github.com/gojargo/jargo) — a WebRTC-native framework for building real-time voice AI agents in Go. It wires speech-to-text, LLMs, and text-to-speech into a streaming, interruption-aware pipeline, with pluggable providers, turn-taking (VAD + smart-turn), and OpenTelemetry observability.

## Summary of Changes

- Added jargo to the Artificial Intelligence section.
- Positioned alphabetically between hotplex and langchaingo.

## Why it belongs in awesome-go

- Pure-Go, WebRTC-native voice-agent framework (pion-based), cgo-free by default.
- Orchestrates many STT/LLM/TTS providers behind uniform interfaces.
- Real-time streaming pipeline with barge-in, turn detection, and the RTVI client protocol.
- Documented (README, pkg.go.dev doc comments), tested, with CI and versioned releases.

Forge link: https://github.com/gojargo/jargo
pkg.go.dev: https://pkg.go.dev/github.com/gojargo/jargo
goreportcard.com: https://goreportcard.com/report/github.com/gojargo/jargo
Coverage: https://codecov.io/gh/gojargo/jargo

- [x] I have read the Contribution Guidelines
- [x] I know that this package was not listed before
- [x] The packages around my addition still meet the Quality Standards
