### PR TITLE
Add deidentify to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -2427,6 +2427,7 @@ _Libraries that are used to help make your application more secure._
 - [CertMagic](https://github.com/caddyserver/certmagic) - Mature, robust, and powerful ACME client integration for fully-managed TLS certificate issuance and renewal.
 - [Coraza](https://github.com/corazawaf/coraza) - Enterprise-ready, modsecurity and OWASP CRS compatible WAF library.
 - [Crenox](https://github.com/crenoxhq/crenox) - Zero-dependency pre-commit secret scanner using Aho-Corasick for high-performance credentials leak detection.
+- [deidentify](https://github.com/aliengiraffe/deidentify) - Deterministic, format-preserving removal of personally identifiable information from text and structured data.
 - [dongle](https://github.com/golang-module/dongle) - A simple, semantic and developer-friendly golang package for encoding&decoding and encryption&decryption.
 - [dotlock](https://github.com/ahmadraza100/dotlock) - Encrypted .env vault manager with interactive TUI for managing secrets across multiple environments and profiles.
 - [encid](https://github.com/bobg/encid) - Encode and decode encrypted integer IDs.


### PR DESCRIPTION
## Required links

_Provide the links below. Our CI will automatically validate them._

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/aliengiraffe/deidentify
- [x] pkg.go.dev: https://pkg.go.dev/github.com/aliengiraffe/deidentify
- [x] goreportcard.com: https://goreportcard.com/report/github.com/aliengiraffe/deidentify
- [x] Coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://app.codecov.io/gh/aliengiraffe/deidentify

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

_These are validated automatically by CI:_

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`). — `go.mod` at root, latest release `v1.0.2`
- [x] The repo has an open source license. — MIT
- [x] The repo documentation has a pkg.go.dev link. — badge in README
- [ ] The repo documentation has a goreportcard link (grade A- or better). — see note below
- [x] The repo documentation has a coverage service link. — Codecov badge in README

> **Note on the Go Report Card checkbox.** `goreportcard.com` has been sunset; the report page now serves a farewell notice recommending `golangci-lint` and no longer computes grades, and the badge endpoint renders the literal text `go report: retired`. I have supplied the goreportcard link above as the template requires, but I removed the badge from the project README rather than ship one that reads "retired" — so I cannot honestly tick this box. As a substitute quality signal, `gofmt -l .`, `go vet ./...`, and `golangci-lint run ./...` (0 issues) all pass, and the lint job is enforced on every PR in CI. Happy to restore the badge if you would prefer it present despite the sunset.

_These are recommended and reported as warnings:_

- [x] The repo has a continuous integration process (GitHub Actions, etc.). — build/test, lint, and benchmark workflows
- [x] CI runs tests that must pass before merging. — tested against Go 1.24.x, 1.25.x, and 1.26.x

## Pull Request content

_These are validated automatically by CI:_

- [x] This PR adds/removes/changes **only one** package. — one line, one file
- [x] The package has been added in **alphabetical order**. — between `Crenox` and `dongle` under Security
- [x] The link text is the **exact project name**. — `deidentify`, matching the `go.mod` module path
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.

I checked the five entries above and below the insertion point (`certificates`, `CertMagic`, `Coraza`, `Crenox`, `dongle`, `dotlock`, `encid`, `entpassgen`). All remain reachable, licensed, and released; I found no candidates for removal.

One thing worth flagging separately: `go test -run TestAlpha` fails on `main` as of `fd1939d`, before my change, with `expected 'acme-proxy' but actual is 'acmetool'` — the first two entries of the Security category are transposed relative to the test's expected ordering. It is unrelated to this PR (the same failure reproduces on a clean checkout) and I have deliberately not touched those lines, since fixing them would violate the one-item-per-PR rule.

---

**About the package.** `deidentify` is a zero-dependency library for removing PII from text and structured data. Replacements are deterministic — the same input and secret key always produce the same output — so referential integrity is preserved across records and runs and anonymized data remains joinable. Replacements are also format-preserving: phone numbers keep their punctuation and area code, credit card numbers keep a valid Luhn checksum, and SSNs keep a structurally valid layout.

Test coverage is 92.5% of statements.
