### PR TITLE
Add ast-metrics to Code Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -3393,6 +3393,7 @@ _Libraries and tools to implement Zero Trust architectures._
 _Source code analysis tools, also known as Static Application Security Testing (SAST) Tools._
 
 - [apicompat](https://github.com/bradleyfalzon/apicompat) - Checks recent changes to a Go project for backwards incompatible changes.
+- [ast-metrics](https://github.com/ast-metrics/ast-metrics) - Static code analyzer for Go and other languages: complexity, coupling, cohesion and maintainability metrics, with HTML, JSON, Markdown and SARIF reports.
 - [asty](https://github.com/asty-org/asty) - Converts golang AST to JSON and JSON to AST.
 - [blanket](https://gitlab.com/verygoodsoftwarenotvirus/blanket) - blanket is a tool that helps you catch functions which don't have direct unit tests in your Go packages.
 - [ChainJacking](https://github.com/Checkmarx/chainjacking) - Find which of your Go lang direct GitHub dependencies is susceptible to ChainJacking attack.


### PR DESCRIPTION
## Required links

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/ast-metrics/ast-metrics
- [x] pkg.go.dev: https://pkg.go.dev/github.com/ast-metrics/ast-metrics
- [x] goreportcard.com: https://goreportcard.com/report/github.com/ast-metrics/ast-metrics
- [x] Coverage service link: https://app.codecov.io/gh/ast-metrics/ast-metrics

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`). Latest is `v0.40.2`.
- [x] The repo has an open source license (MIT).
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link.
- [x] The repo documentation has a coverage service link.
- [x] The repo has a continuous integration process (GitHub Actions).
- [x] CI runs tests that must pass before merging.

## Pull Request content

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order** (between `apicompat` and `asty`).
- [x] The link text is the **exact project name**.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.

I checked the five entries surrounding my addition (`apicompat`, `asty`,
`blanket`, `ChainJacking`, `Chronos`). None of them is archived and all links
resolve, so I did not remove anything. For the record, three of them look
dormant: `apicompat` (last push 2017), `Chronos` (2022) and `asty` (2023). I
left them in place to keep this PR to a single item, but I am happy to open
separate removal PRs if maintainers want.

## About the project

AST Metrics is a static code analyzer written in Go. It parses source code with
tree-sitter and computes maintainability metrics (cyclomatic and cognitive
complexity, Halstead volume, afferent/efferent coupling, LCOM, maintainability
index, community detection on the dependency graph), then reports them as HTML,
JSON, Markdown, SARIF or OpenMetrics. It analyzes Go alongside PHP, Python, Rust
and others, ships as a single binary with no server or runtime dependency, and
is MIT licensed. First commit is from 2024, and it is under active development.