### PR TITLE
Add eu-vat-rates-data-go to Financial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1266,6 +1266,7 @@ _Packages for accounting and finance._
 - [decimal](https://github.com/shopspring/decimal) - Arbitrary-precision fixed-point decimal numbers.
 - [decimal](https://github.com/aytechnet/decimal) - High performance 64-bit decimal partially compatible with [shopspring/decimal](https://github.com/shopspring/decimal) and int64, including Weight and Length.
 - [decimal](https://github.com/govalues/decimal) - Immutable decimal numbers with panic-free arithmetic.
+- [eu-vat-rates-data-go](https://github.com/vatnode/eu-vat-rates-data-go) - VAT rates and VAT number formats for 45 European countries, embedded at compile time and refreshed daily from the European Commission TEDB.
 - [fpdecimal](https://github.com/nikolaydubina/fpdecimal) - Fast and precise serialization and arithmetic for small fixed-point decimals
 - [fpmoney](https://github.com/nikolaydubina/fpmoney) - Fast and simple ISO4217 fixed-point decimal money.
 - [go-finance](https://github.com/alpeb/go-finance) - Library of financial functions for time value of money (annuities), cash flow, interest rate conversions, bonds and depreciation calculations.


### PR DESCRIPTION
Adds <https://github.com/vatnode/eu-vat-rates-data-go> to Financial.

Forge link: https://github.com/vatnode/eu-vat-rates-data-go
pkg.go.dev: https://pkg.go.dev/github.com/vatnode/eu-vat-rates-data-go
goreportcard.com: https://goreportcard.com/report/github.com/vatnode/eu-vat-rates-data-go

Note on that last link: Go Report Card was sunset and now serves a farewell page for every repository, so it cannot produce a grade for this or any other submission. Including it because the automated check asks for it. `go vet` and `gofmt -l` are clean if that is the underlying question.

Disclosure: I maintain this package.

VAT rates — standard, reduced, super-reduced and parking — plus VAT number formats and regex patterns for 45 European countries. The data is embedded with `go:embed`, so lookups are offline and the package has no dependencies. EU rates come from the European Commission TEDB; a scheduled job checks it daily and a new tag goes out when a rate changes.

Financial already has [vat](https://github.com/dannyvankooten/vat), which validates VAT numbers against VIES over the network and fetches rates from a remote source. This one is the offline half: no network call, no API key, rates and format checks resolved from embedded data.

Quality standards:

- Repository created 2026-02-25, over 5 months of history.
- MIT licensed, `go.mod` present, module path matches the repository.
- SemVer releases, latest `v1.16.0`.
- Test coverage 97.2% of statements (`go test -cover`), above the 90% guideline for data packages. No hosted coverage service is wired up; the number is reproducible with `go test -cover ./...`.
- `go vet` and `gofmt` clean.
- English README and pkg.go.dev doc comments on every exported symbol.

Entry is in alphabetical order between `decimal` and `fpdecimal`, description ends with a period. I checked the entries above and below and they still meet the quality standards.