### PR TITLE
chore: templui becomes shadcn-templ

### DIFF
--- a/README.md
+++ b/README.md
@@ -3249,7 +3249,7 @@ _Full stack web frameworks._
 - [rk-boot](https://github.com/rookie-ninja/rk-boot) - A bootstrapper library for building enterprise go microservice with Gin and gRPC quickly and easily.
 - [Ronykit](https://github.com/clubpay/ronykit) - Web framework with pluggable architecture and very performant.
 - [rux](https://github.com/gookit/rux) - Simple and fast web framework for build golang HTTP applications.
-- [templui](https://github.com/axzilla/templui) - Modern UI Components for Go & Templ.
+- [shadcn-templ](https://github.com/axadrn/shadcn-templ) - Unofficial shadcn/ui port for Go and templ: accessible UI components with CLI and registry.
 - [togo](https://github.com/togo-framework/togo) - Full-stack framework that ships your Go backend and React frontend as a single binary; a Laravel-artisan-grade CLI.
 - [uAdmin](https://github.com/uadmin/uadmin) - Fully featured web framework for Golang, inspired by Django.
 - [WebGo](https://github.com/naughtygopher/webgo) - A micro-framework to build web apps with handler chaining, middleware, and context injection. With standard library-compliant HTTP handlers (i.e., `http.HandlerFunc`)..


### PR DESCRIPTION
Updates the existing templui entry. The project was renamed to shadcn-templ (a shadcn/ui port for Go and templ, with shadcn's blessing) and moved from github.com/axzilla/templui to github.com/axadrn/shadcn-templ. Same project, same maintainer, 1.6k+ stars.

- pkg.go.dev: https://pkg.go.dev/github.com/axadrn/shadcn-templ/v2
- goreportcard: https://goreportcard.com/report/github.com/axadrn/shadcn-templ/v2
- The line stays in alphabetical order (rux < shadcn-templ < togo).