### PR TITLE
Add Smeldr to Artificial Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ _Libraries for building programs that leverage AI._
 - [routex](https://github.com/Ad3bay0c/routex) - YAML-driven multi-agent AI runtime for Go with Erlang-style supervision, MCP tool server support, and a CLI.
 - [semantic-search](https://github.com/DavidBelicza/semantic-search) - Meaning-based search over PDF, Markdown, DOCX, source code, and other file types, using generative AI embedding models to vectorize files into a vector database.
 - [skillreaper](https://github.com/thousandflowers/skillreaper) - CLI that scans AI agent session transcripts to identify and safely quarantine unused skills, MCP servers, and agents across Claude Code, Codex CLI, Hermes, OpenCode, Cursor, and OpenClaw.
+- [Smeldr](https://github.com/Smeldr/core) - AI-native content backend with typed lifecycle management, native MCP tools for every content type, and zero runtime dependencies.
 - [trpc-agent-go](https://github.com/trpc-group/trpc-agent-go) - Framework for building LLM-based multi-agent systems.
 - [web-researcher-mcp](https://github.com/zoharbabin/web-researcher-mcp) - MCP server providing AI assistants with web search, content extraction, and multi-source research capabilities. Single binary, 5 search providers with circuit-breaker failover, 4-tier scraping pipeline.
 - [zenflow](https://github.com/zendev-sh/zenflow) - Multi-agent orchestration & workflow engine. Declarative YAML workflows, LLM coordinator with hub-and-spoke mailboxes, race-safe delivery. One YAML file, one Go binary. Runs on any goai-supported provider.


### PR DESCRIPTION
Forge link: https://github.com/Smeldr/core
pkg.go.dev: https://pkg.go.dev/smeldr.dev/core
goreportcard.com: https://goreportcard.com/report/github.com/Smeldr/core
Coverage: https://codecov.io/gh/Smeldr/core

Note: Go Report Card was sunset by its maintainers ("After more than a decade of serving the ecosystem, Go Report Card has been sunset.") -- the link above no longer returns a grade. This appears already accounted for in this repo's own automated quality check, which reports "OK (grade unknown)" for repos in this situation.