### PR TITLE
Add gonfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ _Libraries for configuration parsing._
 - [GoLobby/Config](https://github.com/golobby/config) - GoLobby Config is a lightweight yet powerful configuration manager for the Go programming language.
 - [gone/jconf](https://github.com/One-com/gone/tree/master/jconf) - Modular JSON configuration. Keep your config structs along with the code they configure and delegate parsing to submodules without sacrificing full config serialization.
 - [gonfig](https://github.com/milad-abbasi/gonfig) - Tag-based configuration parser which loads values from different providers into typesafe struct.
+- [gonfiguration](https://github.com/psyb0t/gonfiguration) - Loads configuration from environment variables into structs via reflection, with struct-tag defaults and required fields.
 - [gookit/config](https://github.com/gookit/config) - application config manage(load,get,set). support JSON, YAML, TOML, INI, HCL. multi file load, data override merge.
 - [harvester](https://github.com/beatlabs/harvester) - Harvester, a easy to use static and dynamic configuration package supporting seeding, env vars and Consul integration.
 - [hedzr/store](https://github.com/hedzr/store) - Extensible, high-performance configuration management library, optimized for hierarchical data.


### PR DESCRIPTION
Adds [gonfiguration](https://github.com/psyb0t/gonfiguration) to the **Configuration** section (alphabetical order, single entry).

Loads configuration from environment variables into Go structs via reflection, with struct-tag defaults and required-field validation.

Forge link: https://github.com/psyb0t/gonfiguration
pkg.go.dev: https://pkg.go.dev/github.com/psyb0t/gonfiguration
goreportcard.com: https://goreportcard.com/report/github.com/psyb0t/gonfiguration

**Quality checklist**
- Open source license: MIT.
- `go.mod` present; tagged SemVer releases published.
- Tests run with `-race` in GitHub Actions CI; coverage is **98.2%**, gate-enforced (build fails below threshold).
- README documents install and usage; API on pkg.go.dev.
- Coverage is enforced in-repo and shown via a self-hosted badge (no Codecov/Coveralls upload tokens); the automated coverage-link check flags this as a warning, but the figure is real.