### PR TITLE
Move checker to Validation section and update description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1319,7 +1319,6 @@ _Packages for accounting and finance._
 _Libraries for working with forms._
 
 - [bind](https://github.com/robfig/bind) - Bind form data to any Go values.
-- [checker](https://github.com/cinar/checker) - Checker helps validating user input through rules defined in struct tags or directly through functions.
 - [conform](https://github.com/leebenson/conform) - Keeps user input in check. Trims, sanitizes & scrubs data based on struct tags.
 - [form](https://github.com/go-playground/form) - Decodes url.Values into Go value(s) and Encodes Go value(s) into url.Values. Dual Array and Full map support.
 - [formam](https://github.com/monoculum/formam) - decode form's values into a struct.
@@ -3208,6 +3207,7 @@ _Libraries for working with UUIDs._
 _Libraries for validation._
 
 - [checkdigit](https://github.com/osamingo/checkdigit) - Provide check digit algorithms (Luhn, Verhoeff, Damm) and calculators (ISBN, EAN, JAN, UPC, etc.).
+- [checker](https://github.com/cinar/checker) - Zero-dependency input validation and in-place normalization with struct tags, 23 locales, and JSON Schema generation.
 - [go-validator](https://github.com/tiendc/go-validator) - Validation library using Generics.
 - [gody](https://github.com/guiferpa/gody) - :balloon: A lightweight struct validator for Go.
 - [govalid](https://github.com/twharmon/govalid) - Fast, tag-based validation for structs.


### PR DESCRIPTION
Checker was previously listed under the Forms section from an earlier submission. This moves it to the correct location: ## Validation, alphabetically between checkdigit and go-validator, and updates its description to reflect its v2 zero-dependency validation and normalization capabilities.

Forge link: https://github.com/cinar/checker
pkg.go.dev: https://pkg.go.dev/github.com/cinar/checker/v2
goreportcard.com: https://goreportcard.com/report/github.com/cinar/checker
Coverage: https://app.codecov.io/gh/cinar/checker