### PR TITLE
Fix: remove duplicate MemHop entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,7 +810,6 @@ _Data stores with expiring records, in-memory distributed data stores, or in-mem
 - [lynxdb](https://github.com/lynxbase/lynxdb) - Lightweight columnar log analytics database with a pipe-style query language inspired by SPL.
 - [MemHop](https://github.com/qyiun666/MemHop) - Embedded cognitive memory database for AI agents. Six-layer architecture (L0-L5), Dream consolidation pipeline, three-channel RRF retrieval (BM25 + f16 vector + entity), single .meh file, pure Go, zero infrastructure.
 - [Milvus](https://github.com/milvus-io/milvus) - Milvus is a vector database for embedding management, analytics and search.
-- [MemHop](https://github.com/qyiun666/MemHop) - Embedded cognitive memory database for AI agents. Six-layer architecture (L0-L5), Dream consolidation pipeline, three-channel RRF retrieval (BM25 + f16 vector + entity), single .meh file, pure Go, zero infrastructure.
 - [minisql](https://github.com/RichardKnop/minisql) - Embedded single file SQL database.
 - [moss](https://github.com/couchbase/moss) - Moss is a simple LSM key-value storage engine written in 100% Go.
 - [nanotdb](https://github.com/aymanhs/nanotdb) - A lightweight, zero-dependency, append-only Time-Series Database and Dashboard optimized for low-power hardware.


### PR DESCRIPTION
The previous auto-merged PR (#6514) and a follow-up PR (#6516) both added MemHop, resulting in a duplicate entry. This PR removes the duplicate (the one incorrectly placed after Milvus), keeping only the correctly positioned entry after lynxdb.
Forge link: https://github.com/qyiun666/MemHop
goreportcard.com: https://goreportcard.com/report/github.com/qyiun666/MemHop
pkg.go.dev: https://pkg.go.dev/github.com/qyiun666/MemHop
