### PR TITLE
Add huandu/skiplist to Trees section

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,7 @@ additional ordered map implementations.
 - [merkle](https://github.com/bobg/merkle) - Space-efficient computation of Merkle root hashes and inclusion proofs.
 - [skiplist](https://github.com/MauriceGit/skiplist) - Very fast Go Skiplist implementation.
 - [skiplist](https://github.com/gansidui/skiplist) - Skiplist implementation in Go.
+- [skiplist](https://github.com/huandu/skiplist) - Fast and easy-to-use skip list for Go.
 - [treemap](https://github.com/igrmk/treemap) - Generic key-sorted map using a red-black tree under the hood.
 
 ### Pipes


### PR DESCRIPTION
## Required links

_Our CI will automatically validate them._

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/huandu/skiplist
- [x] pkg.go.dev: https://pkg.go.dev/github.com/huandu/skiplist
- [x] goreportcard.com: https://goreportcard.com/report/github.com/huandu/skiplist
- [x] Coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://coveralls.io/github/huandu/skiplist

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

- [x] The repo has a `go.mod` file and at least one SemVer release (`v1.2.1`).
- [x] The repo has an open source license. (MIT)
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link (grade A- or better).
- [x] The repo documentation has a coverage service link. (Coveralls)

- [x] The repo has a continuous integration process (GitHub Actions).
- [x] CI runs tests that must pass before merging.

## Pull Request content

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**.
- [x] The link text is the **exact project name**. (`skiplist`)
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

This PR adds a single line to the **Trees** category:

```md
- [skiplist](https://github.com/huandu/skiplist) - Fast and easy-to-use skip list for Go.
Category quality
- The packages around my addition still meet the Quality Standards.
Note on neighboring entries: gansidui/skiplist (last push Nov 2014, no license
detected) and MauriceGit/skiplist (no SemVer release, last push Jan 2023) appear
to fall short of the current Quality Standards. I left them untouched to keep this
PR a single-item change per the guidelines, and I'm happy to open separate removal
PRs if maintainers agree.