### PR TITLE
Add flue to Server Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -2539,6 +2539,7 @@ _Libraries and tools for binary serialization._
 - [Fider](https://github.com/getfider/fider) - Fider is an open platform to collect and organize customer feedback.
 - [Flagr](https://github.com/checkr/flagr) - Flagr is an open-source feature flagging and A/B testing service.
 - [flipt](https://github.com/markphelps/flipt) - A self contained feature flag solution written in Go and Vue.js
+- [flue](https://github.com/karnstack/flue) - Self-hosted daemon that serves terminal sessions to a browser tab. Sessions keep running after the tab is closed.
 - [go-feature-flag](https://github.com/thomaspoignant/go-feature-flag) - A simple, complete and lightweight self-hosted feature flag solution 100% Open Source.
 - [go-proxy-cache](https://github.com/fabiocicerchia/go-proxy-cache) - Simple Reverse Proxy with Caching, written in Go, using Redis.
 - [gondola](https://github.com/bmf-san/gondola) - A YAML based golang reverse proxy.


### PR DESCRIPTION
## Required links

_Provide the links below. Our CI will automatically validate them._

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/karnstack/flue
- [x] pkg.go.dev: https://pkg.go.dev/github.com/karnstack/flue
- [ ] goreportcard.com: https://goreportcard.com/report/github.com/karnstack/flue
- [ ] Coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.)

Two of these are not checked, and I want to be upfront about why.

**Go Report Card.** The link above resolves, but it no longer produces a
grade. goreportcard.com has been sunset. Every report URL now serves the
same farewell page, including the ones for projects already on this list.
So I cannot show a grade for flue, and I did not want to tick a box that
says I can. What the repo does have is `make lint`, which runs `go vet`
over three build tag variants plus shellcheck on the install script, and
CI runs it on every push and every pull request.

**Coverage service.** flue does not publish to Codecov or Coveralls yet.
The Go, web and relay test suites all run in CI, but no coverage report is
uploaded anywhere I can link to. I would rather leave this blank than
point at something that is not there.

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

_These are validated automatically by CI:_

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`). Latest is `v0.9.1`.
- [x] The repo has an open source license. MIT.
- [ ] The repo documentation has a pkg.go.dev link.
- [ ] The repo documentation has a goreportcard link (grade A- or better).
- [ ] The repo documentation has a coverage service link.

The README carries CI, release and license badges, but not the three
above. A pkg.go.dev badge is easy to add if that helps. The other two
cannot be added honestly today, for the reasons given at the top.

_These are recommended and reported as warnings:_

- [x] The repo has a continuous integration process (GitHub Actions, etc.).
- [ ] CI runs tests that must pass before merging.

On the last one: CI does run the full test suite on every pull request and
every push to main, and all work lands through pull requests. But the
branch ruleset does not list the CI job as a required status check, so a
red build is not a hard block today. That is worth tightening and it is on
our list.

## Pull Request content

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**. It sits between `flipt` and `go-feature-flag` in Server Applications.
- [x] The link text is the **exact project name**.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.

I checked four entries above and four below. Easegress, Fider, Flagr,
flipt, go-feature-flag, go-proxy-cache, gondola and goshs are all active,
none are archived, and all have commits within the last month.

## About flue

flue is a small Go daemon that holds your terminal sessions and serves
them to a browser tab. Closing the tab does not kill the session, it only
detaches it, so a build or an SSH session keeps running and reattaching
replays what you missed. It is the same space as gotty and ttyd, with
session persistence and a session list across machines added on top.

Site: https://flue.sh

## One thing that may block this

The repository maturity rule asks for at least 5 months of history since
the first commit. flue's first commit is from 2026-07-28, so it is about
three weeks old. It does not meet that rule. Everything else is in place:
MIT license, `go.mod`, tagged SemVer releases up to v0.9.1, English
documentation, a working CI, and daily commits.

I am opening this now rather than sitting on it, but I fully understand if
you would rather hold or close it until flue clears the 5 month mark. Just
say so and I will resubmit then.
