### PR TITLE
docs(readme): REMOVED archived sandid repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2032,7 +2032,6 @@ _These libraries were placed here because none of the other categories seemed to
 - [pdfgen](https://github.com/hyperboloide/pdfgen) - HTTP service to generate PDF from Json requests.
 - [persian](https://github.com/mavihq/persian) - Some utilities for Persian language in go.
 - [purego](https://github.com/ebitengine/purego) - A library for calling C functions from Go without Cgo.
-- [sandid](https://github.com/aofei/sandid) - Every grain of sand on earth has its own ID.
 - [shellwords](https://github.com/Wing924/shellwords) - A Golang library to manipulate strings according to the word parsing rules of the UNIX Bourne shell.
 - [shortid](https://github.com/teris-io/shortid) - Distributed generation of super short, unique, non-sequential, URL friendly IDs.
 - [shoutrrr](https://github.com/containrrr/shoutrrr) - Notification library providing easy access to various messaging services like slack, mattermost, gotify and smtp among others.


### PR DESCRIPTION
The repo [sandid](https://github.com/aofei/sandid) was archived by @aofei on Aug 7, 2025.