### PR TITLE
Add GURL to Other Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -3705,6 +3705,7 @@ _Software written in Go._
 - [GooseForum](https://github.com/leancodebox/GooseForum) - Self-hosted forum platform built with Go, Vue, and Tailwind CSS.
 - [Gor](https://github.com/buger/gor) - Http traffic replication tool, for replaying traffic from production to stage/dev environments in real-time.
 - [Guora](https://github.com/meloalright/guora) - A self-hosted Quora like web application written in Go.
+- [GURL](https://github.com/matveynator/gurl) - When CURL says your SSL library is too old — use GURL. One file. Zero SSL dependencies.
 - [hoofli](https://github.com/dnnrly/hoofli) - Generate PlantUML diagrams from Chrome or Firefox network inspections.
 - [hotswap](https://github.com/edwingeng/hotswap) - A complete solution to reload your go code without restarting your server, interrupting or blocking any ongoing procedure.
 - [hugo](https://gohugo.io/) - Fast and Modern Static Website Engine.


### PR DESCRIPTION
## Required links

- [x] Forge link: https://github.com/matveynator/gurl
- [x] pkg.go.dev: https://pkg.go.dev/github.com/matveynator/gurl
- [x] goreportcard.com: https://goreportcard.com/report/github.com/matveynator/gurl
- [x] Coverage service link: https://coveralls.io/repos/github/matveynator/gurl/badge.svg?branch=master

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines).
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards).

## Repository requirements

- [x] The repo has a `go.mod` file and SemVer release `v1.0.0`.
- [x] The repo has an open source GPL-3.0 license.
- [x] The repo documentation links to pkg.go.dev, Go Report Card, and Coveralls.
- [x] GitHub Actions runs formatting, vet, race tests, and coverage.

## Pull Request content

- [x] This PR adds only GURL.
- [x] GURL is in alphabetical order in Other Software.
- [x] The link text is the exact project name.
- [x] The requested description is concise and ends with a period.

## Category quality

- [x] I checked the surrounding entries. Several older entries predate the current SemVer requirement; I left them unchanged because package-addition PRs must modify only one item.

Go Report Card was retired globally in August 2026 and now returns a `retired` badge instead of grades. The required report URL is included and remains reachable; GURL passes `gofmt` and `go vet` in its CI.
