### PR TITLE
Add relay to Server Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -2477,6 +2477,8 @@ _Libraries and tools for binary serialization._
 
 **[⬆ back to top](#contents)**
 
+* [relay](https://github.com/valtors/relay) - MCP server with 40 tools for AI agents. Memory, web fetch, search, file ops, screenshots, and multi-agent coordination in one Go binary.
+
 ## Server Applications
 
 - [algernon](https://github.com/xyproto/algernon) - HTTP/2 web server with built-in support for Lua, Markdown, GCSS and Amber.

--- a/README.md
+++ b/README.md
@@ -2515,6 +2515,7 @@ _Libraries and tools for binary serialization._
 - [pocketbase](https://github.com/pocketbase/pocketbase) - PocketBase is a realtime backend in 1 file consisting of embedded database (SQLite) with realtime subscriptions, built-in auth management and much more.
 - [protoxy](https://github.com/camgraff/protoxy) - A proxy server that converts JSON request bodies to Protocol Buffers.
 - [psql-streamer](https://github.com/blind-oracle/psql-streamer) - Stream database events from PostgreSQL to Kafka.
+- [relay](https://github.com/valtors/relay) - MCP server with 40+ tools for AI agents. File operations, web search, screenshots, multi-agent coordination. Single Go binary.
 - [riemann-relay](https://github.com/blind-oracle/riemann-relay) - Relay to load-balance Riemann events and/or convert them to Carbon.
 - [RoadRunner](https://github.com/spiral/roadrunner) - High-performance PHP application server, load-balancer and process manager.
 - [SFTPGo](https://github.com/drakkan/sftpgo) - Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support. It can serve local filesystem and Cloud Storage backends such as S3 and Google Cloud Storage.


### PR DESCRIPTION
## What

Adding [relay](https://github.com/valtors/relay) to the Server Applications section.

## Why

Relay is an MCP (Model Context Protocol) server written in Go with 40+ tools for AI agents. It provides memory, web fetch, search, file operations, screenshots, and multi-agent coordination in a single binary.

- Go binary, no runtime needed
- 40+ tools across 7 categories
- SQLite-backed agent memory
- Cross-platform (Windows, macOS, Linux)
- MIT licensed
- pkg.go.dev: https://pkg.go.dev/github.com/valtors/relay
- NPM: [userelay](https://www.npmjs.com/package/userelay)
- Tagged releases: https://github.com/valtors/relay/releases

Forge link: https://github.com/valtors/relay
goreportcard.com: https://goreportcard.com/report/github.com/valtors/relay

## Checklist

- [x] Go module path matches GitHub URL in go.mod
- [x] Has a tagged SemVer release
- [x] pkg.go.dev page is reachable
- [x] Entry is alphabetically sorted
- [x] Description is concise (one line)
- [x] Uses the format: `- [project](url) - Description.`
