### PR TITLE
Add eagle-image-api to Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1545,6 +1545,7 @@ _Libraries for manipulating images._
 - [canvas](https://github.com/tdewolff/canvas) - Vector graphics to PDF, SVG or rasterized image.
 - [color-extractor](https://github.com/marekm4/color-extractor) - Dominant color extractor with no external dependencies.
 - [darkroom](https://github.com/gojek/darkroom) - An image proxy with changeable storage backends and image processing engines with focus on speed and resiliency.
+- [eagle-image-api](https://github.com/nicobistolfi/eagle-image-api) - Image optimization and transformation API using libvips, deployable to AWS Lambda and CloudFront.
 - [geopattern](https://github.com/pravj/geopattern) - Create beautiful generative image patterns from a string.
 - [gg](https://github.com/fogleman/gg) - 2D rendering in pure Go.
 - [gift](https://github.com/disintegration/gift) - Package of image processing filters.


### PR DESCRIPTION
## Required links

_Provide the links below. Our CI will automatically validate them._

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/nicobistolfi/eagle-image-api
- [x] pkg.go.dev: https://pkg.go.dev/github.com/nicobistolfi/eagle-image-api
- [x] goreportcard.com: https://goreportcard.com/report/github.com/nicobistolfi/eagle-image-api
- [x] Coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://app.codecov.io/gh/nicobistolfi/eagle-image-api

Coverage: https://app.codecov.io/gh/nicobistolfi/eagle-image-api

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

_These are validated automatically by CI:_

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`). — `go.mod` at root, latest release `v1.1.0`
- [x] The repo has an open source license. — MIT
- [x] The repo documentation has a pkg.go.dev link. — badge in README
- [ ] The repo documentation has a goreportcard link (grade A- or better). — see note below
- [x] The repo documentation has a coverage service link. — Codecov badge in README

> **Note on the Go Report Card checkbox.** `goreportcard.com` has been sunset. The report page now serves a farewell notice recommending `golangci-lint`, and the badge endpoint returns SVG whose label is the literal text `go report: retired`. I have supplied the goreportcard link above because the template requires it, and the badge remains in the project README so the CI link check still finds it — but since no grade is computed any more, I cannot honestly tick this box.
>
> As substitute quality signals, all of the following run in CI on every pull request and currently pass with zero findings: `gofmt -l .`, `go vet ./...`, `staticcheck ./...`, and `golangci-lint run ./...`. `govulncheck ./...` also reports no vulnerabilities. I am happy to drop the retired badge from the README if the maintainers would prefer that over one reading "retired".

_These are recommended and reported as warnings:_

- [x] The repo has a continuous integration process (GitHub Actions, etc.). — build, test, lint, and coverage upload on every PR and on `main`
- [x] CI runs tests that must pass before merging. — `go test -race` across all packages, gating the deploy workflows

## Pull Request content

_These are validated automatically by CI:_

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**. — between `darkroom` and `geopattern` in Images
- [x] The link text is the **exact project name**. — `eagle-image-api`
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The category has at least 3 items. — Images has 40+
- [x] The package is in the correct category. — see note below

> **On category fit.** Images is described as "Libraries for manipulating images," and this project is a deployable service rather than an importable library. I placed it in Images because the category already contains directly comparable image-processing services — `imaginary`, `imagor`, `mort`, `picfit`, `webp-server`, and `darkroom` — and this sits alongside them rather than alongside the general-purpose libraries. Happy to move it if the maintainers see a better home.

## About the project

Eagle Image API is an image optimization and transformation service built on libvips via [govips](https://github.com/davidbyttow/govips). It resizes, crops, blurs, sharpens, flips, and rotates images fetched from a URL, and negotiates AVIF or WebP output from the client's `Accept` header, falling back to the source format. AVIF encoding is skipped above a configurable megapixel ceiling, since it is slow enough on large images to risk exceeding a Lambda timeout.

It ships as an AWS Lambda container behind API Gateway and CloudFront, described by a CloudFormation template in the repository, plus an `eagle` CLI that deploys the whole stack into a user's own AWS account with one command. Access can be restricted with an origin allowlist, and failures can optionally redirect to the source image so a broken transformation degrades to the original asset.

**Quality standards:**

- **Test coverage: 91.4%** ([Codecov](https://app.codecov.io/gh/nicobistolfi/eagle-image-api)), above the 80% threshold. Image tests run against real libvips rather than mocks.
- **Documentation:** every package and exported identifier carries a doc comment, published on [pkg.go.dev](https://pkg.go.dev/github.com/nicobistolfi/eagle-image-api).
- **Maturity:** first commit November 2023, so roughly 32 months of history, well past the 5-month minimum.
- **License:** MIT.
- **Release:** `v1.1.0`, SemVer tagged, with binaries published by GoReleaser for macOS and Linux on amd64 and arm64.

## A note on the failing `TestAlpha` job

If CI reports a `TestAlpha` failure, it is **pre-existing on `main` and unrelated to this change**. It fires in the Security category over the ordering of `acme-proxy` and `acmetool`:

```
--- FAIL: TestAlpha/Libraries_that_are_used_to_help_make_your_application_more_secure.
    main_test.go:129: expected 'acme-proxy' but actual is 'acmetool'
```

I reproduced it on a clean checkout of `main` with no changes applied, and the output is byte-identical with and without this commit. The Images category passes, which is what confirms this entry is correctly ordered. I left it alone since CONTRIBUTING asks that a PR change only one thing, but I am happy to open a separate PR fixing that ordering if it would help.
