### PR TITLE
Add cnn-fear-and-greed-parse to Financial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1256,6 +1256,7 @@ _Packages for accounting and finance._
 - [accounting](https://github.com/leekchan/accounting) - money and currency formatting for golang.
 - [ach](https://github.com/moov-io/ach) - A reader, writer, and validator for Automated Clearing House (ACH) files.
 - [bbgo](https://github.com/c9s/bbgo) - A crypto trading bot framework written in Go. Including common crypto exchange API, standard indicators, back-testing and many built-in strategies.
+- [cnn-fear-and-greed-parse](https://github.com/wildsurfer/cnn-fear-and-greed-parse) - Client for CNN's Fear & Greed Index with the seven component indicators and about a year of daily history.
 - [currency](https://github.com/bojanz/currency) - Handles currency amounts, provides currency information and formatting.
 - [currency](https://github.com/naughtygopher/currency) - High performant & accurate currency computation package.
 - [dec128](https://github.com/jokruger/dec128) - High performance 128-bit fixed-point decimal numbers.


### PR DESCRIPTION
## Required links

_Provide the links below. Our CI will automatically validate them._

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/wildsurfer/cnn-fear-and-greed-parse
- [x] pkg.go.dev: https://pkg.go.dev/github.com/wildsurfer/cnn-fear-and-greed-parse/v2
- [x] goreportcard.com: https://goreportcard.com/report/github.com/wildsurfer/cnn-fear-and-greed-parse
- [x] Coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://coveralls.io/github/wildsurfer/cnn-fear-and-greed-parse

Coverage: https://coveralls.io/github/wildsurfer/cnn-fear-and-greed-parse

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

_These are validated automatically by CI:_

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`). Latest release is `v2.2.0`.
- [x] The repo has an open source license. MIT.
- [x] The repo documentation has a pkg.go.dev link. Badge in the README.
- [ ] The repo documentation has a goreportcard link (grade A- or better). See the note below.
- [x] The repo documentation has a coverage service link. Coveralls badge in the README.

> Note on the goreportcard checkbox: goreportcard.com has been sunset and does not compute grades anymore, so I cannot tick this box honestly. I provided the link above because the template requires it, but I did not put a retired badge in the README. As substitute quality signals: `gofmt -l .` and `go vet ./...` are clean, tests run in CI on every push, and total coverage is 85.6% (88.0% for the library package) on [Coveralls](https://coveralls.io/github/wildsurfer/cnn-fear-and-greed-parse).

_These are recommended and reported as warnings:_

- [x] The repo has a continuous integration process (GitHub Actions, etc.). Vet, tests and coverage upload on every push and PR, plus a weekly scheduled test against the real endpoint.
- [x] CI runs tests that must pass before merging.

## Pull Request content

_These are validated automatically by CI:_

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**. Between `bbgo` and `currency` in Financial.
- [x] The link text is the **exact project name**.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.

I checked the entries around the insertion point (`accounting`, `ach`, `bbgo`, both `currency` packages, `dec128`). All of them are reachable, licensed and released. I did not find candidates for removal.

## About the package

cnn-fear-and-greed-parse is a zero-dependency client for CNN's Fear & Greed Index, a 0-100 gauge of US stock market sentiment. It returns the current score and rating, the values for the previous close, week, month and year, the seven component indicators with their raw daily series, and about a year of daily history. The module also ships a small CLI and an MCP server, both built on the standard library only. The repository exists since 2021: v1 parsed the old HTML page, and v2 is a rewrite on the JSON endpoint that CNN's own page uses.
