### PR TITLE
Add genericsyncmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,7 @@ additional ordered map implementations.
 - [cmap](https://github.com/lrita/cmap) - a thread-safe concurrent map for go, support using `interface{}` as key and auto scale up shards.
 - [concurrent-swiss-map](https://github.com/mhmtszr/concurrent-swiss-map) - A high-performance, thread-safe generic concurrent hash map implementation with Swiss Map.
 - [dict](https://github.com/srfrog/dict) - Python-like dictionaries (dict) for Go.
+- [genericsyncmap](https://github.com/donomii/genericsyncmap) - Type-safe generic wrapper for `sync.Map` with full method parity and zero dependencies.
 - [go-shelve](https://github.com/lucmq/go-shelve) - A persistent, map-like object for the Go programming language. Supports multiple embedded key-value stores.
 - [goradd/maps](https://github.com/goradd/maps) - Go 1.18+ generic map interface for maps; safe maps; ordered maps; ordered, safe maps; etc.
 - [hmap](https://github.com/lyonnee/hmap) - HMap is a concurrent and secure, generic support Map implementation designed to provide an easy-to-use API.


### PR DESCRIPTION
Adds genericsyncmap to the Maps category.

Forge link: https://github.com/donomii/genericsyncmap
pkg.go.dev: https://pkg.go.dev/github.com/donomii/genericsyncmap
goreportcard.com: https://goreportcard.com/report/github.com/donomii/genericsyncmap
Coverage: https://app.codecov.io/gh/donomii/genericsyncmap

- [x] I have read the contribution guidelines and quality standards.
- [x] The repository has 5+ months of history, an MIT license, a go.mod file, and a v1.0.0 release.
- [x] The repository has English README and package documentation, CI, tests, race detection, linting, vetting, examples, and public coverage above 90%.
- [x] This PR adds one package in alphabetical order with a concise description ending in a period.
- [x] The packages around this addition are active, unarchived, and licensed.