### PR TITLE
Add db-migrator.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,6 +835,7 @@ _Data stores with expiring records, in-memory distributed data stores, or in-mem
 - [avro](https://github.com/khezen/avro) - Discover SQL schemas and convert them to AVRO schemas. Query SQL records into AVRO bytes.
 - [bytebase](https://github.com/bytebase/bytebase) - Safe database schema change and version control for DevOps teams.
 - [darwin](https://github.com/GuiaBolso/darwin) - Database schema evolution library for Go.
+- [db-migrator.go](https://github.com/raoptimus/db-migrator.go) - CLI for versioned database schema migrations with support for PostgreSQL, MySQL, ClickHouse, Tarantool, and Apache Iceberg.
 - [dbmate](https://github.com/amacneil/dbmate) - A lightweight, framework-agnostic database migration tool.
 - [go-fixtures](https://github.com/RichardKnop/go-fixtures) - Django style fixtures for Golang's excellent built-in database/sql library.
 - [go-pg-migrate](https://github.com/lawzava/go-pg-migrate) - CLI-friendly package for go-pg migrations management.


### PR DESCRIPTION
Adding **db-migrator.go** to the *Database Schema Migration* section.

db-migrator.go is a CLI for versioned database schema migrations. In addition to PostgreSQL
and MySQL, it has first-class support for ClickHouse (clusters, replication, `ON CLUSTER`),
Tarantool (Lua migrations), and Apache Iceberg (via the REST Catalog, Spark-SQL DDL) —
backends most Go migration tools cover thinly or not at all.

Forge link: https://github.com/raoptimus/db-migrator.go
pkg.go.dev: https://pkg.go.dev/github.com/raoptimus/db-migrator.go
goreportcard.com: https://goreportcard.com/report/github.com/raoptimus/db-migrator.go
Coverage: https://raw.githack.com/wiki/raoptimus/db-migrator.go/coverage.html

License: BSD-3-Clause · Latest release: v1.8.0

> Note: goreportcard.com was sunset in 2026; the canonical report URL is included above for the
> automated check. Code quality is enforced in CI via golangci-lint (25+ linters, see
> `.golangci.yml`) together with unit and integration tests across all supported drivers, and
> test coverage is 80.7%.

**Checklist**
- [x] OSI-approved license (BSD-3-Clause)
- [x] Semantic version release (v1.8.0)
- [x] Tests + CI (GitHub Actions: lint, unit, integration, coverage)
- [x] pkg.go.dev documentation
- [x] Test coverage >= 80% (80.7%)
- [x] One item added; alphabetical order preserved (between `darwin` and `dbmate`)
- [x] Description is factual, non-promotional, and ends with a period