### PR TITLE
Add TTM to Other Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -3671,6 +3671,7 @@ _Software written in Go._
 - [syncthing](https://syncthing.net/) - Open, decentralized file synchronization tool and protocol.
 - [tcpdog](https://github.com/mehrdadrad/tcpdog) - eBPF based TCP observability.
 - [tinycare-tui](https://github.com/DMcP89/tinycare-tui) - Small terminal app that shows git commits from the last 24 hours and week, current weather, some self care advice, a joke, and you current todo list tasks.
+- [TTM](https://github.com/vst93/ttm) - SSH bookmark manager with TUI, Gist sync, and in-session file transfer.
 - [tldx](https://github.com/brandonyoungdev/tldx) - Bulk domain availability checker using RDAP, DNS, and WHOIS fallback with keyword permutation generation.
 - [toxiproxy](https://github.com/shopify/toxiproxy) - Proxy to simulate network and system conditions for automated tests.
 - [tsuru](https://tsuru.io/) - Extensible and open source Platform as a Service software.


### PR DESCRIPTION
## Required links

- [x] Forge link: https://github.com/vst93/ttm
- [x] pkg.go.dev: https://pkg.go.dev/github.com/vst93/ttm
- [x] goreportcard.com: https://goreportcard.com/report/github.com/vst93/ttm
- [ ] Coverage service link: https://app.codecov.io/gh/vst93/ttm (not yet set up)

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`): `v0.3.12`
- [x] The repo has an open source license (MIT).
- [ ] The repo documentation has a pkg.go.dev link (module path updated to `github.com/vst93/ttm`, pending indexing).
- [ ] The repo documentation has a goreportcard link (service sunset as of 2026).
- [ ] The repo documentation has a coverage service link (not yet set up).

## Pull Request content

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**.
- [x] The link text is the **exact project name**.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.

---

**Notes:**
- Module path recently updated from `ttm` to `github.com/vst93/ttm`. pkg.go.dev indexing in progress.
- Go Report Card (goreportcard.com) has been sunset. The link is provided for completeness but the service is no longer available.