### PR TITLE
feat: add OpenChainBench to Blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ _Tools for building blockchains._
 - [kubo](https://github.com/ipfs/kubo) - An IPFS implementation in Go. It provides content-addressable storage which can be used for decentralized storage in DApps. It is based on the IPFS protocol.
 - [lnd](https://github.com/lightningnetwork/lnd) - A complete implementation of a Lightning Network node.
 - [nview](https://github.com/blinklabs-io/nview) - Local monitoring tool for a Cardano Node. It's a TUI (terminal user interface) designed to fit most screens.
+- [OpenChainBench](https://github.com/ChainBench/OpenChainBench) - Open-source blockchain infrastructure benchmark harnesses: RPC latency, L1/L2 finality, bridge fees, oracle deviation, and perp DEX costs across 20+ chains.
 - [pactus](https://github.com/pactus-project/pactus) - A full-node implementation of the Pactus blockchain in Go.
 - [solana-go](https://github.com/gagliardetto/solana-go) - Go library to interface with Solana JSON RPC and WebSocket interfaces.
 - [tendermint](https://github.com/tendermint/tendermint) - High-performance middleware for transforming a state machine written in any programming language into a Byzantine Fault Tolerant replicated state machine using the Tendermint consensus and blockchain protocols.


### PR DESCRIPTION
OpenChainBench provides open-source Go harnesses for continuous blockchain infrastructure benchmarking: multi-region RPC provider latency, L1/L2 finality, bridge fees, oracle deviation (Chainlink/Pyth/Redstone), and perp DEX costs across 20+ chains. The harnesses expose Prometheus metrics and use Go's net/http, WebSocket, and JSON-RPC. MIT licensed, CC-BY-4.0 data.

Repo: https://github.com/ChainBench/OpenChainBench