### PR TITLE
Add go-arch to Standard CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ _Libraries for building standard or basic Command Line applications._
 - [flagvar](https://github.com/sgreben/flagvar) - A collection of flag argument types for Go's standard `flag` package.
 - [flash-flags](https://github.com/agilira/flash-flags) - Ultra-fast, zero-dependency, POSIX-compliant flag parsing library that can be used as drop-in stdlib replacement with security hardening.
 - [getopt](https://github.com/jon-codes/getopt) - An accurate Go `getopt`, validated against the GNU libc implementation.
-- [go-arch](https://github.com/SalvucciFacundo/go-arch-cli) - CLI tool for scaffolding Go applications with Minimalist, Standard, and Hexagonal architecture patterns.
+- [go-arch](https://github.com/SalvucciFacundo/go-arch) - CLI tool for scaffolding Go applications with Minimalist, Standard, and Hexagonal architecture patterns.
 - [go-arg](https://github.com/alexflint/go-arg) - Struct-based argument parsing in Go.
 - [go-flags](https://github.com/jessevdk/go-flags) - go command line option parser.
 - [go-getoptions](https://github.com/DavidGamba/go-getoptions) - Go option parser inspired by the flexibility of Perl’s GetOpt::Long.

--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ _Libraries for building standard or basic Command Line applications._
 - [flagvar](https://github.com/sgreben/flagvar) - A collection of flag argument types for Go's standard `flag` package.
 - [flash-flags](https://github.com/agilira/flash-flags) - Ultra-fast, zero-dependency, POSIX-compliant flag parsing library that can be used as drop-in stdlib replacement with security hardening.
 - [getopt](https://github.com/jon-codes/getopt) - An accurate Go `getopt`, validated against the GNU libc implementation.
+- [go-arch](https://github.com/SalvucciFacundo/go-arch-cli) - CLI tool for scaffolding Go applications with Minimalist, Standard, and Hexagonal architecture patterns.
 - [go-arg](https://github.com/alexflint/go-arg) - Struct-based argument parsing in Go.
 - [go-flags](https://github.com/jessevdk/go-flags) - go command line option parser.
 - [go-getoptions](https://github.com/DavidGamba/go-getoptions) - Go option parser inspired by the flexibility of Perl’s GetOpt::Long.


### PR DESCRIPTION
Add go-arch (CLI tool for scaffolding Go applications with Minimalist, Standard, and Hexagonal architecture patterns) under Standard CLI.

Forge link: https://github.com/SalvucciFacundo/go-arch
pkg.go.dev: https://pkg.go.dev/github.com/SalvucciFacundo/go-arch/v2
goreportcard.com: https://goreportcard.com/report/github.com/SalvucciFacundo/go-arch