### PR TITLE
Add nansen-go to Third-party APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2947,6 +2947,7 @@ _Libraries for accessing third party APIs._
 - [megos](https://github.com/andygrunwald/megos) - Client library for accessing an [Apache Mesos](https://mesos.apache.org/) cluster.
 - [minio-go](https://github.com/minio/minio-go) - Minio Go Library for Amazon S3 compatible cloud storage.
 - [mixpanel](https://github.com/dukex/mixpanel) - Mixpanel is a library for tracking events and sending Mixpanel profile updates to Mixpanel from your go applications.
+- [nansen-go](https://github.com/tigusigalpa/nansen-go) - Go client for Nansen AI API with Smart Money analytics, token screener, profiler, and zero dependencies.
 - [newsapi-go](https://github.com/jellydator/newsapi-go) - Go client for [NewsAPI](https://newsapi.org/).
 - [openaigo](https://github.com/otiai10/openaigo) - OpenAI GPT3/GPT3.5 ChatGPT API client library for Go.
 - [patreon-go](https://github.com/mxpv/patreon-go) - Go library for Patreon API.


### PR DESCRIPTION
Forge link: https://github.com/tigusigalpa/nansen-go
pkg.go.dev: https://pkg.go.dev/github.com/tigusigalpa/nansen-go
goreportcard.com: https://goreportcard.com/report/github.com/tigusigalpa/nansen-go
Coverage: https://app.codecov.io/gh/tigusigalpa/nansen-go