### PR TITLE
Add ScheduleGate to Other Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -3722,6 +3722,7 @@ _Software written in Go._
 - [restic](https://github.com/restic/restic) - De-duplicating backup program.
 - [sake](https://github.com/alajmo/sake) - sake is a command runner for local and remote hosts.
 - [scc](https://github.com/boyter/scc) - Sloc Cloc and Code, a very fast accurate code counter with complexity calculations and COCOMO estimates.
+- [ScheduleGate](https://github.com/gjunqueira-sys/ScheduleGate) - DCMA 14-point schedule assessment CLI for MS Project Excel/CSV exports.
 - [Seaweed File System](https://github.com/chrislusf/seaweedfs) - Fast, Simple and Scalable Distributed File System with O(1) disk seek.
 - [shell2http](https://github.com/msoap/shell2http) - Executing shell commands via http server (for prototyping or remote control).
 - [Snitch](https://github.com/lucasgomide/snitch) - Simple way to notify your team and many tools when someone has deployed any application via Tsuru.


### PR DESCRIPTION
Forge link: https://github.com/gjunqueira-sys/ScheduleGate
pkg.go.dev: https://pkg.go.dev/github.com/gjunqueira-sys/ScheduleGate
goreportcard.com: https://goreportcard.com/report/github.com/gjunqueira-sys/ScheduleGate

**What:** adds [ScheduleGate](https://github.com/gjunqueira-sys/ScheduleGate) to the `Software Packages > Other Software` list.

ScheduleGate is a single Go binary that runs a DCMA 14-point Integrated Master Schedule (IMS) health assessment on MS Project Excel/CSV exports. It's used by schedulers in defense/government project controls work, fully offline, no upload, AGPL-3.0.