### PR TITLE
Add secretgenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2448,6 +2448,7 @@ _Libraries that are used to help make your application more secure._
 - [redact](https://github.com/alesr/redact) - Redact sensitive information from slog-based logs using a configurable pipeline.
 - [SafeDep/vet](https://github.com/safedep/vet) - Protect against malicious open source packages.
 - [secret](https://github.com/rsjethani/secret) - Prevent your secrets from leaking into logs, std\* etc.
+- [secretgenerator](https://github.com/rafaelperoco/secretgenerator) - CSPRNG-backed credential generator with a versioned JSON schema for passwords, passphrases, secrets, API keys, and PINs.
 - [secure](https://github.com/unrolled/secure) - HTTP middleware for Go that facilitates some quick security wins.
 - [secureio](https://github.com/xaionaro-go/secureio) - An keyexchanging+authenticating+encrypting wrapper and multiplexer for `io.ReadWriteCloser` based on XChaCha20-poly1305, ECDH and ED25519.
 - [simple-scrypt](https://github.com/elithrar/simple-scrypt) - Scrypt package with a simple, obvious API and automatic cost calibration built-in.


### PR DESCRIPTION
## Package

Forge link: https://github.com/rafaelperoco/secretgenerator
pkg.go.dev: https://pkg.go.dev/github.com/rafaelperoco/secretgenerator/pkg/secretgen
goreportcard.com: https://goreportcard.com/report/github.com/rafaelperoco/secretgenerator
Coverage: https://github.com/rafaelperoco/secretgenerator/actions/workflows/ci.yml

## Category

Security (alongside other password/credential generators such as `go-generate-password` and `acopw-go`).

## Why it belongs

Auditable CSPRNG credential generation with a stable schema-v1 JSON contract for AI agents and pipelines, NIST-aligned entropy floors, public Go API at `pkg/secretgen`, and SLSA 3 + cosign-signed releases.

Note: Go Report Card has been sunset as a service; the URL is still included for the automated PR checklist. Local `golangci-lint` + CI gates cover the same ground.

## Checklist

- [x] One item only
- [x] Alphabetical under Security
- [x] Description ends with a period
- [x] go.mod, SemVer release (v2.0.0), OSS license (MIT)
- [x] README + exported package docs