### PR TITLE
Add caddy-waf to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -2463,6 +2463,7 @@ _Libraries that are used to help make your application more secure._
 - [BadActor](https://github.com/jaredfolkins/badactor) - In-memory, application-driven jailer built in the spirit of fail2ban.
 - [beelzebub](https://github.com/mariocandela/beelzebub) - A secure low code honeypot framework, leveraging AI for System Virtualization.
 - [booster](https://github.com/anatol/booster) - Fast initramfs generator with full-disk encryption support.
+- [caddy-waf](https://github.com/fabriziosalmi/caddy-waf) - Web Application Firewall middleware for the Caddy server, with a regex rule engine, anomaly scoring, IP/DNS/ASN/country blacklists and rate limiting.
 - [Cameradar](https://github.com/Ullaakut/cameradar) - Tool and library to remotely hack RTSP streams from surveillance cameras.
 - [canery](https://github.com/rluders/canery) - Minimal, stateless authorization engine with a pluggable evaluation model.
 - [certificates](https://github.com/mvmaasakkers/certificates) - An opinionated tool for generating tls certificates.


### PR DESCRIPTION
## Add caddy-waf

**Category:** Security

Forge link: https://github.com/fabriziosalmi/caddy-waf
pkg.go.dev: https://pkg.go.dev/github.com/fabriziosalmi/caddy-waf
goreportcard.com: https://goreportcard.com/report/github.com/fabriziosalmi/caddy-waf
Coverage: https://app.codecov.io/gh/fabriziosalmi/caddy-waf

**Entry:** `- [caddy-waf](https://github.com/fabriziosalmi/caddy-waf) - Web Application Firewall middleware for the Caddy server, with a regex rule engine, anomaly scoring, IP/DNS/ASN/country blacklists and rate limiting.`

- [x] Added in alphabetical order (Security: `booster` → `caddy-waf` → `Cameradar`).
- [x] Description has correct capitalization and ends with a period.
- [x] Not listed before (searched the README).
- [x] OSI-approved license (AGPL-3.0), tests, actively maintained (807+ stars), registered Caddy module `http.handlers.waf`.
- [x] Single package, single PR.

caddy-waf is a Go Caddy module (`xcaddy build --with github.com/fabriziosalmi/caddy-waf`), alongside other Go WAFs already listed (Coraza, teler-waf).