### PR TITLE
Add roamr

### DIFF
--- a/README.md
+++ b/README.md
@@ -2186,6 +2186,7 @@ _Libraries for working with various layers of the network._
 - [psql-wire](https://github.com/jeroenrinzema/psql-wire) - PostgreSQL server wire protocol. Build your own server and start serving connections..
 - [publicip](https://github.com/polera/publicip) - Package publicip returns your public facing IPv4 address (internet egress).
 - [quic-go](https://github.com/lucas-clemente/quic-go) - An implementation of the QUIC protocol in pure Go.
+- [roamr](https://github.com/sourabh-khot65/roamr) - CLI that scores nearby saved WiFi networks and tells you which to use, and why.
 - [sdns](https://github.com/semihalev/sdns) - A high-performance, recursive DNS resolver server with DNSSEC support, focused on preserving privacy.
 - [sftp](https://github.com/pkg/sftp) - Package sftp implements the SSH File Transfer Protocol as described in <https://filezilla-project.org/specs/draft-ietf-secsh-filexfer-02.txt>.
 - [ssh](https://github.com/gliderlabs/ssh) - Higher-level API for building SSH servers (wraps crypto/ssh).


### PR DESCRIPTION
Adding roamr, a CLI that scores nearby saved WiFi networks and recommends the best one with an explanation.

Forge link: https://github.com/sourabh-khot65/roamr
pkg.go.dev: https://pkg.go.dev/github.com/sourabh-khot65/roamr
goreportcard.com: https://goreportcard.com/report/github.com/sourabh-khot65/roamr

roamr is now indexed on pkg.go.dev (v0.1.1).

- [x] Added in alphabetical order within the Networking section
- [x] Link is to a GitHub repo with a real project
- [x] MIT licensed
- [x] Has tests and CI
- [x] Has a Go reference (pkg.go.dev) badge
- [x] Description is short, starts with a capital, ends with a period