### PR TITLE
Add SiteBrush to Other Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -3698,6 +3698,7 @@ _Software written in Go._
 - [scc](https://github.com/boyter/scc) - Sloc Cloc and Code, a very fast accurate code counter with complexity calculations and COCOMO estimates.
 - [Seaweed File System](https://github.com/chrislusf/seaweedfs) - Fast, Simple and Scalable Distributed File System with O(1) disk seek.
 - [shell2http](https://github.com/msoap/shell2http) - Executing shell commands via http server (for prototyping or remote control).
+- [SiteBrush](https://github.com/matveynator/sitebrush) - Static HTML editor and CMS that imports existing websites and serves published pages as static files.
 - [Snitch](https://github.com/lucasgomide/snitch) - Simple way to notify your team and many tools when someone has deployed any application via Tsuru.
 - [sonic](https://github.com/go-sonic/sonic) - Sonic is a Go Blogging Platform. Simple and Powerful.
 - [Stack Up](https://github.com/pressly/sup) - Stack Up, a super simple deployment tool - just Unix - think of it like 'make' for a network of servers.


### PR DESCRIPTION
## Required links

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/matveynator/sitebrush
- [x] pkg.go.dev: https://pkg.go.dev/github.com/matveynator/sitebrush/v2
- [x] goreportcard.com: https://goreportcard.com/report/github.com/matveynator/sitebrush
- [x] Coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://app.codecov.io/gh/matveynator/sitebrush

Coverage: https://app.codecov.io/gh/matveynator/sitebrush

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`).
- [x] The repo has an open source license.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link (grade A- or better).
- [x] The repo documentation has a coverage service link.
- [x] The repo has a continuous integration process (GitHub Actions, etc.).
- [x] CI runs tests that must pass before merging.

## Pull Request content

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**.
- [x] The link text is the **exact project name**.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

I reviewed the nearby entries. SeaweedFS and shell2http remain active; Snitch, sonic, and Stack Up have older activity. I did not change those entries because this PR intentionally adds only one project.

## Project history note

This repository contains SiteBrush v2, rewritten in Go. The earlier PHP implementation is preserved at https://github.com/matveynator/sitebrush-v1 and dates back to 2021. The current Go repository is newer, so the automated maturity check may report a non-blocking warning.
