### PR TITLE
Update netchan description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2186,7 +2186,7 @@ _Libraries for working with various layers of the network._
 - [natiu-mqtt](https://github.com/soypat/natiu-mqtt) - A dead-simple, non-allocating, low level implementation of MQTT well suited for embedded systems.
 - [nbio](https://github.com/lesismal/nbio) - Pure Go 1000k+ connections solution, support tls/http1.x/websocket and basically compatible with net/http, with high-performance and low memory cost, non-blocking, event-driven, easy-to-use.
 - [net](https://golang.org/x/net) - This repository holds supplementary Go networking libraries.
-- [netchan](https://github.com/matveynator/netchan) - Extends Go channel semantics across processes and machines, including values, reply channels, and session channels.
+- [netchan](https://github.com/matveynator/netchan) - Network Channels (netchan) for Golang: Secure, cluster-ready, supports nested channels & any data type. Inspired by Rob Pike.
 - [nethawk](https://github.com/Flowtriq/nethawk) - Terminal UI for real-time network traffic capture, analysis, and attack detection with JSON output mode.
 - [netpoll](https://github.com/cloudwego/netpoll) - A high-performance non-blocking I/O networking framework, which focused on RPC scenarios, developed by ByteDance.
 - [NFF-Go](https://github.com/intel-go/nff-go) - Framework for rapid development of performant network functions for cloud and bare-metal (former YANFF).


### PR DESCRIPTION
## Required links

- [x] Forge link: https://github.com/matveynator/netchan
- [x] pkg.go.dev: https://pkg.go.dev/github.com/matveynator/netchan/v2
- [x] goreportcard.com: https://goreportcard.com/report/github.com/matveynator/netchan
- [x] Coverage: https://app.codecov.io/gh/matveynator/netchan

## Summary

Updates the existing netchan entry to describe its secure, cluster-ready network channels, nested-channel support, general value transport, and connection to Rob Pike's original network-channel concept.

## Validation

- Changes only the existing netchan description.
- Preserves the project link, category, and alphabetical position.
- Keeps the description on one line and ends it with a period.
