### PR TITLE
Add manus-ai-go to Third party APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2925,6 +2925,7 @@ _Libraries for accessing third party APIs._
 - [lemonsqueezy-go](https://github.com/NdoleStudio/lemonsqueezy-go) - Go client for the Lemon Squeezy API.
 - [libgoffi](https://github.com/clevabit/libgoffi) - Library adapter toolbox for native [libffi](https://sourceware.org/libffi/) integration
 - [libopenapi](https://github.com/pb33f/libopenapi) - Parse, validate, and work with OpenAPI, Swagger, Overlays, and Arazzo specifications.
+- [manus-ai-go](https://github.com/tigusigalpa/manus-ai-go) - Go client for Manus AI API v2 with task automation, file management, webhooks, and type-safe models.
 - [Medium](https://github.com/Medium/medium-sdk-go) - Golang SDK for Medium's OAuth2 API.
 - [megos](https://github.com/andygrunwald/megos) - Client library for accessing an [Apache Mesos](https://mesos.apache.org/) cluster.
 - [minio-go](https://github.com/minio/minio-go) - Minio Go Library for Amazon S3 compatible cloud storage.


### PR DESCRIPTION
- Forge link: https://github.com/tigusigalpa/manus-ai-go
- pkg.go.dev: https://pkg.go.dev/github.com/tigusigalpa/manus-ai-go/v2
- goreportcard.com: https://goreportcard.com/report/github.com/tigusigalpa/manus-ai-go
- Coverage: https://app.codecov.io/gh/tigusigalpa/manus-ai-go