### PR TITLE
Add GoModel to Artificial Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ _Libraries for building programs that leverage AI._
 - [dakera-go](https://github.com/dakera-ai/dakera-go) - Official Go client SDK for the Dakera self-hosted agent memory server, providing typed interfaces for memory store/recall, session management, namespace operations, and decay configuration.
 - [fun](https://gitlab.com/tozd/go/fun) - The simplest but powerful way to use large language models (LLMs) in Go.
 - [goai](https://github.com/zendev-sh/goai) - Go SDK for building AI applications. One SDK, 20+ providers. Inspired by Vercel AI SDK.
+- [GoModel](https://github.com/ENTERPILOT/GoModel) - AI gateway exposing a unified OpenAI-compatible API across OpenAI, Anthropic, Gemini, Groq, xAI, Ollama and other providers, with routing, usage tracking, rate limits, and guardrails.
 - [hotplex](https://github.com/hrygo/hotplex) - AI Agent runtime engine with long-lived sessions for Claude Code, OpenCode, pi-mono and other CLI AI tools. Provides full-duplex streaming, multi-platform integrations, and secure sandbox.
 - [jargo](https://github.com/gojargo/jargo) - Framework for building real-time voice AI agents over WebRTC, wiring speech-to-text, LLMs, and text-to-speech into a streaming pipeline.
 - [langchaingo](https://github.com/tmc/langchaingo) - LangChainGo is a framework for developing applications powered by language models.


### PR DESCRIPTION
## Description

Adding [GoModel](https://github.com/ENTERPILOT/GoModel) — an AI gateway that exposes a unified OpenAI-compatible API across OpenAI, Anthropic, Gemini, Groq, xAI, Ollama and other providers, with routing, usage tracking, rate limits, and guardrails.

## Summary of Changes

- Added GoModel to the Artificial Intelligence section.
- Positioned alphabetically between goai and hotplex.

## Why it belongs in awesome-go

- Single OpenAI-compatible API (chat, responses, embeddings, audio, realtime websocket/WebRTC) across a dozen providers, self-hosted as one Go binary.
- Virtual models with load balancing and failover, per-path rate limits, budgets, usage tracking, audit logging, and an admin dashboard.
- MIT licensed, active development since December 2025, SemVer releases, CI with race-enabled tests.

Forge link: https://github.com/ENTERPILOT/GoModel
pkg.go.dev: https://pkg.go.dev/github.com/enterpilot/gomodel
goreportcard.com: https://goreportcard.com/report/github.com/enterpilot/gomodel
Coverage: not published yet (tests run in CI via GitHub Actions; a Codecov badge is planned)

- [x] I have read the Contribution Guidelines
- [x] I know that this package was not listed before
- [x] The packages around my addition still meet the Quality Standards