### PR TITLE
Add netchan to Networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2187,6 +2187,7 @@ _Libraries for working with various layers of the network._
 - [nbio](https://github.com/lesismal/nbio) - Pure Go 1000k+ connections solution, support tls/http1.x/websocket and basically compatible with net/http, with high-performance and low memory cost, non-blocking, event-driven, easy-to-use.
 - [net](https://golang.org/x/net) - This repository holds supplementary Go networking libraries.
 - [nethawk](https://github.com/Flowtriq/nethawk) - Terminal UI for real-time network traffic capture, analysis, and attack detection with JSON output mode.
+- [netchan](https://github.com/matveynator/netchan) - Extends Go channel semantics across processes and machines, including values, reply channels, and session channels.
 - [netpoll](https://github.com/cloudwego/netpoll) - A high-performance non-blocking I/O networking framework, which focused on RPC scenarios, developed by ByteDance.
 - [NFF-Go](https://github.com/intel-go/nff-go) - Framework for rapid development of performant network functions for cloud and bare-metal (former YANFF).
 - [nodepass](https://github.com/NodePassProject/nodepass) - A secure, efficient TCP/UDP tunneling solution that delivers fast, reliable access across network restrictions using pre-established TCP/QUIC/WebSocket or HTTP/2 connections.

--- a/README.md
+++ b/README.md
@@ -2186,8 +2186,8 @@ _Libraries for working with various layers of the network._
 - [natiu-mqtt](https://github.com/soypat/natiu-mqtt) - A dead-simple, non-allocating, low level implementation of MQTT well suited for embedded systems.
 - [nbio](https://github.com/lesismal/nbio) - Pure Go 1000k+ connections solution, support tls/http1.x/websocket and basically compatible with net/http, with high-performance and low memory cost, non-blocking, event-driven, easy-to-use.
 - [net](https://golang.org/x/net) - This repository holds supplementary Go networking libraries.
-- [nethawk](https://github.com/Flowtriq/nethawk) - Terminal UI for real-time network traffic capture, analysis, and attack detection with JSON output mode.
 - [netchan](https://github.com/matveynator/netchan) - Extends Go channel semantics across processes and machines, including values, reply channels, and session channels.
+- [nethawk](https://github.com/Flowtriq/nethawk) - Terminal UI for real-time network traffic capture, analysis, and attack detection with JSON output mode.
 - [netpoll](https://github.com/cloudwego/netpoll) - A high-performance non-blocking I/O networking framework, which focused on RPC scenarios, developed by ByteDance.
 - [NFF-Go](https://github.com/intel-go/nff-go) - Framework for rapid development of performant network functions for cloud and bare-metal (former YANFF).
 - [nodepass](https://github.com/NodePassProject/nodepass) - A secure, efficient TCP/UDP tunneling solution that delivers fast, reliable access across network restrictions using pre-established TCP/QUIC/WebSocket or HTTP/2 connections.


### PR DESCRIPTION
## Required links

- [x] Forge link: https://github.com/matveynator/netchan
- [x] pkg.go.dev: https://pkg.go.dev/github.com/matveynator/netchan/v2
- [x] goreportcard.com: https://goreportcard.com/report/github.com/matveynator/netchan
- [x] Coverage: https://app.codecov.io/gh/matveynator/netchan
- [x] Release: https://github.com/matveynator/netchan/releases/tag/v2.0.0

## Summary

Adds netchan to the Networking category. NetChan extends Go channel semantics across process and machine boundaries while preserving typed values, backpressure, reply channels, session channels, and channel closure.

## Validation

- Added exactly one project.
- Placed the entry alphabetically between net and nethawk.
- Used the exact repository name and a concise, non-promotional description.
- Confirmed the repository is public, licensed, versioned, documented on pkg.go.dev, and tested in CI.
- Checked the surrounding Networking entries; they remain accessible and unarchived.
