### PR TITLE
Add goenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ _Libraries for configuration parsing._
 - [GoCfg](https://github.com/Jagerente/gocfg) - Config manager with Struct Tags based contracts, custom value providers, parsers, and documentation generation. Customizable yet simple.
 - [goconfig](https://github.com/fulldump/goconfig) - Populate Go structs from flags, environment variables, config.json and defaults with deterministic precedence. No extra dependencies.
 - [godotenv](https://github.com/joho/godotenv) - Go port of Ruby's dotenv library (Loads environment variables from `.env`).
+- [goenv](https://github.com/psyb0t/goenv) - Reads the ENV environment variable and reports whether the process is running in production or development.
 - [GoLobby/Config](https://github.com/golobby/config) - GoLobby Config is a lightweight yet powerful configuration manager for the Go programming language.
 - [gone/jconf](https://github.com/One-com/gone/tree/master/jconf) - Modular JSON configuration. Keep your config structs along with the code they configure and delegate parsing to submodules without sacrificing full config serialization.
 - [gonfig](https://github.com/milad-abbasi/gonfig) - Tag-based configuration parser which loads values from different providers into typesafe struct.


### PR DESCRIPTION
Adds [goenv](https://github.com/psyb0t/goenv) to the **Configuration** section (alphabetical order, single entry).

Reads the ENV environment variable and reports whether the process is running in production or development.

Forge link: https://github.com/psyb0t/goenv
pkg.go.dev: https://pkg.go.dev/github.com/psyb0t/goenv
goreportcard.com: https://goreportcard.com/report/github.com/psyb0t/goenv

**Quality checklist**
- Open source license: MIT.
- `go.mod` present; tagged SemVer releases published.
- Tests run with `-race` in GitHub Actions CI; coverage is **100%**, gate-enforced (build fails below threshold).
- README documents install and usage; API on pkg.go.dev.
- Coverage is enforced in-repo and shown via a self-hosted badge (no Codecov/Coveralls upload tokens); the automated coverage-link check flags this as a warning, but the figure is real.