### PR TITLE
Add aichteeteapee

### DIFF
--- a/README.md
+++ b/README.md
@@ -3204,6 +3204,7 @@ _Libraries for manipulating video._
 
 _Full stack web frameworks._
 
+- [aichteeteapee](https://github.com/psyb0t/aichteeteapee) - Batteries-included HTTP server library with a router, middleware stack, WebSocket hubs, file uploads, and OpenAPI validation.
 - [Andurel](https://github.com/mbvlabs/andurel) - Rails-inspired full-stack Go web framework with scaffolding, database tooling, and server-rendered or Inertia frontends.
 - [Atreugo](https://github.com/savsgio/atreugo) - High performance and extensible micro web framework with zero memory allocations in hot paths.
 - [Barf](https://github.com/opensaucerer/barf) - Basically, A Remarkable Framework for building JSON-based web APIs. It is entirely unobtrusive and re-invents no wheel. It is crafted such that getting started is easy and quick while being flexible enough for more complex use cases.


### PR DESCRIPTION
Adds [aichteeteapee](https://github.com/psyb0t/aichteeteapee) to the **Web Frameworks** section (alphabetical order, single entry).

A batteries-included HTTP server library: router, middleware stack (auth, CORS, logging, recovery, timeouts), WebSocket hubs, file uploads, static serving, request proxying with caching, and OpenAPI validation.

Forge link: https://github.com/psyb0t/aichteeteapee
pkg.go.dev: https://pkg.go.dev/github.com/psyb0t/aichteeteapee
goreportcard.com: https://goreportcard.com/report/github.com/psyb0t/aichteeteapee

**Quality checklist**
- Open source license: MIT.
- `go.mod` present (Go 1.26); tagged SemVer releases published.
- Repository history: well over 5 months since first commit.
- Tests run with `-race` in GitHub Actions CI; coverage is **86.1%**, gate-enforced.
- README documents install and usage; API on pkg.go.dev.

Note: coverage is enforced in-repo via CI and shown by a self-hosted badge rather than Codecov/Coveralls, so the automated coverage-link check may flag it — the 86.1% figure is real and gate-enforced on every run.