### PR TITLE
Add quant-harvest - carbon-aware scheduler for post-quantum workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1650,6 +1650,7 @@ _Libraries for scheduling jobs._
 - [leprechaun](https://github.com/kilgaloon/leprechaun) - Job scheduler that supports webhooks, crons and classic scheduling.
 - [ofelia](https://github.com/netresearch/ofelia) - Docker job scheduler (crontab for Docker); fork of mcuadros/ofelia that adds a web UI, job dependencies, retries, and job persistence.
 - [pending](https://github.com/kahoon/pending) - ID-based debounced task scheduler for deferred tasks with cancellation, graceful shutdown, and optional concurrency limits.
+- [quant-harvest](https://github.com/Skeletor-Pirate/quant-harvest) - Carbon-aware deferred-execution scheduler for post-quantum (ML-KEM) workloads — defers heavy crypto batch jobs until grid carbon intensity drops below threshold. Go + SQLite WAL + Prometheus.
 - [sched](https://github.com/romshark/sched) - A job scheduler with the ability to fast-forward time.
 - [scheduler](https://github.com/carlescere/scheduler) - Cronjobs scheduling made easy.
 - [scheduler](https://github.com/yuseferi/scheduler) - Go-native distributed job scheduler with delayed tasks, batched Redis coordination, retries, lease-based recovery, and versioned queue partitioning.


### PR DESCRIPTION
Carbon-aware deferred-execution scheduler for post-quantum (ML-KEM) workloads — defers heavy crypto batch jobs until grid carbon intensity drops below threshold. Go + SQLite WAL + Prometheus.

- Live demo: https://quant-harvest.onrender.com
- GitHub: https://github.com/Skeletor-Pirate/quant-harvest
- Release v0.1.0: https://github.com/Skeletor-Pirate/quant-harvest/releases/tag/v0.1.0
- Apache-2.0, category: Job Scheduler
- Fits green computing + scheduling niche not yet covered

Checklist per CONTRIBUTING:
- [x] One link, short description, alphabetical order
- [x] Repo has go.mod, CI, license