### PR TITLE
Add samber/slog-datadog to Logging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1762,6 +1762,7 @@ _Libraries for generating and working with log files._
 - [slf4g](https://github.com/echocat/slf4g) - Simple Logging Facade for Golang: Simple structured logging; but powerful, extendable and customizable, with huge amount of learnings from decades of past logging frameworks.
 - [slog](https://github.com/gookit/slog) - Lightweight, configurable, extensible logger for Go.
 - [slog-configurator](https://github.com/psyb0t/slog-configurator) - Configures the standard library log/slog logger from environment variables: level, format, source location, and stdout/stderr split.
+- [slog-datadog](https://github.com/samber/slog-datadog) - A slog handler for Datadog.
 - [slog-formatter](https://github.com/samber/slog-formatter) - Common formatters for slog and helpers to build your own.
 - [slog-multi](https://github.com/samber/slog-multi) - Chain of slog.Handler (pipeline, fanout...).
 - [slogor](https://gitlab.com/greyxor/slogor) - A colorful slog handler.


### PR DESCRIPTION
## Summary of Changes
- Added `samber/slog-datadog` under `## Logging` in `README.md`.

## Metadata Links
- Forge link: https://github.com/samber/slog-datadog
- pkg.go.dev: https://pkg.go.dev/github.com/samber/slog-datadog
- goreportcard.com: https://goreportcard.com/report/github.com/samber/slog-datadog
- Coverage: https://app.codecov.io/gh/samber/slog-datadog

## Quality Control Checklist
- [x] **Uniqueness:** Verified `slog-datadog` is not currently listed in `README.md`.
- [x] **Alphabetization:** Inserted in strict alphabetical order under Logging.
- [x] **Link Health:** Active canonical repository link.
- [x] **Formatting:** Follows exact `- [Name](URL) - Description.` syntax with capital first letter and ending period.