### PR TITLE
Add samber/slog-loki to Logging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1764,6 +1764,7 @@ _Libraries for generating and working with log files._
 - [slog-configurator](https://github.com/psyb0t/slog-configurator) - Configures the standard library log/slog logger from environment variables: level, format, source location, and stdout/stderr split.
 - [slog-datadog](https://github.com/samber/slog-datadog) - A slog handler for Datadog.
 - [slog-formatter](https://github.com/samber/slog-formatter) - Common formatters for slog and helpers to build your own.
+- [slog-loki](https://github.com/samber/slog-loki) - A slog handler for Grafana Loki.
 - [slog-multi](https://github.com/samber/slog-multi) - Chain of slog.Handler (pipeline, fanout...).
 - [slogor](https://gitlab.com/greyxor/slogor) - A colorful slog handler.
 - [spew](https://github.com/davecgh/go-spew) - Implements a deep pretty printer for Go data structures to aid in debugging.


### PR DESCRIPTION
## Summary of Changes
- Added `samber/slog-loki` under `## Logging` in `README.md`.

## Metadata Links
- Forge link: https://github.com/samber/slog-loki
- pkg.go.dev: https://pkg.go.dev/github.com/samber/slog-loki
- goreportcard.com: https://goreportcard.com/report/github.com/samber/slog-loki
- Coverage: https://app.codecov.io/gh/samber/slog-loki

## Quality Control Checklist
- [x] **Uniqueness:** Verified `slog-loki` is not currently listed in `README.md`.
- [x] **Alphabetization:** Inserted in strict alphabetical order under Logging.
- [x] **Link Health:** Active canonical repository link.
- [x] **Formatting:** Follows exact `- [Name](URL) - Description.` syntax with capital first letter and ending period.