### PR TITLE
Add ctxerrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1185,6 +1185,7 @@ _Embedding other languages inside your go code._
 
 _Libraries for handling errors._
 
+- [ctxerrors](https://github.com/psyb0t/ctxerrors) - Wrap errors with the file, line, and function name of each call site.
 - [emperror](https://github.com/emperror/emperror) - Error handling tools and best practices for Go libraries and applications.
 - [eris](https://github.com/rotisserie/eris) - A better way to handle, trace, and log errors in Go. Compatible with the standard error library and github.com/pkg/errors.
 - [errlog](https://github.com/snwfdhmp/errlog) - Hackable package that determines responsible source code for an error (and some other fast-debugging features). Pluggable to any logger in-place.


### PR DESCRIPTION
Adds [ctxerrors](https://github.com/psyb0t/ctxerrors) to the **Error Handling** section (alphabetical order, single entry).

Error wrapping for Go that captures the file, line, and function name at each wrap site, so a wrapped error carries its own call path.

Forge link: https://github.com/psyb0t/ctxerrors
pkg.go.dev: https://pkg.go.dev/github.com/psyb0t/ctxerrors
goreportcard.com: https://goreportcard.com/report/github.com/psyb0t/ctxerrors

**Quality checklist**
- Open source license: MIT.
- `go.mod` present; tagged SemVer releases published.
- Repository history: well over 5 months since first commit.
- Tests run with `-race` in GitHub Actions CI; coverage is **94.8%** and the build fails below the repo's threshold.
- README documents install and usage; API on pkg.go.dev.

**On the missing Codecov/Coveralls link — deliberate, not an oversight.** The coverage is real (94.8%) and enforced on every push: `make test-coverage` runs `go test -race` and fails the build under threshold, and the live figure is rendered by a self-hosted SVG badge committed to a `badges` branch — no third-party coverage service, no upload tokens to babysit, nothing external to rot. The automated check only recognizes codecov.io/coveralls.io URLs, so it flags this as a warning; the number is legit and gate-enforced, and I'm happy to point at CI run logs if you want to verify.