### PR TITLE
Add traverse to Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3116,6 +3116,7 @@ _General utilities and tools to make your life easier._
 - [throttle](https://github.com/yudppp/throttle) - Throttle is an object that will perform exactly one action per duration.
 - [tik](https://github.com/andy2046/tik) - Simple and easy timing wheel package for Go.
 - [tome](https://github.com/cyruzin/tome) - Tome was designed to paginate simple RESTful APIs.
+- [traverse](https://github.com/chenyc21/traverse) - A TUI file manager that treats Windows as a first-class citizen. Native PowerShell integration, instant filter, Git diff preview.
 - [toolbox](https://github.com/viant/toolbox) - Slice, map, multimap, struct, function, data conversion utilities. Service router, macro evaluator, tokenizer.
 - [UNIS](https://github.com/esemplastic/unis) - Common Architecture™ for String Utilities in Go.
 - [upterm](https://github.com/owenthereal/upterm) - A tool for developers to share terminal/tmux sessions securely over the web. It’s perfect for remote pair programming, accessing computers behind NATs/firewalls, remote debugging, and more.


### PR DESCRIPTION
## What

Add [traverse](https://github.com/chenyc21/traverse) to the **Utilities** section.

## About traverse

A TUI file manager that treats Windows as a first-class citizen:

- Native PowerShell integration (Ctrl+Z to open shell)
- Instant filter (/ to search files)
- Git diff preview with syntax highlighting
- Single binary, no dependencies
- Built with Bubble Tea

## Changes

Added traverse entry after  in the Utilities section (alphabetical order).