### PR TITLE
Add oapixconstgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -3457,6 +3457,7 @@ _Plugin for text editors and IDEs._
 - [gotests](https://github.com/cweill/gotests) - Generate Go tests from your source code.
 - [gounit](https://github.com/hexdigest/gounit) - Generate Go tests using your own templates.
 - [hasgo](https://github.com/DylanMeeus/hasgo) - Generate Haskell inspired functions for your slices.
+- [oapixconstgen](https://github.com/psyb0t/oapixconstgen) - Generate typed Go constants from an OpenAPI spec's x-constants extension.
 - [options-gen](https://github.com/kazhuravlev/options-gen) - Functional options described by Dave Cheney's post "Functional options for friendly APIs".
 - [re2dfa](https://gitlab.com/opennota/re2dfa) - Transform regular expressions into finite state machines and output Go source code.
 - [sqlgen](https://github.com/anqiansong/sqlgen) - Generate gorm, xorm, sqlx, bun, sql code from SQL file or DSN.


### PR DESCRIPTION
Adds [oapixconstgen](https://github.com/psyb0t/oapixconstgen) to **Go Generate Tools** (alphabetically, between hasgo and options-gen).

Forge link: https://github.com/psyb0t/oapixconstgen
pkg.go.dev: https://pkg.go.dev/github.com/psyb0t/oapixconstgen
goreportcard.com: https://goreportcard.com/report/github.com/psyb0t/oapixconstgen

A Go tool that reads the `x-constants` extension from an OpenAPI spec and generates a Go file of properly typed constants, keeping the API spec and Go code in sync. Same external-spec-to-Go-source shape as the existing sqlgen / godal / re2dfa entries in this section.

- MIT licensed, go.mod + SemVer tags, pkg.go.dev reachable
- Single item, added in alphabetical order