### PR TITLE
Add E2BGateway - Multi-backend gateway for AI agent sandboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2129,6 +2129,7 @@ _Libraries for working with various layers of the network._
 - [dns](https://github.com/miekg/dns) - Go library for working with DNS.
 - [dnsmonster](https://github.com/mosajjal/dnsmonster) - Passive DNS Capture/Monitoring Framework.
 - [easytcp](https://github.com/DarthPestilane/easytcp) - A light-weight TCP framework written in Go (Golang), built with message router. EasyTCP helps you build a TCP server easily fast and less painful.
+- [E2BGateway](https://github.com/e2bgateway/e2bgateway) - A unified gateway that enables the official E2B client to interoperate with multiple agent runtimes including agent-sandbox and OpenSandbox. Features zero-code migration, multi-backend routing, auth, rate limiting, and OpenTelemetry observability.
 - [ether](https://github.com/songgao/ether) - Cross-platform Go package for sending and receiving ethernet frames.
 - [ethernet](https://github.com/mdlayher/ethernet) - Package ethernet implements marshaling and unmarshalling of IEEE 802.3 Ethernet II frames and IEEE 802.1Q VLAN tags.
 - [event](https://github.com/cheng-zhongliang/event) - Simple I/O event notification library written in Golang.


### PR DESCRIPTION
## Description

Adding E2BGateway to the Networking section. E2BGateway is a Go-based gateway that provides full E2B SDK compatibility while routing requests to multiple sandbox backends for AI agents.

## About E2BGateway

E2BGateway acts as an abstraction layer for AI agent sandboxes. It provides a fully compatible interface aligned with the official E2B client protocol, transparently routing requests to diverse underlying agent runtime implementations.

### Key Features

- **Multi-Backend Support**: Routes to agent-sandbox (Kubernetes), OpenSandbox, or E2B Cloud
- **Zero-Code Migration**: Existing E2B SDK users just change one URL
- **Production Ready**: Auth, rate limiting, audit logging, OpenTelemetry observability
- **High Performance**: Built with Go for low latency and high throughput
- **WebSocket Support**: Full duplex communication for streaming code execution
- **Kubernetes Native**: Integrates with kubernetes-sigs/agent-sandbox CRDs

### Use Cases

1. **Cost Optimization**: Route dev traffic to self-hosted, prod to E2B Cloud
2. **Data Sovereignty**: Keep all sandboxes on your own infrastructure
3. **Multi-Tenant Platforms**: Different backends per tenant
4. **Hybrid Cloud**: Mix cloud and self-hosted backends

### Quick Example

```python
import os
os.environ["E2B_API_URL"] = "https://your-gateway.com"

from e2b_code_interpreter import Sandbox
sbx = Sandbox.create(template="code-interpreter")
result = sbx.run_code("print('Hello from E2BGateway!')")
```

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md)
- [x] The project is open source with Apache 2.0 license
- [x] The project has a comprehensive README
- [x] The project is written in Go
- [x] The entry is in alphabetical order
- [x] The project is actively maintained

## Links

- **Repository**: https://github.com/e2bgateway/e2bgateway
- **Documentation**: https://github.com/e2bgateway/e2bgateway/tree/main/docs

## Why it's awesome

E2BGateway fills a unique niche in the Go ecosystem:
- Only multi-backend gateway for E2B protocol
- Bridges cloud and self-hosted AI agent infrastructure
- Production-grade with enterprise features
- Active development and community support

Thanks for considering!