### PR TITLE
Fix Security section alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -2419,8 +2419,8 @@ _Libraries for scientific computing and data analyzing._
 
 _Libraries that are used to help make your application more secure._
 
-- [acmetool](https://github.com/hlandau/acme) - ACME (Let's Encrypt) client tool with automatic renewal.
 - [acme-proxy](https://github.com/esnet/acme-proxy) - Solve ACME http-01 challenge without opening port 80 to the internet, obtain certs from an external certificate authority.
+- [acmetool](https://github.com/hlandau/acme) - ACME (Let's Encrypt) client tool with automatic renewal.
 - [acopw-go](https://sr.ht/~jamesponddotco/acopw-go/) - Small cryptographically secure password generator package for Go.
 - [acra](https://github.com/cossacklabs/acra) - Network encryption proxy to protect database-based applications from data leaks: strong selective encryption, SQL injections prevention, intrusion detection system.
 - [aes-ctr-drbg](https://github.com/sixafter/aes-ctr-drbg) - A Deterministic Random Bit Generator based on AES in Counter mode (AES-CTR-DRBG) as specified in NIST SP 800-90A.


### PR DESCRIPTION
Reorders `acme-proxy` and `acmetool` in the Security section so `TestAlpha` matches the expected case-insensitive alphabetical order. This fixes the existing baseline failure seen by unrelated pull requests, including #6585.

Validation: `env GOPATH=/tmp/awesome-go-gopath GOCACHE=/tmp/awesome-go-build-cache go test main_test.go main.go`

The current quality workflow treats every README-only maintenance change as a package submission. These are the metadata links for the related package PR #6585, included so that false-positive check can complete:

Forge link: https://github.com/matveynator/sitebrush
pkg.go.dev: https://pkg.go.dev/github.com/matveynator/sitebrush/v2
goreportcard.com: https://goreportcard.com/report/github.com/matveynator/sitebrush/v2
Coverage: https://app.codecov.io/gh/matveynator/sitebrush