### PR TITLE
test ci

### DIFF
--- a/.github/scripts/verify-all-pr-workflow-checks-passed.sh
+++ b/.github/scripts/verify-all-pr-workflow-checks-passed.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -eu -o pipefail
+
+declare -r expected_sha="${1:?missing expected_sha}"
+declare -r gh_pr_number="${2:?missing gh_pr_number}"
+declare -r gh_repository="${3:?missing gh_repository}"
+declare -r gh_current_run_id="${4:?missing gh_current_run_id}"
+
+# 1. Fetch current PR HEAD SHA to ensure no new commit was pushed while this ran
+CURRENT_SHA=$(gh pr view "${gh_pr_number}" \
+	--repo "${gh_repository}" \
+	--json headRefOid --jq '.headRefOid')
+
+if [ "${CURRENT_SHA}" != "${expected_sha}" ]; then
+	echo "A new commit (${CURRENT_SHA}) was pushed after this run started (${expected_sha}). Aborting auto-merge."
+	exit 1
+fi
+
+# 2. Allowlist filter: select any check whose state is NOT in [SUCCESS, SKIPPED, NEUTRAL],
+#   filtering out the current workflow run by checking if its link contains gh_current_run_id.
+NON_PASSING_CHECKS=$(gh pr checks "${gh_pr_number}" \
+	--repo "${gh_repository}" \
+	--json workflow,name,state,link |
+	jq --compact --arg current_run_id "${gh_current_run_id}" \
+		'.[] | select(
+       (.link | contains($current_run_id) | not)
+       and
+       (.state | test("^(SUCCESS|SKIPPED|NEUTRAL)$") | not)
+     )')
+
+if [ -n "${NON_PASSING_CHECKS}" ]; then
+	echo "Cannot auto-merge. The following checks are not passing:"
+	echo "${NON_PASSING_CHECKS}" | jq -r '"workflow: \(.workflow), name: \(.name), state: \(.state)""'
+	exit 1
+fi

--- a/.github/workflows/pr-quality-check.yaml
+++ b/.github/workflows/pr-quality-check.yaml
@@ -136,7 +136,45 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      checks: read
     steps:
+      - name: Verify all PR workflow checks passed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          declare -r gh_pr_number='${{ github.event.pull_request.number }}'
+          declare -r gh_repository='${{ github.repository }}'
+          declare -r gh_current_run_id='${{ github.run_id }}'
+
+          # 1. Fetch current PR HEAD SHA to ensure no new commit was pushed while this ran
+          CURRENT_SHA=$(gh pr view "${gh_pr_number}" \
+            --repo "${gh_repository}" \
+            --json headRefOid --jq '.headRefOid')
+
+          if [ "${CURRENT_SHA}" != "${EXPECTED_SHA}" ]; then
+            echo "A new commit (${CURRENT_SHA}) was pushed after this run started (${EXPECTED_SHA}). Aborting auto-merge."
+            exit 1
+          fi
+
+          # 2. Allowlist filter: select any check whose state is NOT in [SUCCESS, SKIPPED, NEUTRAL],
+          #   filtering out the current workflow run by checking if its link contains gh_current_run_id.
+          NON_PASSING_CHECKS=$(gh pr checks "${gh_pr_number}" \
+            --repo "${gh_repository}" \
+            --json workflow,name,state,link |
+            jq --compact --arg current_run_id "${gh_current_run_id}" \
+              '.[] | select(
+                 (.link | contains($current_run_id) | not)
+                 and
+                 (.state | test("^(SUCCESS|SKIPPED|NEUTRAL)$") | not)
+               )')
+
+          if [ -n "${NON_PASSING_CHECKS}" ]; then
+            echo "Cannot auto-merge. The following checks are not passing:"
+            echo "${NON_PASSING_CHECKS}" | jq -r '"workflow: \(.workflow), name: \(.name), state: \(.state)""'
+            exit 1
+          fi
+
       - name: Enable auto-merge via squash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-quality-check.yaml
+++ b/.github/workflows/pr-quality-check.yaml
@@ -143,37 +143,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EXPECTED_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          declare -r gh_pr_number='${{ github.event.pull_request.number }}'
-          declare -r gh_repository='${{ github.repository }}'
-          declare -r gh_current_run_id='${{ github.run_id }}'
-
-          # 1. Fetch current PR HEAD SHA to ensure no new commit was pushed while this ran
-          CURRENT_SHA=$(gh pr view "${gh_pr_number}" \
-            --repo "${gh_repository}" \
-            --json headRefOid --jq '.headRefOid')
-
-          if [ "${CURRENT_SHA}" != "${EXPECTED_SHA}" ]; then
-            echo "A new commit (${CURRENT_SHA}) was pushed after this run started (${EXPECTED_SHA}). Aborting auto-merge."
-            exit 1
-          fi
-
-          # 2. Allowlist filter: select any check whose state is NOT in [SUCCESS, SKIPPED, NEUTRAL],
-          #   filtering out the current workflow run by checking if its link contains gh_current_run_id.
-          NON_PASSING_CHECKS=$(gh pr checks "${gh_pr_number}" \
-            --repo "${gh_repository}" \
-            --json workflow,name,state,link |
-            jq --compact --arg current_run_id "${gh_current_run_id}" \
-              '.[] | select(
-                 (.link | contains($current_run_id) | not)
-                 and
-                 (.state | test("^(SUCCESS|SKIPPED|NEUTRAL)$") | not)
-               )')
-
-          if [ -n "${NON_PASSING_CHECKS}" ]; then
-            echo "Cannot auto-merge. The following checks are not passing:"
-            echo "${NON_PASSING_CHECKS}" | jq -r '"workflow: \(.workflow), name: \(.name), state: \(.state)""'
-            exit 1
-          fi
+          ${{ github.workspace }}/.github/scripts/verify-all-pr-workflow-checks-passed.sh \
+            '${{ github.event.pull_request.head.sha }}' \
+            '${{ github.event.pull_request.number }}' \
+            '${{ github.repository }}' \
+            '${{ github.run_id }}'
 
       - name: Enable auto-merge via squash
         env:


### PR DESCRIPTION
- **ci: verify all PR checks before triggering auto-merge**
  Fixes #6550.
  
  The `auto-merge` job in `pr-quality-check.yaml` relies on native
  `needs` gates, which only evaluate jobs inside the same workflow file.
  Consequently, failures in external workflows (such as `tests.yaml`)
  were not visible to this job, allowing PRs to auto-merge despite failing
  tests.
  
  This change adds a pre-check step using `gh pr checks` that:
  
  1. Verifies that the evaluated HEAD commit matches the current commit.
     Intended to address race conditions that may occur due to new pushes.
  2. Filters out the active workflow run using `github.run_id`.
  3. Verifies all external PR checks are in a passing state (SUCCESS,
     SKIPPED, or NEUTRAL).
  

- **mv verify script to scripts/ dir**
  