### PR TITLE
Add gocue to the Audio and Music section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ _Libraries for manipulating audio and music._
 - [go-resample](https://github.com/gojargo/go-resample) - Pure-Go (no cgo) audio sample-rate converter with sinc, linear, and zero-order-hold converters.
 - [go-wav](https://github.com/tphakala/go-wav) - Pure-Go WAV/RIFF reader and writer with RF64 and BW64 support for files larger than 4 GiB.
 - [GoAudio](https://github.com/DylanMeeus/GoAudio) - Native Go Audio Processing Library.
+- [gocue](https://github.com/iSerganov/gocue) - Audio analysis CLI that detects cue-in, cue-out, and overlay points and measures EBU R128 loudness, emitting JSON for Liquidsoap.
 - [gosamplerate](https://github.com/dh1tw/gosamplerate) - libsamplerate bindings for go.
 - [id3v2](https://github.com/bogem/id3v2) - ID3 decoding and encoding library for Go.
 - [malgo](https://github.com/gen2brain/malgo) - Mini audio library.


### PR DESCRIPTION
## Required links

_Provide the links below. Our CI will automatically validate them._

- [x] Forge link (github.com, gitlab.com, etc): https://github.com/iSerganov/gocue
- [x] pkg.go.dev: https://pkg.go.dev/github.com/iSerganov/gocue
- [x] goreportcard.com: https://goreportcard.com/report/github.com/iSerganov/gocue
- [ ] Coverage service link: not published to a coverage service. gocue reports coverage
  from CI via a self-hosted shields.io endpoint badge
  (https://github.com/iSerganov/gocue/actions/workflows/ci.yml). Happy to wire up Codecov
  if that is a blocker for merge.

## Pre-submission checklist

- [x] I have read the [Contribution Guidelines](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#contribution-guidelines)
- [x] I have read the [Quality Standards](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md#quality-standards)

## Repository requirements

_These are validated automatically by CI:_

- [x] The repo has a `go.mod` file and at least one SemVer release (`vX.Y.Z`).
      Module `github.com/iSerganov/gocue`; releases v1.0.0 → v1.2.0.
- [x] The repo has an open source license. Apache-2.0.
- [x] The repo documentation has a pkg.go.dev link.
- [x] The repo documentation has a goreportcard link (grade A- or better).
- [ ] The repo documentation has a coverage service link. See note above.

_These are recommended and reported as warnings:_

- [x] The repo has a continuous integration process (GitHub Actions, etc.).
- [x] CI runs tests that must pass before merging. `ci.yml` runs golangci-lint,
      `go test -race` with coverage, and a Liquidsoap integration suite on every
      push and pull_request.

## Pull Request content

_These are validated automatically by CI:_

- [x] This PR adds/removes/changes **only one** package.
- [x] The package has been added in **alphabetical order**. Between `GoAudio` and
      `gosamplerate` in Audio and Music; `TestAlpha` passes for that section.
- [x] The link text is the **exact project name**. `gocue`.
- [x] The description is clear, concise, non-promotional, and **ends with a period**.
- [x] The link in README.md matches the forge link above.

## Category quality

- [x] The packages around my addition still meet the Quality Standards.

Checked the four entries above and below my addition (`go-mpris`, `go-opus`,
`go-resample`, `go-wav`, `gosamplerate`, `id3v2`, `malgo`, plus `GoAudio`). All
carry an open source license and none are archived. Several are low-activity
(`gosamplerate`, `id3v2`, `GoAudio` last pushed 2024 or earlier) but read as
finished, stable libraries rather than abandoned ones, so I am not proposing any
removals.

Thanks for your PR, you're awesome! :sunglasses:
