### PR TITLE
Add gofindimpl

### DIFF
--- a/README.md
+++ b/README.md
@@ -3467,6 +3467,7 @@ _Plugin for text editors and IDEs._
 - [go-swagger](https://github.com/go-swagger/go-swagger) - Swagger 2.0 implementation for go. Swagger is a simple yet powerful representation of your RESTful API.
 - [go-template-playground](https://bartventer.github.io/go-template-playground/) - An interactive environment to create and test Go templates.
 - [godbg](https://github.com/tylerwince/godbg) - Implementation of Rusts `dbg!` macro for quick and easy debugging during development.
+- [gofindimpl](https://github.com/psyb0t/gofindimpl) - Find all structs that implement a given Go interface across a codebase.
 - [gomodrun](https://github.com/dustinblackman/gomodrun/) - Go tool that executes and caches binaries included in go.mod files.
 - [gotemplate.io](https://gotemplate.io/) - Online tool to preview `text/template` templates live.
 - [gotestdox](https://github.com/bitfield/gotestdox) - Show Go test results as readable sentences.


### PR DESCRIPTION
Adds [gofindimpl](https://github.com/psyb0t/gofindimpl) to the **Go Tools** section (alphabetical order, single entry).

A CLI tool that scans a codebase and reports every struct implementing a given Go interface, emitting the results as JSON.

Forge link: https://github.com/psyb0t/gofindimpl
pkg.go.dev: https://pkg.go.dev/github.com/psyb0t/gofindimpl
goreportcard.com: https://goreportcard.com/report/github.com/psyb0t/gofindimpl

**Quality checklist**
- Open source license: MIT.
- `go.mod` present; tagged SemVer releases published.
- Repository history: well over 5 months since first commit.
- Tests run with `-race` in GitHub Actions CI; coverage is **90.3%** and the build fails below the repo's threshold.
- README documents install and usage; API on pkg.go.dev.

**On the missing Codecov/Coveralls link — deliberate, not an oversight.** The coverage is real (90.3%) and enforced on every push: `make test-coverage` runs `go test -race` and fails the build under threshold, and the live figure is rendered by a self-hosted SVG badge committed to a `badges` branch — no third-party coverage service, no upload tokens to babysit, nothing external to rot. The automated check only recognizes codecov.io/coveralls.io URLs, so it flags this as a warning; the number is legit and gate-enforced, and I'm happy to point at CI run logs if you want to verify.