### PR TITLE
Add servicepack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,6 +1098,7 @@ _Packages that help with building Distributed Systems._
 - [rpcplatform](https://github.com/nexcode/rpcplatform) - Framework for microservices with service discovery, load balancing, and related features.
 - [rpcx](https://github.com/smallnest/rpcx) - Distributed pluggable RPC service framework like alibaba Dubbo.
 - [Semaphore](https://github.com/jexia/semaphore) - A straightforward (micro) service orchestrator.
+- [servicepack](https://github.com/psyb0t/servicepack) - Framework for running multiple services concurrently in a single binary, locally or distributed across machines.
 - [sleuth](https://github.com/ursiform/sleuth) - Library for master-less p2p auto-discovery and RPC between HTTP services (using [ZeroMQ](https://github.com/zeromq/libzmq)).
 - [sponge](https://github.com/zhufuyi/sponge) - A distributed development framework that integrates automatic code generation, gin and grpc frameworks, base development frameworks.
 - [Tarmac](https://github.com/tarmac-project/tarmac) - Framework for writing functions, microservices, or monoliths with WebAssembly


### PR DESCRIPTION
Adds [servicepack](https://github.com/psyb0t/servicepack) to the **Distributed Systems** section (alphabetical order, single entry).

A framework for running multiple services concurrently in a single binary — run the whole stack locally for debugging, or distribute services across machines via one environment variable.

Forge link: https://github.com/psyb0t/servicepack
pkg.go.dev: https://pkg.go.dev/github.com/psyb0t/servicepack
goreportcard.com: https://goreportcard.com/report/github.com/psyb0t/servicepack

**Quality checklist**
- Open source license: MIT.
- `go.mod` present; tagged SemVer releases published.
- Repository history: well over 5 months since first commit.
- Tests run with `-race` in GitHub Actions CI; coverage is **95.2%** and the build fails below the repo's threshold.
- README documents install and usage; API on pkg.go.dev.

**On the missing Codecov/Coveralls link — deliberate, not an oversight.** The coverage is real (95.2%) and enforced on every push: `make test-coverage` runs `go test -race` and fails the build under threshold, and the live figure is rendered by a self-hosted SVG badge committed to a `badges` branch — no third-party coverage service, no upload tokens to babysit, nothing external to rot. The automated check only recognizes codecov.io/coveralls.io URLs, so it flags this as a warning; the number is legit and gate-enforced, and I'm happy to point at CI run logs if you want to verify.