### PR TITLE
Add slog-configurator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1729,6 +1729,7 @@ _Libraries for generating and working with log files._
 - [sentry-go](https://github.com/getsentry/sentry-go) - Sentry SDK for Go. Helps monitor and track errors with real-time alerts and performance monitoring.
 - [slf4g](https://github.com/echocat/slf4g) - Simple Logging Facade for Golang: Simple structured logging; but powerful, extendable and customizable, with huge amount of learnings from decades of past logging frameworks.
 - [slog](https://github.com/gookit/slog) - Lightweight, configurable, extensible logger for Go.
+- [slog-configurator](https://github.com/psyb0t/slog-configurator) - Configures the standard library log/slog logger from environment variables: level, format, source location, and stdout/stderr split.
 - [slog-formatter](https://github.com/samber/slog-formatter) - Common formatters for slog and helpers to build your own.
 - [slog-multi](https://github.com/samber/slog-multi) - Chain of slog.Handler (pipeline, fanout...).
 - [slogor](https://gitlab.com/greyxor/slogor) - A colorful slog handler.


### PR DESCRIPTION
Adds [slog-configurator](https://github.com/psyb0t/slog-configurator) to the **Logging** section (alphabetical order, single entry).

Configures the standard library log/slog logger from environment variables (level, format, source location) with an automatic stdout/stderr split and stackable custom handlers.

Forge link: https://github.com/psyb0t/slog-configurator
pkg.go.dev: https://pkg.go.dev/github.com/psyb0t/slog-configurator
goreportcard.com: https://goreportcard.com/report/github.com/psyb0t/slog-configurator

**Quality checklist**
- Open source license: MIT.
- `go.mod` present (Go 1.26); tagged SemVer releases published.
- Repository history: well over 5 months since first commit.
- Tests run with `-race` in GitHub Actions CI; coverage is **96.3%**, gate-enforced.
- README documents install and usage; API on pkg.go.dev.

Note: coverage is enforced in-repo via CI and shown by a self-hosted badge rather than Codecov/Coveralls, so the automated coverage-link check may flag it — the 96.3% figure is real and gate-enforced on every run.