### PR TITLE
Add proxq

### DIFF
--- a/README.md
+++ b/README.md
@@ -2180,6 +2180,7 @@ _Libraries for working with various layers of the network._
 - [nodepass](https://github.com/NodePassProject/nodepass) - A secure, efficient TCP/UDP tunneling solution that delivers fast, reliable access across network restrictions using pre-established TCP/QUIC/WebSocket or HTTP/2 connections.
 - [peerdiscovery](https://github.com/schollz/peerdiscovery) - Pure Go library for cross-platform local peer discovery using UDP multicast.
 - [portproxy](https://github.com/aybabtme/portproxy) - Simple TCP proxy which adds CORS support to API's which don't support it.
+- [proxq](https://github.com/psyb0t/docker-proxq) - Asynchronous reverse proxy that queues each request in Redis and returns a job ID to poll for the response, with path-prefix routing, retries, and caching.
 - [psql-wire](https://github.com/jeroenrinzema/psql-wire) - PostgreSQL server wire protocol. Build your own server and start serving connections..
 - [publicip](https://github.com/polera/publicip) - Package publicip returns your public facing IPv4 address (internet egress).
 - [quic-go](https://github.com/lucas-clemente/quic-go) - An implementation of the QUIC protocol in pure Go.


### PR DESCRIPTION
Adds [proxq](https://github.com/psyb0t/docker-proxq) to **Networking** (alphabetically, between portproxy and psql-wire).

Forge link: https://github.com/psyb0t/docker-proxq
pkg.go.dev: https://pkg.go.dev/github.com/psyb0t/docker-proxq
goreportcard.com: https://goreportcard.com/report/github.com/psyb0t/docker-proxq

An asynchronous reverse proxy: it accepts a request, enqueues it in Redis, and immediately returns a job ID the client polls for the result — useful when a CDN or front proxy has a shorter timeout than the backend needs. Supports path-prefix upstream routing with prefix stripping, per-upstream timeouts, retries with backoff, response caching, and a direct-proxy bypass for large bodies. Same shape as the existing fullproxy / portproxy / chproxy entries in this section.

- MIT licensed, go.mod + SemVer tags (v0.10.7), pkg.go.dev reachable
- Single item, added in alphabetical order