### PR TITLE
Add MemHop - embedded cognitive memory database for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ _Data stores with expiring records, in-memory distributed data stores, or in-mem
 - [lotusdb](https://github.com/flower-corp/lotusdb) - Fast k/v database compatible with lsm and b+tree.
 - [lynxdb](https://github.com/lynxbase/lynxdb) - Lightweight columnar log analytics database with a pipe-style query language inspired by SPL.
 - [Milvus](https://github.com/milvus-io/milvus) - Milvus is a vector database for embedding management, analytics and search.
+- [MemHop](https://github.com/qyiun666/MemHop) - Embedded cognitive memory database for AI agents. Six-layer architecture (L0-L5), Dream consolidation pipeline, three-channel RRF retrieval (BM25 + f16 vector + entity), single .meh file, pure Go, zero infrastructure.
 - [minisql](https://github.com/RichardKnop/minisql) - Embedded single file SQL database.
 - [moss](https://github.com/couchbase/moss) - Moss is a simple LSM key-value storage engine written in 100% Go.
 - [nanotdb](https://github.com/aymanhs/nanotdb) - A lightweight, zero-dependency, append-only Time-Series Database and Dashboard optimized for low-power hardware.

--- a/README.md
+++ b/README.md
@@ -808,8 +808,8 @@ _Data stores with expiring records, in-memory distributed data stores, or in-mem
 - [LinDB](https://github.com/lindb/lindb) - LinDB is a scalable, high performance, high availability distributed time series database.
 - [lotusdb](https://github.com/flower-corp/lotusdb) - Fast k/v database compatible with lsm and b+tree.
 - [lynxdb](https://github.com/lynxbase/lynxdb) - Lightweight columnar log analytics database with a pipe-style query language inspired by SPL.
-- [Milvus](https://github.com/milvus-io/milvus) - Milvus is a vector database for embedding management, analytics and search.
 - [MemHop](https://github.com/qyiun666/MemHop) - Embedded cognitive memory database for AI agents. Six-layer architecture (L0-L5), Dream consolidation pipeline, three-channel RRF retrieval (BM25 + f16 vector + entity), single .meh file, pure Go, zero infrastructure.
+- [Milvus](https://github.com/milvus-io/milvus) - Milvus is a vector database for embedding management, analytics and search.
 - [minisql](https://github.com/RichardKnop/minisql) - Embedded single file SQL database.
 - [moss](https://github.com/couchbase/moss) - Moss is a simple LSM key-value storage engine written in 100% Go.
 - [nanotdb](https://github.com/aymanhs/nanotdb) - A lightweight, zero-dependency, append-only Time-Series Database and Dashboard optimized for low-power hardware.


### PR DESCRIPTION
## What

Add [MemHop](https://github.com/qyiun666/MemHop) to the \"Databases Implemented in Go\" section, positioned alphabetically between lynxdb and Milvus.

## About MemHop

MemHop is an embedded cognitive memory database for AI agents, written in pure Go with only 4 direct dependencies (xxhash, gse, ollama, go-openai). It models memory after the human brain with a six-layer cognitive architecture and a \"Dream\" consolidation pipeline.

### Key features

- **Six-layer cognitive architecture** — L0 Profile, L1 Engram, L2 Context, L3 Knowledge, L4 Archive, L5 Crystal
- **Dream consolidation pipeline** — 5-stage memory consolidation with at most 3 LLM calls per cycle
- **Three-channel RRF retrieval** — BM25 (gse CJK) + f16 vector (Ollama) + entity fuzzy matching
- **Single .meh file** — A/B dual headers, CRC32, mmap zero-copy, cross-platform file lock
- **Zero infrastructure** — No cgo, no server, no external services beyond embedding/LLM endpoint
- **L3 knowledge graph** — Multi-hypergraph with community detection (Louvain)

### Benchmark

100% Recall@5 on [LOCOMO10](https://github.com/snap-research/LOCOMO) (199 QA queries)

### Links

Forge link: https://github.com/qyiun666/MemHop
pkg.go.dev: https://pkg.go.dev/github.com/qyiun666/MemHop
goreportcard.com: https://goreportcard.com/report/github.com/qyiun666/MemHop

- **GitHub**: https://github.com/qyiun666/MemHop
- **License**: MIT OR Apache-2.0