### PR TITLE
Add vault to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -2467,6 +2467,7 @@ _Libraries that are used to help make your application more secure._
 - [teler-waf](https://github.com/kitabisa/teler-waf) - teler-waf is a Go HTTP middleware that provide teler IDS functionality to protect against web-based attacks and improve the security of Go-based web applications. It is highly configurable and easy to integrate into existing Go applications.
 - [themis](https://github.com/cossacklabs/themis) - high-level cryptographic library for solving typical data security tasks (secure data storage, secure messaging, zero-knowledge proof authentication), available for 14 languages, best fit for multi-platform apps.
 - [urusai](https://github.com/calpa/urusai) - Urusai ("noisy" in Japanese) is a Go implementation of a random HTTP/DNS traffic noise generator that helps protect privacy by creating digital smokescreens while browsing.
+- [vault](https://github.com/valtors/vault) - Sandbox runtime for AI agents: filesystem overlay, env sanitizer, network policy, and MCP prompt-injection scanner with per-sandbox audit logging.
 - [veil](https://github.com/getveil/veil) - Local HTTPS proxy that hides API credentials from AI coding agents. OS keychain integration, format-aware placeholders, SQLite audit log.
 
 


### PR DESCRIPTION
Sandbox runtime for AI agents. Wraps untrusted processes in filesystem overlay, sanitized environment, network policy, and MCP prompt-injection scanner with per-sandbox audit logging.

Forge link: https://github.com/valtors/vault
pkg.go.dev: https://pkg.go.dev/github.com/valtors/vault
goreportcard.com: https://goreportcard.com/report/github.com/valtors/vault
Coverage: https://github.com/valtors/vault (76.3%, tracked in CI)