### PR TITLE
Add go-spamcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -1134,6 +1134,7 @@ _Libraries and tools that implement email creation and sending._
 - [go-message](https://github.com/emersion/go-message) - Streaming library for the Internet Message Format and mail messages.
 - [go-premailer](https://github.com/vanng822/go-premailer) - Inline styling for HTML mail in Go.
 - [go-simple-mail](https://github.com/xhit/go-simple-mail) - Very simple package to send emails with SMTP Keep Alive and two timeouts: Connect and Send.
+- [go-spamcheck](https://github.com/psyb0t/go-spamcheck) - Client for Postmark's SpamCheck API that scores a raw email against SpamAssassin rules.
 - [Hectane](https://github.com/hectane/hectane) - Lightweight SMTP client providing an HTTP API.
 - [hermes](https://github.com/matcornic/hermes) - Golang package that generates clean, responsive HTML e-mails.
 - [Maddy](https://github.com/foxcpp/maddy) - All-in-one (SMTP, IMAP, DKIM, DMARC, MTA-STS, DANE) email server


### PR DESCRIPTION
Adds [go-spamcheck](https://github.com/psyb0t/go-spamcheck) to the **Email** section (alphabetical order, single entry).

A tiny client for Postmark's public SpamCheck API: submit a raw email, get its SpamAssassin score and matched-rule breakdown. No account or API key required.

Forge link: https://github.com/psyb0t/go-spamcheck
pkg.go.dev: https://pkg.go.dev/github.com/psyb0t/go-spamcheck
goreportcard.com: https://goreportcard.com/report/github.com/psyb0t/go-spamcheck

**Quality checklist**
- Open source license: MIT.
- `go.mod` present (Go 1.26); tagged SemVer releases published.
- Repository history: well over 5 months since first commit.
- Tests run with `-race` in GitHub Actions CI; coverage is **97.1%**, gate-enforced.
- README documents install and usage; API on pkg.go.dev.

Note: coverage is enforced in-repo via CI and shown by a self-hosted badge rather than Codecov/Coveralls, so the automated coverage-link check may flag it — the 97.1% figure is real and gate-enforced on every run.