### PR TITLE
Add Casdoor to Server Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -2551,6 +2551,7 @@ _Libraries and tools for binary serialization._
 
 - [algernon](https://github.com/xyproto/algernon) - HTTP/2 web server with built-in support for Lua, Markdown, GCSS and Amber.
 - [Caddy](https://github.com/caddyserver/caddy) - Caddy is an alternative, HTTP/2 web server that's easy to configure and use.
+- [Casdoor](https://github.com/casdoor/casdoor) - Identity and access management (IAM) and single sign-on (SSO) server with a web UI, supporting OAuth 2.0, OIDC, SAML, CAS and LDAP.
 - [consul](https://www.consul.io/) - Consul is a tool for service discovery, monitoring and configuration.
 - [cortex-tenant](https://github.com/blind-oracle/cortex-tenant) - Prometheus remote write proxy that adds add Cortex tenant ID header based on metric labels.
 - [devd](https://github.com/cortesi/devd) - Local webserver for developers.


### PR DESCRIPTION
Adds [Casdoor](https://github.com/casdoor/casdoor) to **Server Applications**, in alphabetical order between Caddy and consul.

Casdoor is a self-hosted identity and access management (IAM) / single sign-on (SSO) server written in Go, with a built-in web UI. It speaks OAuth 2.0, OIDC, SAML, CAS and LDAP, and is deployed as a server application rather than consumed as a library — the same shape as the neighbouring entries (Caddy, consul, etcd, Gitea).

Forge link: https://github.com/casdoor/casdoor
pkg.go.dev: https://pkg.go.dev/github.com/casdoor/casdoor
goreportcard.com: https://goreportcard.com/report/github.com/casdoor/casdoor
Coverage: https://app.codecov.io/gh/casdoor/casdoor

- Apache-2.0 licensed, first released 2020, actively maintained (14k+ stars)
- `go.mod` present, SemVer releases published regularly
- English README and documentation: https://casdoor.org/docs/overview

Checklist:
- [x] One PR adds only one item
- [x] Correct category and alphabetical order
- [x] Link text is the exact project name
- [x] Description is concise, non-promotional, and ends with a period
- [x] Open source license, `go.mod`, SemVer releases, >5 months of history
- [x] English documentation