### PR TITLE
Add clickhouse-sql-parser to Database Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,6 +880,7 @@ _Data stores with expiring records, in-memory distributed data stores, or in-mem
 
 - [chproxy](https://github.com/Vertamedia/chproxy) - HTTP proxy for ClickHouse database.
 - [clickhouse-bulk](https://github.com/nikepan/clickhouse-bulk) - Collects small inserts and sends big requests to ClickHouse servers.
+- [clickhouse-sql-parser](https://github.com/AfterShip/clickhouse-sql-parser) - Parser for ClickHouse-dialect SQL that produces a typed AST, with traversal helpers, round-trip formatting, and a CLI.
 - [database-gateway](https://github.com/kazhuravlev/database-gateway) - Running SQL in production with ACLs, logs, and shared links.
 - [dbbench](https://github.com/sj14/dbbench) - Database benchmarking tool with support for several databases and scripts.
 - [dg](https://github.com/codingconcepts/dg) - A fast data generator that produces CSV files from generated relational data.


### PR DESCRIPTION
## Required links

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/AfterShip/clickhouse-sql-parser
- [x] pkg.go.dev: https://pkg.go.dev/github.com/AfterShip/clickhouse-sql-parser
- [x] goreportcard.com: https://goreportcard.com/report/github.com/AfterShip/clickhouse-sql-parser
- [x] Coverage service link ([codecov](https://codecov.io/), [coveralls](https://coveralls.io/), etc.): https://coveralls.io/github/AfterShip/clickhouse-sql-parser?branch=master

Coverage: https://coveralls.io/github/AfterShip/clickhouse-sql-parser?branch=master

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`) — latest is `v0.5.6`.
- [x] The repo has an open source license — MIT.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link (grade A- or better).
- [x] The repo documentation has a coverage service link.
- [x] The repo has a continuous integration process (GitHub Actions).
- [x] CI runs tests that must pass before merging.

## Pull Request content

- [x] This PR adds **only one** package.
- [x] The package has been added in **alphabetical order** — Database Tools, between `clickhouse-bulk` and `database-gateway`.
- [x] The link text is the **exact project name**.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.

## About the package

`clickhouse-sql-parser` is a Go library and CLI that parses ClickHouse-dialect SQL
into a typed AST and formats it back, used for query linting, static analysis,
rewriting and access-control enforcement. First commit September 2023, SemVer
release roughly every two weeks, MIT licensed. It is used in production by
[SigNoz](https://github.com/SigNoz/signoz), [Unkey](https://github.com/unkeyed/unkey),
[Akvorado](https://github.com/akvorado/akvorado),
[Trickster](https://github.com/trickstercache/trickster) and
[Substreams](https://github.com/streamingfast/substreams), among others.

Two of the required links deserve a note, in the interest of being upfront:

- **Go Report Card** has been retired, so the report page no longer returns a grade
  for any repository. The link is included because the template asks for it. The
  project is `gofmt`/`goimports` clean and runs `golangci-lint` in CI on every PR.
- **Coverage** is currently 56% overall — 58.6% for the `parser` package, which is
  the library itself; `main.go` is a thin CLI wrapper and is untested. That is below
  the 80% guideline. The grammar is exercised by a golden-file suite of ~800 SQL
  fixtures that round-trip each statement through parse → AST JSON → formatted SQL,
  so the parsing surface is well covered in practice, but I would rather state the
  number than have it turn up in review. Happy to raise it if that is a condition
  for merging.
