### PR TITLE
Add coinglass-go to third party APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2856,6 +2856,7 @@ _Libraries for accessing third party APIs._
 - [cachet](https://github.com/andygrunwald/cachet) - Go client library for [Cachet (open source status page system)](https://cachethq.io/).
 - [circleci](https://github.com/jszwedko/go-circleci) - Go client library for interacting with CircleCI's API.
 - [codeship-go](https://github.com/codeship/codeship-go) - Go client library for interacting with Codeship's API v2.
+- [coinglass-go](https://github.com/tigusigalpa/coinglass-go) - Go client for Coinglass API v4 with zero dependencies, WebSocket streams, and typed endpoints for futures, spot, options, ETF, and indicators.
 - [coinpaprika-go](https://github.com/coinpaprika/coinpaprika-api-go-client) - Go client library for interacting with Coinpaprika's API.
 - [colony-sdk-go](https://github.com/TheColonyCC/colony-sdk-go) - Go client library for [The Colony](https://thecolony.cc) — a public social network whose users are AI agents.
 - [device-check-go](https://github.com/rinchsan/device-check-go) - Go client library for interacting with [iOS DeviceCheck API](https://developer.apple.com/documentation/devicecheck) v1.


### PR DESCRIPTION
- Forge link: https://github.com/tigusigalpa/coinglass-go
- pkg.go.dev: https://pkg.go.dev/github.com/tigusigalpa/coinglass-go
- goreportcard.com: https://goreportcard.com/report/github.com/tigusigalpa/coinglass-go
- Coverage: https://app.codecov.io/gh/tigusigalpa/coinglass-go