### PR TITLE
fix: rename acmetool to acme to match repo name and fix alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -2420,7 +2420,7 @@ _Libraries for scientific computing and data analyzing._
 
 _Libraries that are used to help make your application more secure._
 
-- [acmetool](https://github.com/hlandau/acme) - ACME (Let's Encrypt) client tool with automatic renewal.
+- [acme](https://github.com/hlandau/acme) - ACME (Let's Encrypt) client tool with automatic renewal.
 - [acme-proxy](https://github.com/esnet/acme-proxy) - Solve ACME http-01 challenge without opening port 80 to the internet, obtain certs from an external certificate authority.
 - [acopw-go](https://sr.ht/~jamesponddotco/acopw-go/) - Small cryptographically secure password generator package for Go.
 - [acra](https://github.com/cossacklabs/acra) - Network encryption proxy to protect database-based applications from data leaks: strong selective encryption, SQL injections prevention, intrusion detection system.


### PR DESCRIPTION
## What changed

The link text `acmetool` does not match the repository name `acme` (https://github.com/hlandau/acme). Renaming it to `acme` also fixes the alphabetical ordering in the Security section, as `acme` sorts before `acme-proxy`. This resolves the `TestAlpha` CI failure (see #6550).

Forge link: https://github.com/hlandau/acme
pkg.go.dev: https://pkg.go.dev/github.com/hlandau/acme
goreportcard.com: https://goreportcard.com/report/github.com/hlandau/acme