### PR TITLE
Add dispositio to Other Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -3684,6 +3684,7 @@ _Software written in Go._
 - [crawley](https://github.com/s0rg/crawley) - Web scraper/crawler for cli.
 - [croc](https://github.com/schollz/croc) - Easily and securely send files or folders from one computer to another.
 - [CrunchyCleaner](https://github.com/Knuspii/CrunchyCleaner) - A lightweight, software cache cleanup tool for Windows & Linux.
+- [dispositio](https://github.com/tsraveling/dispositio) - Terminal tool for planning large projects in simple markdown.
 - [Documize](https://github.com/documize/community) - Modern wiki software that integrates data from SaaS tools.
 - [dp](https://github.com/scryinfo/dp) - Through SDK for data exchange with blockchain, developers can get easy access to DAPP development.
 - [drive](https://github.com/odeke-em/drive) - Google Drive client for the commandline.


### PR DESCRIPTION
Forge link: https://github.com/tsraveling/dispositio
pkg.go.dev: https://pkg.go.dev/github.com/tsraveling/dispositio
goreportcard.com: https://goreportcard.com/report/github.com/tsraveling/dispositio
Coverage: https://app.codecov.io/gh/tsraveling/dispositio

**What:** adds [dispositio](https://github.com/tsraveling/dispositio) to the `Software Packages > Other Software` list.

dispositio is a terminal UI for planning long-running projects, storing the whole plan as plain Markdown. Milestones are H1 headers with a duration in weeks, tasks are checkboxes, and indented checkboxes are subtasks, so the file stays readable and editable outside the app and can live in the repository alongside the work it describes. Milestones are laid out on a timeline from the project start date; finishing early pulls later milestones forward and overrunning pushes them back.
