### PR TITLE
Add KeibiDrop to Other Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -3691,6 +3691,7 @@ _Software written in Go._
 - [joincap](https://github.com/assafmo/joincap) - Command-line utility for merging multiple pcap files together.
 - [JuiceFS](https://github.com/juicedata/juicefs) - Distributed POSIX file system built on top of Redis and AWS S3.
 - [Juju](https://jujucharms.com/) - Cloud-agnostic service deployment and orchestration - supports EC2, Azure, Openstack, MAAS and more.
+- [KeibiDrop](https://github.com/KeibiSoft/KeibiDrop) - On-demand peer-to-peer filesystem that mounts a remote folder and hides link latency with read-ahead, end-to-end encrypted with hybrid X25519 and ML-KEM-1024.
 - [Layli](https://layli.app) - Draw pretty layout diagrams as code.
 - [Leaps](https://github.com/jeffail/leaps) - Pair programming service using Operational Transforms.
 - [lgo](https://github.com/yunabe/lgo) - Interactive Go programming with Jupyter. It supports code completion, code inspection and 100% Go compatibility.


### PR DESCRIPTION
## Required links

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/KeibiSoft/KeibiDrop
- [x] pkg.go.dev: https://pkg.go.dev/github.com/KeibiSoft/KeibiDrop
- [x] goreportcard.com: https://goreportcard.com/report/github.com/KeibiSoft/KeibiDrop
- [ ] Coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): not configured yet, see the note below

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`).
- [x] The repo has an open source license.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link (grade A- or better).
- [ ] The repo documentation has a coverage service link.

- [x] The repo has a continuous integration process (GitHub Actions, etc.).
- [x] CI runs tests that must pass before merging.

## Pull Request content

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**.
- [x] The link text is the **exact project name**.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.

## Notes for the reviewer

Added under Other Software, next to JuiceFS, which is the closest neighbour on
the list: both mount a remote store as a POSIX filesystem. KeibiDrop connects two
machines directly rather than going through Redis and S3, and reads fetch file
ranges on demand so a large tree is browsable before any full copy exists.

Three things stated plainly rather than left for you to find.

**The licence, which your automated check will flag.** The project is MPL-2.0
and `LICENSE` at the repository root holds the Mozilla text. Exhibit B, the
"Incompatible With Secondary Licenses" notice, is deliberately left out, because
the desktop UI is a separate proprietary Rust component and the Go core is
dual-licensed around it. GitHub's classifier needs a byte match against the full
canonical text, so the missing exhibit makes it report `NOASSERTION` and your
check will read that as no open source licence. The licence is real, it is
MPL-2.0, and it is readable in the file.

**Coverage service.** There is no Codecov or Coveralls link yet. Unit coverage
across `pkg/` and `internal/` is 53.2% mean over 17 packages, from 100% on
`pkg/sync-tracker` and 97.8% on `internal/fp` down to 42% on `pkg/logic/common`.
That figure understates the suite, because the integration tests live in a
separate `tests/` package and their coverage does not attribute back without
`-coverpkg`. The repository has 190 test files and 31,838 lines of test code,
more test code than product code, including a model checker under `tests/model/`
that enumerates protocol interleavings. Happy to wire a coverage service and
report back if you want the number before merging.

**Maturity.** The current tag is v0.4.2 and the project labels itself pre-alpha.
It is under active development with regular commits, CI on macOS, Linux and
Windows, and a published release cadence. If you would rather this waited for a
stable tag, say so and I will close and resubmit later.

Thanks for maintaining the list.
