### PR TITLE
Fix quality checks for README reorders

### DIFF
--- a/.github/workflows/pr-quality-check.yaml
+++ b/.github/workflows/pr-quality-check.yaml
@@ -15,15 +15,25 @@ jobs:
     outputs:
       is_package_pr: ${{ steps.check.outputs.is_package_pr }}
     steps:
-      - name: Check if README.md is modified
+      - name: Check if package entries are modified
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           files=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files --jq '.[].filename' 2>/dev/null || echo "")
           if echo "$files" | grep -q '^README.md$'; then
-            echo "is_package_pr=true" >> "$GITHUB_OUTPUT"
-            echo "README.md is modified — this is a package PR"
+            readme_patch=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files --jq '.[] | select(.filename == "README.md") | .patch // ""' 2>/dev/null || echo "")
+
+            # A pure reorder has the same package entries on both sides of the diff.
+            added_entries=$(printf '%s\n' "$readme_patch" | awk '/^\+- \[/{print substr($0, 2)}' | sort)
+            removed_entries=$(printf '%s\n' "$readme_patch" | awk '/^-- \[/{print substr($0, 2)}' | sort)
+            if [ -n "$added_entries" ] && [ "$added_entries" = "$removed_entries" ]; then
+              echo "is_package_pr=false" >> "$GITHUB_OUTPUT"
+              echo "README.md only reorders existing package entries — skipping quality checks"
+            else
+              echo "is_package_pr=true" >> "$GITHUB_OUTPUT"
+              echo "README.md changes package entries — this is a package PR"
+            fi
           else
             echo "is_package_pr=false" >> "$GITHUB_OUTPUT"
             echo "README.md not modified — skipping quality checks"


### PR DESCRIPTION
## Summary

- distinguish pure README entry reorders from package additions or updates
- skip package metadata validation when the added and removed entry sets are identical
- preserve all existing quality checks for actual package changes

## Root cause

The current detector classifies every pull request touching `README.md` as a package PR. Maintenance-only reorders therefore run package-submission validation against an unchanged entry and can fail link consistency, as seen in #6586.

## Validation

The detector logic was evaluated against the live patches for:

- #6586: identical added and removed entry sets, correctly classified as a reorder
- #6585: one added entry and no removed entries, correctly classified as a package PR

The updated workflow also parses successfully as YAML.
