### PR TITLE
Add go-wav to Audio and Music

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ _Libraries for manipulating audio and music._
 - [go-mpris](https://github.com/leberKleber/go-mpris) - Client for mpris dbus interfaces.
 - [go-opus](https://github.com/tphakala/go-opus) - Native Go implementation of the Opus audio codec (RFC 6716) with RFC-compliant decoder.
 - [go-resample](https://github.com/gojargo/go-resample) - Pure-Go (no cgo) audio sample-rate converter with sinc, linear, and zero-order-hold converters.
+- [go-wav](https://github.com/tphakala/go-wav) - Pure-Go WAV/RIFF reader and writer with RF64 and BW64 support for files larger than 4 GiB.
 - [GoAudio](https://github.com/DylanMeeus/GoAudio) - Native Go Audio Processing Library.
 - [gosamplerate](https://github.com/dh1tw/gosamplerate) - libsamplerate bindings for go.
 - [id3v2](https://github.com/bogem/id3v2) - ID3 decoding and encoding library for Go.


### PR DESCRIPTION
## Required links

_Provide the links below. Our CI will automatically validate them._

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/tphakala/go-wav
- [x] pkg.go.dev: https://pkg.go.dev/github.com/tphakala/go-wav
- [x] goreportcard.com: https://goreportcard.com/report/github.com/tphakala/go-wav
- [x] Coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://app.codecov.io/gh/tphakala/go-wav

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

_These are validated automatically by CI:_

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`).
- [x] The repo has an open source license.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link (grade A- or better).
- [x] The repo documentation has a coverage service link.

_These are recommended and reported as warnings:_

- [x] The repo has a continuous integration process (GitHub Actions, etc.).
- [x] CI runs tests that must pass before merging.

## Pull Request content

_These are validated automatically by CI:_

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**.
- [x] The link text is the **exact project name**.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.

---

Note: goreportcard.com was sunset this week, so the automated Go Report Card check can no longer fetch a grade for any submission. For reference, go-wav is clean under `gofmt -s`, `go vet`, and `golangci-lint`, has ~96% test coverage across the module, targets Go 1.26 with zero runtime dependencies, and ships a tagged v1.0.0 release.