### PR TITLE
fix: correct alphabetical order in Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2420,8 +2420,8 @@ _Libraries for scientific computing and data analyzing._
 
 _Libraries that are used to help make your application more secure._
 
-- [acmetool](https://github.com/hlandau/acme) - ACME (Let's Encrypt) client tool with automatic renewal.
 - [acme-proxy](https://github.com/esnet/acme-proxy) - Solve ACME http-01 challenge without opening port 80 to the internet, obtain certs from an external certificate authority.
+- [acmetool](https://github.com/hlandau/acme) - ACME (Let's Encrypt) client tool with automatic renewal.
 - [acopw-go](https://sr.ht/~jamesponddotco/acopw-go/) - Small cryptographically secure password generator package for Go.
 - [acra](https://github.com/cossacklabs/acra) - Network encryption proxy to protect database-based applications from data leaks: strong selective encryption, SQL injections prevention, intrusion detection system.
 - [aes-ctr-drbg](https://github.com/sixafter/aes-ctr-drbg) - A Deterministic Random Bit Generator based on AES in Counter mode (AES-CTR-DRBG) as specified in NIST SP 800-90A.


### PR DESCRIPTION
## What changed

Fixed alphabetical ordering in the **Security** section: `acme-proxy` was listed after `acmetool` instead of before. This was causing `TestAlpha` CI failures (see #6550).

The hyphen in `acme-proxy` sorts before the `t` in `acmetool`, so `acme-proxy` must come first.

This is a reordering fix only — no new packages are added or removed.

Forge link: https://github.com/esnet/acme-proxy
pkg.go.dev: https://pkg.go.dev/github.com/esnet/acme-proxy
goreportcard.com: https://goreportcard.com/report/github.com/esnet/acme-proxy