### PR TITLE
Add orderbook to Financial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1289,6 +1289,7 @@ _Packages for accounting and finance._
 - [money](https://github.com/govalues/money) - Immutable monetary amounts and exchange rates with panic-free arithmetic.
 - [ofxgo](https://github.com/aclindsa/ofxgo) - Query OFX servers and/or parse the responses (with example command-line client).
 - [orderbook](https://github.com/i25959341/orderbook) - Matching Engine for Limit Order Book in Golang.
+- [orderbook](https://github.com/intrepidkarthi/orderbook) - Embeddable limit order book and matching engine with integer-exact pricing, a single-writer core, and write-ahead-log crash recovery.
 - [payme](https://github.com/jovandeginste/payme) - QR code generator (ASCII & PNG) for SEPA payments.
 - [paystack-sdk-go](https://github.com/samaasi/paystack-sdk-go) - A comprehensive, zero-dependency, and fully typed Go SDK for the Paystack API.
 - [swift](https://code.pfad.fr/swift/) - Offline validity check of IBAN (International Bank Account Number) and retrieval of BIC (for some countries).


### PR DESCRIPTION
## Required links

- [x] Forge link: https://github.com/intrepidkarthi/orderbook
- [x] pkg.go.dev: https://pkg.go.dev/github.com/intrepidkarthi/orderbook
- [x] goreportcard.com: https://goreportcard.com/report/github.com/intrepidkarthi/orderbook
- [ ] Coverage service link: not yet published to a coverage service. Measured at v0.26.0: **83.8%** of statements over `pkg/...` and `internal/...`, 73.4% counting the `cmd/` binaries and `examples/` demos. `codecov.yml` and the upload step are committed; the repo is not activated on codecov.io yet, so I have not put a link here that would 404.

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`) — [v0.26.0](https://github.com/intrepidkarthi/orderbook/releases/tag/v0.26.0)
- [x] The repo has an open source license — MIT
- [x] The repo documentation has a pkg.go.dev link
- [x] The repo documentation has a goreportcard link — **removed deliberately**: goreportcard.com was [sunset on 1 July 2026](https://goreportcard.com/sunset/) and `gojp/goreportcard` is archived. The badge endpoint now serves an SVG reading "go report: retired", so it was dropped from the README rather than left advertising a dead service. The report URL is still in the required-links block above.
- [ ] The repo documentation has a coverage service link — see above.
- [x] The repo has a continuous integration process — GitHub Actions: build, vet, `go test -race`, benchmarks, and a nightly soak
- [x] CI runs tests that must pass before merging

## Pull Request content

- [x] This PR adds **only one** package — the diff is a single line
- [x] The package has been added in **alphabetical order** (after `ofxgo` and the existing `orderbook`, before `payme`)
- [x] The link text is the **exact project name**
- [x] The description is clear, concise, non-promotional, and **ends with a period**
- [x] The link in README.md matches the forge link above

`go test main_test.go main.go` passes identically with and without this change — 4 pre-existing `TestAlpha` ordering errors on `main`, in *Data stores with expiring records* (`easycache`/`echovault`) and *Libraries that are used to help make your application more secure* (`acme-proxy`/`acmetool`), neither touched here.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.

Checked the five nearest entries; all are live and none are archived: `ofxgo` (Feb 2026), `orderbook` — i25959341 (Apr 2025), `payme` (Jul 2026), `paystack-sdk-go` (Jun 2026), `money` — govalues (Jan 2025).

---

### About the package

An embeddable limit order book and matching engine. It works in `int64` ticks and lots with no floating point on the money path, and a per-symbol `Instrument` converts decimals only at the API boundary.

- **Single-writer core** — one matching goroutine owns the book with no lock on the hot path (the LMAX model); a `Runner` fronts it with an MPSC queue for concurrent producers.
- **Zero-allocation match path** — `Match` into a caller-supplied buffer allocates 0 B/op.
- **Deterministic and recoverable** — the same ordered command stream produces byte-identical trades and book state, gated in CI against a 2,000-command tape; `pkg/wal` provides a checksummed write-ahead log with snapshots, segment rotation and retention.
- **Full order surface** — limit, market, stop / stop-limit, iceberg, post-only, pegged, OCO / bracket, trailing-stop; GTC / IOC / FOK / DAY / GTD.

**Note on the duplicate name:** there is already an `orderbook` in this section ([i25959341/orderbook](https://github.com/i25959341/orderbook)). They are different projects with the same package name, which the section already accommodates for `decimal` (three entries) and `go-finance` (two). Happy to rename the link text if you would rather disambiguate.

**Disclosure:** I'm the author of the project. It is explicit that it is an experiment rather than a product — it has never run a live market, and [docs/PRODUCTION-READINESS.md](https://github.com/intrepidkarthi/orderbook/blob/main/docs/PRODUCTION-READINESS.md) is a written account of what it does not do.