### PR TITLE
Add samber/slog-zap to Logging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1767,6 +1767,7 @@ _Libraries for generating and working with log files._
 - [slog-formatter](https://github.com/samber/slog-formatter) - Common formatters for slog and helpers to build your own.
 - [slog-loki](https://github.com/samber/slog-loki) - A slog handler for Grafana Loki.
 - [slog-multi](https://github.com/samber/slog-multi) - Chain of slog.Handler (pipeline, fanout...).
+- [slog-zap](https://github.com/samber/slog-zap) - A slog handler for Zap.
 - [slogor](https://gitlab.com/greyxor/slogor) - A colorful slog handler.
 - [spew](https://github.com/davecgh/go-spew) - Implements a deep pretty printer for Go data structures to aid in debugging.
 - [sqldb-logger](https://github.com/simukti/sqldb-logger) - A logger for Go SQL database driver without modify existing \*sql.DB stdlib usage.


### PR DESCRIPTION
## Summary of Changes
- Added `samber/slog-zap` under `## Logging` in `README.md`.

## Metadata Links
- Forge link: https://github.com/samber/slog-zap
- pkg.go.dev: https://pkg.go.dev/github.com/samber/slog-zap/v2
- goreportcard.com: https://goreportcard.com/report/github.com/samber/slog-zap/v2
- Coverage: https://app.codecov.io/gh/samber/slog-zap

## Quality Control Checklist
- [x] **Uniqueness:** Verified `slog-zap` is not currently listed in `README.md`.
- [x] **Alphabetization:** Inserted in strict alphabetical order under Logging.
- [x] **Link Health:** Active canonical repository link.
- [x] **Formatting:** Follows exact `- [Name](URL) - Description.` syntax with capital first letter and ending period.