### PR TITLE
Add caddy-analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3541,7 +3541,6 @@ _Software written in Go._
 
 ### DevOps Tools
 
-  - [caddy-analyzer](https://github.com/lenny-ts/caddy-analyzer) - Security-focused log analyzer for Caddy v2 with 26 attack categories, dual-pass detection engine, and real-time iptables blocking.
 - [abbreviate](https://github.com/dnnrly/abbreviate) - abbreviate is a tool turning long strings in to shorter ones with configurable separators, for example to embed branch names in to deployment stack IDs.
 - [alaz](https://github.com/ddosify/alaz) - Effortless, Low-Overhead, eBPF-based Kubernetes Monitoring.
 - [aptly](https://github.com/aptly-dev/aptly) - aptly is a Debian repository management tool.
@@ -3551,6 +3550,7 @@ _Software written in Go._
 - [Balerter](https://github.com/balerter/balerter) - A self-hosted script-based alerting manager.
 - [Blast](https://github.com/dave/blast) - A simple tool for API load testing and batch jobs.
 - [bombardier](https://github.com/codesenberg/bombardier) - Fast cross-platform HTTP benchmarking tool.
+- [caddy-analyzer](https://github.com/lenny-ts/caddy-analyzer) - Security-focused log analyzer for Caddy v2 with 26 attack categories, dual-pass detection engine, and real-time iptables blocking.
 - [cassowary](https://github.com/rogerwelin/cassowary) - Modern cross-platform HTTP load-testing tool written in Go.
 - [chaosmonkey](https://github.com/Netflix/chaosmonkey) - A resiliency tool that helps applications tolerate random instance failures.
 - [colima](https://github.com/abiosoft/colima) - Container runtimes on macOS (and Linux) with minimal setup.

--- a/README.md
+++ b/README.md
@@ -3541,6 +3541,7 @@ _Software written in Go._
 
 ### DevOps Tools
 
+  - [caddy-analyzer](https://github.com/lenny-ts/caddy-analyzer) - Security-focused log analyzer for Caddy v2 with 26 attack categories, dual-pass detection engine, and real-time iptables blocking.
 - [abbreviate](https://github.com/dnnrly/abbreviate) - abbreviate is a tool turning long strings in to shorter ones with configurable separators, for example to embed branch names in to deployment stack IDs.
 - [alaz](https://github.com/ddosify/alaz) - Effortless, Low-Overhead, eBPF-based Kubernetes Monitoring.
 - [aptly](https://github.com/aptly-dev/aptly) - aptly is a Debian repository management tool.


### PR DESCRIPTION
Forge link: https://github.com/lenny-ts/caddy-analyzer


caddy-analyzer is a security-focused log analyzer for Caddy v2's structured JSON logs. It features a dual-pass detection engine covering 26 attack categories (SQLi, XSS, SSRF, RCE, SSTI, Log4j, XXE, CRLF, JWT abuse, beaconing/C2, scanner detection), all tagged with MITRE ATT&CK technique IDs. The `guard` subcommand provides real-time iptables blocking with sliding window rate limiting, 8 blocklist feeds (Spamhaus, FireHOL, Tor, AbuseIPDB), GeoIP enrichment via offline mmdb, and Sigma export for SIEM integration. Supports files, Docker, Kubernetes, and journalctl as input sources.