### PR TITLE
Add templ-islands to Web Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3253,6 +3253,7 @@ _Full stack web frameworks._
 - [rk-boot](https://github.com/rookie-ninja/rk-boot) - A bootstrapper library for building enterprise go microservice with Gin and gRPC quickly and easily.
 - [Ronykit](https://github.com/clubpay/ronykit) - Web framework with pluggable architecture and very performant.
 - [rux](https://github.com/gookit/rux) - Simple and fast web framework for build golang HTTP applications.
+- [templ-islands](https://github.com/SalvucciFacundo/templ-islands) - Hybrid optimistic UI islands runtime for Go and templ.
 - [templui](https://github.com/axzilla/templui) - Modern UI Components for Go & Templ.
 - [togo](https://github.com/togo-framework/togo) - Full-stack framework that ships your Go backend and React frontend as a single binary; a Laravel-artisan-grade CLI.
 - [uAdmin](https://github.com/uadmin/uadmin) - Fully featured web framework for Golang, inspired by Django.


### PR DESCRIPTION
Adds `templ-islands` to the Web Frameworks section.

`templ-islands` is a hybrid optimistic UI islands runtime for Go and templ components.

Forge link: https://github.com/SalvucciFacundo/templ-islands
pkg.go.dev: https://pkg.go.dev/github.com/salvuccifacundo/templ-islands
goreportcard.com: https://goreportcard.com/report/github.com/salvuccifacundo/templ-islands