### PR TITLE
Add forge to Artificial Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ _Libraries for building programs that leverage AI._
 - [ai](https://github.com/joakimcarlsson/ai) - A Go toolkit for building AI agents and applications across multiple providers with unified LLM, embeddings, tool calling, and MCP integration.
 - [chromem-go](https://github.com/philippgille/chromem-go) - Embeddable vector database for Go with Chroma-like interface and zero third-party dependencies. In-memory with optional persistence.
 - [dakera-go](https://github.com/dakera-ai/dakera-go) - Official Go client SDK for the Dakera self-hosted agent memory server, providing typed interfaces for memory store/recall, session management, namespace operations, and decay configuration.
+- [forge](https://github.com/valtors/forge) - Local-first agent runtime with process supervision, memory, sandboxing, and MCP server wiring.
 - [fun](https://gitlab.com/tozd/go/fun) - The simplest but powerful way to use large language models (LLMs) in Go.
 - [goai](https://github.com/zendev-sh/goai) - Go SDK for building AI applications. One SDK, 20+ providers. Inspired by Vercel AI SDK.
 - [GoModel](https://github.com/ENTERPILOT/GoModel) - AI gateway exposing a unified OpenAI-compatible API across OpenAI, Anthropic, Gemini, Groq, xAI, Ollama and other providers, with routing, usage tracking, rate limits, and guardrails.


### PR DESCRIPTION
Local-first agent runtime. One binary manages process supervision, memory, sandboxing, MCP server wiring, and observability for coding agents.

Forge link: https://github.com/valtors/forge
pkg.go.dev: https://pkg.go.dev/github.com/valtors/forge
Go Report Card: https://goreportcard.com/report/github.com/valtors/forge
Coverage: https://app.codecov.io/gh/valtors/forge (73.3%, tracked in CI)