### PR TITLE
Add birdeye-go to Third-party APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2870,6 +2870,7 @@ _Libraries for accessing third party APIs._
 - [aws-encryption-sdk-go](https://github.com/chainifynet/aws-encryption-sdk-go) - Unofficial Go SDK implementation of the [AWS Encryption SDK](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/index.html).
 - [aws-sdk-go](https://github.com/aws/aws-sdk-go-v2) - The official AWS SDK for the Go programming language.
 - [bqwriter](https://github.com/OTA-Insight/bqwriter) - High Level Go Library to write data into [Google BigQuery](https://cloud.google.com/bigquery) at a high throughout.
+- [birdeye-go](https://github.com/tigusigalpa/birdeye-go) - Go client for Birdeye DeFi API with typed spot prices, OHLCV candles, historical data, and raw request escape hatch.
 - [brewerydb](https://github.com/naegelejd/brewerydb) - Go library for accessing the BreweryDB API.
 - [cachet](https://github.com/andygrunwald/cachet) - Go client library for [Cachet (open source status page system)](https://cachethq.io/).
 - [circleci](https://github.com/jszwedko/go-circleci) - Go client library for interacting with CircleCI's API.


### PR DESCRIPTION
Forge link: https://github.com/tigusigalpa/birdeye-go
pkg.go.dev: https://pkg.go.dev/github.com/tigusigalpa/birdeye-go
goreportcard.com: https://goreportcard.com/report/github.com/tigusigalpa/birdeye-go
Coverage: https://app.codecov.io/gh/tigusigalpa/birdeye-go