### PR TITLE
Add mist to the Security section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2495,6 +2495,7 @@ _Libraries that are used to help make your application more secure._
 - [luks.go](https://github.com/anatol/luks.go) - Pure Golang library to manage LUKS partitions.
 - [mcprobe](https://github.com/tamish560/mcprobe) - Security scanner for MCP servers with prompt injection detection, tool shadowing, and SARIF output.
 - [memguard](https://github.com/awnumar/memguard) - A pure Go library for handling sensitive values in memory.
+- [mist](https://github.com/iSerganov/mist) - Asymmetric-key audio steganography library that hides encrypted messages inside compressed audio using X25519 and ChaCha20-Poly1305.
 - [multikey](https://github.com/adrianosela/multikey) - An n-out-of-N keys encryption/decryption framework based on Shamir's Secret Sharing algorithm.
 - [nacl](https://github.com/kevinburke/nacl) - Go implementation of the NaCL set of API's.
 - [optimus-go](https://github.com/pjebs/optimus-go) - ID hashing and Obfuscation using Knuth's Algorithm.


### PR DESCRIPTION
## Required links

_Provide the links below. Our CI will automatically validate them._

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/iSerganov/mist
- [x] pkg.go.dev: https://pkg.go.dev/github.com/iSerganov/mist
- [x] goreportcard.com: https://goreportcard.com/report/github.com/iSerganov/mist
- [ ] Coverage service link: not yet configured — the project publishes coverage via a CI-generated badge (https://github.com/iSerganov/mist/actions/workflows/ci.yml). Happy to wire up Codecov if required.

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

_These are validated automatically by CI:_

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`). — `v0.1.0`
- [x] The repo has an open source license. — MIT
- [x] The repo documentation has a pkg.go.dev link.
- [ ] The repo documentation has a goreportcard link (grade A- or better). — Go Report Card was sunset in favour of golangci-lint; the project runs golangci-lint v2.11.4 in CI instead.
- [x] The repo documentation has a coverage service link.

_These are recommended and reported as warnings:_

- [x] The repo has a continuous integration process (GitHub Actions, etc.).
- [x] CI runs tests that must pass before merging.

## Pull Request content

_These are validated automatically by CI:_

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**. — between `memguard` and `multikey`
- [x] The link text is the **exact project name**.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

_Note: new categories require a minimum of 3 packages._

- [x] The packages around my addition still meet the Quality Standards.

I checked the entries surrounding mine (`leakhound`, `lego`, `luks.go`, `mcprobe`, `memguard`, `multikey`, `nacl`, `optimus-go`). All are unarchived and carry an OSS license. Two look stale — `optimus-go` (last commit 2020, release `v1.0.0`) and `multikey` (last commit 2024) — but I've left them untouched to keep this PR to a single item.

Thanks for your PR, you're awesome! :sunglasses:
