### PR TITLE
Remove kepfi from DevOps Tools (dead repository)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3565,7 +3565,6 @@ _Software written in Go._
 - [k9s](https://github.com/derailed/k9s) - Kubernetes CLI to manage your clusters in style.
 - [kala](https://github.com/ajvb/kala) - Simplistic, modern, and performant job scheduler.
 - [kcli](https://github.com/cswank/kcli) - Command line tool for inspecting kafka topics/partitions/messages.
-- [kepfi](https://github.com/Knuspii/kepfi) - A smart alternative to rm with a recovery bin and storage tracking.
 - [kind](https://github.com/kubernetes-sigs/kind) - Kubernetes IN Docker - local clusters for testing Kubernetes.
 - [ko](https://github.com/google/ko) - Command line tool for building and deploying Go applications on Kubernetes
 - [kool](https://github.com/kool-dev/kool) - Command line tool for managing Docker environments as an easy way.


### PR DESCRIPTION
Removes the `kepfi` entry from **DevOps Tools**. The linked repository no longer exists.

Refs #6279 (Investigate repositories with more than 1 year without update).

### Which criteria the project is not meeting

- **The project is no longer open-sourced / the repository is gone.** `https://github.com/Knuspii/kepfi` returns HTTP 404 with no redirect, so the listed link is dead and the source is no longer available.
- **The quality standard links have been removed.** With the repository deleted, pkg.go.dev, Go Report Card and coverage for the module are unreachable, and there is no README or license to review.

### Evidence

1. HTTP status (following redirects):

```
$ curl -s -o /dev/null -w "%{http_code}\n" -L https://github.com/Knuspii/kepfi
404
```

There is no `location` header on the response — GitHub does not redirect it to a renamed repository.

2. GitHub GraphQL API:

```
$ gh api graphql -f query='{repository(owner:"Knuspii",name:"kepfi"){nameWithOwner}}'
{"data":{"repository":null},"errors":[{"type":"NOT_FOUND", ...
  "message":"Could not resolve to a Repository with the name 'Knuspii/kepfi'."}]}
```

3. No renamed successor. The owner account still exists and has 12 public repositories, none of which is kepfi under another name:

```
arduino-tft-matrix-rain, CrunchyCleaner, FartBomb, git-top.net,
gmodserver_raspberrypi_arm64, home-server, HomeLab-Doctor, JunkLauncher,
Knuspii, nixos-kde, nixpkgs, nixpkgs-review-gha
```

So a link fix is not possible and removal is the correct action.

### Notification

The entry was added in #6173 by @Knuspii, who is also the repository owner — pinging so they have an opportunity to respond (for example by restoring the repository).

### Guideline compliance

- One item removed, one line deleted, `README.md` only (`1 file changed, 1 deletion(-)`).
- DevOps Tools keeps **106** entries after the removal, well above the 3-entry category minimum.
- Alphabetical ordering of the surrounding entries (`kcli` → `kind`) is preserved.

### Validation

- `go test -run '^(TestAlpha|TestDuplicatedLinks|TestSeparator|TestRenderIndex|TestToHTML|TestGenerate)$' ./...` — identical result before and after the change: `TestAlpha`, `TestSeparator`, `TestRenderIndex`, `TestToHTML`, `TestGenerate` and both `pkg/` packages pass. The only failure, `TestDuplicatedLinks/relay` (`duplicated link 'https://github.com/valtors/relay'`), already fails on an unmodified checkout of `main` and is unrelated to this entry.
- `AWESOME_SKIP_FETCH=1 go run .` — the site generator completes successfully (`Rendered 5536 project pages`, sitemap and static assets written), and no page is generated for the removed entry.



---

Bot-required links (they reference the *removed* project; all dead, which is the point of this PR):

Forge link: https://github.com/Knuspii/kepfi
pkg.go.dev: https://pkg.go.dev/github.com/Knuspii/kepfi
goreportcard.com: https://goreportcard.com/report/github.com/Knuspii/kepfi
