### PR TITLE
Add samber/slog-sentry to Logging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1767,6 +1767,7 @@ _Libraries for generating and working with log files._
 - [slog-formatter](https://github.com/samber/slog-formatter) - Common formatters for slog and helpers to build your own.
 - [slog-loki](https://github.com/samber/slog-loki) - A slog handler for Grafana Loki.
 - [slog-multi](https://github.com/samber/slog-multi) - Chain of slog.Handler (pipeline, fanout...).
+- [slog-sentry](https://github.com/samber/slog-sentry) - A slog handler for Sentry.
 - [slog-slack](https://github.com/samber/slog-slack) - A slog handler for Slack.
 - [slog-zap](https://github.com/samber/slog-zap) - A slog handler for Zap.
 - [slogor](https://gitlab.com/greyxor/slogor) - A colorful slog handler.


### PR DESCRIPTION
## Required links

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/samber/slog-sentry
- [x] pkg.go.dev: https://pkg.go.dev/github.com/samber/slog-sentry/v2
- [x] goreportcard.com: https://goreportcard.com/report/github.com/samber/slog-sentry
- [x] Coverage service link: https://app.codecov.io/gh/samber/slog-sentry

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`).
- [x] The repo has an open source license.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link (grade A- or better).
- [x] The repo documentation has a coverage service link.

- [x] The repo has a continuous integration process (GitHub Actions, etc.).
- [x] CI runs tests that must pass before merging.

## Pull Request content

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**.
- [x] The link text is the **exact project name**.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.
