### PR TITLE
Add mcprobe to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -2444,6 +2444,7 @@ _Libraries that are used to help make your application more secure._
 - [leakhound](https://github.com/nilpoona/leakhound) - Static analysis tool to detect accidental logging of sensitive struct fields, preventing data leaks in logs.
 - [lego](https://github.com/go-acme/lego) - Pure Go ACME client library and CLI tool (for use with Let's Encrypt).
 - [luks.go](https://github.com/anatol/luks.go) - Pure Golang library to manage LUKS partitions.
+- [mcprobe](https://github.com/tamish560/mcprobe) - Security scanner for MCP servers with prompt injection detection, tool shadowing, and SARIF output.
 - [memguard](https://github.com/awnumar/memguard) - A pure Go library for handling sensitive values in memory.
 - [multikey](https://github.com/adrianosela/multikey) - An n-out-of-N keys encryption/decryption framework based on Shamir's Secret Sharing algorithm.
 - [nacl](https://github.com/kevinburke/nacl) - Go implementation of the NaCL set of API's.


### PR DESCRIPTION
Security scanner for MCP servers. Connects via stdio/HTTP/SSE, runs 18 injection-detection patterns against tool descriptions, checks for tool shadowing, supports baseline diffing, and outputs SARIF for CI/CD.

Forge link: https://github.com/tamish560/mcprobe
pkg.go.dev: https://pkg.go.dev/github.com/tamish560/mcprobe
goreportcard.com: https://goreportcard.com/report/github.com/tamish560/mcprobe
Coverage: https://github.com/tamish560/mcprobe (58.6%, tracked in CI)