### PR TITLE
Add go-resample to Audio and Music section

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ _Libraries for manipulating audio and music._
 - [flac](https://github.com/mewkiz/flac) - Native Go FLAC encoder/decoder with support for FLAC streams.
 - [gaad](https://github.com/Comcast/gaad) - Native Go AAC bitstream parser.
 - [go-mpris](https://github.com/leberKleber/go-mpris) - Client for mpris dbus interfaces.
+- [go-resample](https://github.com/gojargo/go-resample) - Pure-Go (no cgo) audio sample-rate converter with sinc, linear, and zero-order-hold converters.
 - [GoAudio](https://github.com/DylanMeeus/GoAudio) - Native Go Audio Processing Library.
 - [gosamplerate](https://github.com/dh1tw/gosamplerate) - libsamplerate bindings for go.
 - [id3v2](https://github.com/bogem/id3v2) - ID3 decoding and encoding library for Go.


### PR DESCRIPTION
## Description

Adding [go-resample](https://github.com/gojargo/go-resample) — a pure-Go (no cgo) audio sample-rate converter. It handles arbitrary and time-varying conversion ratios in the range [1/256, 256] over interleaved float32 frames, with five converters that trade quality against CPU cost: three Kaiser-windowed sinc variants, linear, and zero-order-hold.

## Summary of Changes

- Added go-resample to the Audio and Music section.
- Positioned alphabetically between go-mpris and GoAudio.

## Why it belongs in awesome-go

- Pure-Go and cgo-free — cross-compiles and links cleanly into static binaries.
- Arbitrary and time-varying resampling ratios via a polyphase Kaiser-windowed sinc filter.
- Streaming and one-shot APIs over interleaved float32 with any channel count.
- Documented (README, pkg.go.dev doc comments), tested, with CI and versioned releases.

Forge link: https://github.com/gojargo/go-resample
pkg.go.dev: https://pkg.go.dev/github.com/gojargo/go-resample
goreportcard.com: https://goreportcard.com/report/github.com/gojargo/go-resample
Coverage: https://codecov.io/gh/gojargo/go-resample

- [x] I have read the Contribution Guidelines
- [x] I know that this package was not listed before
- [x] The packages around my addition still meet the Quality Standards
