### PR TITLE
Add telegram-wallet-go to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1300,6 +1300,7 @@ _Packages for accounting and finance._
 - [paystack-sdk-go](https://github.com/samaasi/paystack-sdk-go) - A comprehensive, zero-dependency, and fully typed Go SDK for the Paystack API.
 - [swift](https://code.pfad.fr/swift/) - Offline validity check of IBAN (International Bank Account Number) and retrieval of BIC (for some countries).
 - [techan](https://github.com/sdcoffey/techan) - Technical analysis library with advanced market analysis and trading strategies.
+- [telegram-wallet-go](https://github.com/tigusigalpa/telegram-wallet-go) - Go client for Telegram Wallet Pay API with HMAC-SHA256 webhook verification, middleware for net/http, Gin, and Echo.
 - [ticker](https://github.com/achannarasappa/ticker) - Terminal stock watcher and stock position tracker.
 - [transaction](https://github.com/claygod/transaction) - Embedded transactional database of accounts, running in multithreaded mode.
 - [udecimal](https://github.com/quagmt/udecimal) - High performance, high precision, zero allocation fixed-point decimal library for financial applications.


### PR DESCRIPTION
Forge link: https://github.com/tigusigalpa/telegram-wallet-go
pkg.go.dev: https://pkg.go.dev/github.com/tigusigalpa/telegram-wallet-go
goreportcard.com: https://goreportcard.com/report/github.com/tigusigalpa/telegram-wallet-go
Coverage: https://app.codecov.io/gh/tigusigalpa/telegram-wallet-go